### PR TITLE
style: allow guard clause if statements

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -11,7 +11,7 @@ linters <- c(
         # All default box linters
         defaults = box.linters::box_default_linters,
         # Set indentation to 8 spaces
-        indentation_linter = lintr::indentation_linter(2),
+        indentation_linter = custom_linters_env$indentation_guard_clause_linter(indent = 2),
         # Check that all commas are followed by spaces, but do not have spaces before them.
         commas_linter = lintr::commas_linter(allow_trailing = FALSE),
         # Check that all comments are preceded by a space

--- a/R/linters.R
+++ b/R/linters.R
@@ -1,5 +1,64 @@
 # nolint start: unused_declared_object_linter.
 
+#' Allow Guard Clause `if` Statements Without Braces
+#'
+#' Wraps [lintr::indentation_linter()] to avoid emitting indentation warnings for guard-clause
+#' style `if` statements where a single, indented expression immediately follows the condition
+#' on the next line. This keeps the rest of the indentation behavior intact while permitting the
+#' brace-less guard clause convention adopted in the codebase.
+#'
+#' @param indent Integer number of spaces to use for indentation checks.
+#' @param ... Additional arguments forwarded to [lintr::indentation_linter()].
+#'
+#' @importFrom lintr indentation_linter Linter
+#' @keywords internal
+indentation_guard_clause_linter <- function(indent = 2L, ...) {
+  base_linter <- lintr::indentation_linter(indent = indent, ...)
+
+  lintr::Linter(
+    function(source_expression) {
+      lints <- base_linter(source_expression)
+
+      if (length(lints) == 0L)
+        return(list())
+
+      file_lines <- source_expression$file_lines
+
+      should_keep <- vapply(
+        lints,
+        function(lint) {
+          line_number <- lint$line_number
+
+          if (is.null(line_number) || is.na(line_number) || line_number <= 1L)
+            return(TRUE)
+
+          prev_line <- file_lines[[as.character(line_number - 1L)]]
+
+          if (is.null(prev_line))
+            return(TRUE)
+
+          prev_trim <- trimws(prev_line)
+
+          if (!grepl("^(if|else if)\\b", prev_trim) || grepl("\\{\\s*$", prev_trim))
+            return(TRUE)
+
+          current_line <- file_lines[[as.character(line_number)]]
+
+          if (is.null(current_line) || !grepl("^\\s", current_line) || !nzchar(trimws(current_line)))
+            return(TRUE)
+
+          FALSE
+        },
+        logical(1)
+      )
+
+      lints[should_keep]
+    },
+    name = "indentation_guard_clause_linter",
+    linter_level = attr(base_linter, "linter_level", exact = TRUE)
+  )
+}
+
 #' Disallow `dir.create()` Function Calls
 #'
 #' This linter flags any usage of the [dir.create()] function, which is not permitted in the codebase.

--- a/R/options.R
+++ b/R/options.R
@@ -243,9 +243,8 @@ options.list <- function(options_dir = NULL, should_return_verbose_names = FALSE
   )
   options_dir <- options_dir %||% PATHS$DIR_USR_CONFIG
 
-  if (!dir.exists(options_dir)) {
+  if (!dir.exists(options_dir))
     return(character(0))
-  }
 
   options_files <- list.files(
     path = options_dir,
@@ -409,9 +408,8 @@ options.load <- function(
     options(prefixed_options)
   }
 
-  if (should_return) {
+  if (should_return)
     return(prefixed_options)
-  }
 
   invisible(NULL)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,18 +19,16 @@ get_valid_boxpath <- function(libname, pkgname) {
   dev_path <- file.path(pkg_path, "inst")
 
   boxpath_defined <- function(path) {
-    if (length(current_box_path) == 0) {
+    if (length(current_box_path) == 0)
       return(FALSE)
-    }
     grepl(path, current_box_path)
   }
 
   if (all(c(
     boxpath_defined(pkg_path),
     boxpath_defined(dev_path)
-  ))) {
+  )))
     return(current_box_path) # Already valid
-  }
 
   unique(c(current_box_path, pkg_path, dev_path))
 }

--- a/inst/artma/data/fill.R
+++ b/inst/artma/data/fill.R
@@ -24,9 +24,8 @@ fill_dof_using_pcc <- function(df, replace_existing = NULL, drop_missing = NULL,
     fillable_rows <- fillable_rows & is.na(dof) # Only missing values
   }
 
-  if (sum(fillable_rows) == 0) {
+  if (sum(fillable_rows) == 0)
     return(df)
-  }
   df[fillable_rows, "dof"] <- dof_calc$calculate_dof(
     t_value = t_values[fillable_rows],
     pcc = pcc[fillable_rows]

--- a/inst/artma/data_config/read.R
+++ b/inst/artma/data_config/read.R
@@ -23,9 +23,8 @@ get_data_config <- function(
   config_exists <- is.list(config)
 
   if (isTRUE(config_exists)) {
-    if (data_config_is_valid(config)) {
+    if (data_config_is_valid(config))
       return(config)
-    }
 
     if (!fix_if_invalid) {
       cli::cli_abort("The data config is invalid. Please run {.code artma::config.fix()} to fix it.")

--- a/inst/artma/data_config/utils.R
+++ b/inst/artma/data_config/utils.R
@@ -6,9 +6,8 @@ data_config_is_valid <- function(
     config = NULL) {
   config <- if (is.null(config)) getOption("artma.data.config") else config
   # There is potentially room for more checks here
-  if (is.list(config)) {
+  if (is.list(config))
     return(TRUE)
-  }
   return(FALSE)
 }
 

--- a/inst/artma/libs/file_utils.R
+++ b/inst/artma/libs/file_utils.R
@@ -61,8 +61,7 @@ validate_files <- function(files) {
 #' @return `NULL` The function writes the file and does not return anything
 #' @export
 write_txt_file <- function(msg_list, full_path) {
-  if (rlang::is_empty(msg_list)) {
+  if (rlang::is_empty(msg_list))
     return(NULL) # Nothing to write
-  }
   writeLines(unlist(msg_list), full_path)
 }

--- a/inst/artma/libs/number_utils.R
+++ b/inst/artma/libs/number_utils.R
@@ -25,9 +25,8 @@ generate_random_vector <- function(from, to, length.out, integer = FALSE) {
     cli::cli_abort("Invalid range: 'from' should be less than or equal to 'to'.")
   }
 
-  if (integer) {
+  if (integer)
     return(sample(from:to, size = length.out, replace = TRUE))
-  }
 
   stats::runif(n = length.out, min = from, max = to)
 }

--- a/inst/artma/libs/path.R
+++ b/inst/artma/libs/path.R
@@ -28,9 +28,8 @@ turn_path_into_box_importable <- function(input_path) {
 
     i <- dirname(i)
   }
-  if (i == ".") {
+  if (i == ".")
     return(NULL) # This indicates the path could not be found
-  }
 
   # Ensure the resulting import statement starts with '<pkg_name> / ...'
   path_parts <- c(CONST$PACKAGE_NAME, path_parts)

--- a/inst/artma/libs/string.R
+++ b/inst/artma/libs/string.R
@@ -9,28 +9,23 @@ pluralize <- function(word, count = NULL) {
   validate(is.character(word))
 
   if (is.null(count)) {
-    if (grepl("[sxz]$", word) || grepl("[sc]h$", word)) {
+    if (grepl("[sxz]$", word) || grepl("[sc]h$", word))
       return(paste0(word, "es"))
-    } else if (grepl("[^aeiou]y$", word)) {
+    if (grepl("[^aeiou]y$", word))
       return(sub("y$", "ies", word))
-    } else {
-      return(paste0(word, "s"))
-    }
+    return(paste0(word, "s"))
   }
 
   validate(is.numeric(count))
 
-  if (count == 1) {
+  if (count == 1)
     return(word)
-  }
 
-  if (grepl("[sxz]$", word) || grepl("[sc]h$", word)) {
+  if (grepl("[sxz]$", word) || grepl("[sc]h$", word))
     return(paste0(word, "es"))
-  } else if (grepl("[^aeiou]y$", word)) {
+  if (grepl("[^aeiou]y$", word))
     return(sub("y$", "ies", word))
-  } else {
-    return(paste0(word, "s"))
-  }
+  return(paste0(word, "s"))
 }
 #' Find a string in a vector of strings using a substring
 #'

--- a/inst/artma/libs/utils.R
+++ b/inst/artma/libs/utils.R
@@ -5,15 +5,15 @@
 #' `logical` TRUE if the object is a function call, FALSE otherwise
 #' @export
 is_function_call <- function(obj) {
-  if (is.call(obj)) {
-    func_name <- as.character(obj[[1]])
-    is_valid_function_call <- exists(func_name) && is.function(get(func_name))
-    if (!(is_valid_function_call)) {
-      return(FALSE)
-    }
-  } else {
+  if (!is.call(obj))
     return(FALSE)
-  }
+
+  func_name <- as.character(obj[[1]])
+  is_valid_function_call <- exists(func_name) && is.function(get(func_name))
+
+  if (!is_valid_function_call)
+    return(FALSE)
+
   return(TRUE)
 }
 

--- a/inst/artma/libs/validation.R
+++ b/inst/artma/libs/validation.R
@@ -21,16 +21,14 @@ parse_condition <- function(cond_expr, env = parent.frame()) {
   # Note: 'cond_expr' might already be a call if using e.g. substitute(...)
   if (is.character(cond_expr)) {
     cond_call <- tryCatch(rlang::parse_expr(cond_expr), error = function(e) NULL)
-    if (is.null(cond_call)) {
+    if (is.null(cond_call))
       return(glue::glue("Condition did not hold: {cond_expr}"))
-    }
   } else {
     cond_call <- cond_expr
   }
 
-  if (!rlang::is_call(cond_call)) {
+  if (!rlang::is_call(cond_call))
     return(glue::glue("Condition did not hold: {deparse(cond_expr)}"))
-  }
 
   # Extract the function name and argument
   fn_name <- as.character(cond_call[[1]]) # e.g. "is.character"
@@ -208,9 +206,8 @@ is_char_vector_or_empty <- function(x, throw_error = FALSE) {
 #' validate_opt_path(NULL) # passes
 #' @export
 validate_opt_path <- function(opt_path) {
-  if (is.null(opt_path)) {
+  if (is.null(opt_path))
     return(invisible(NULL))
-  }
   if (!is.character(opt_path)) {
     cli::cli_abort("The option path must be a character string.")
   }

--- a/inst/artma/options/template.R
+++ b/inst/artma/options/template.R
@@ -105,9 +105,8 @@ get_option_defs <- function(template_path = NULL, opt_path = NULL) {
   raw_template_options <- read_template(template_path)
   options_def <- flatten_template_options(raw_template_options)
 
-  if (is.null(opt_path)) {
+  if (is.null(opt_path))
     return(options_def)
-  }
 
   options_def[startsWith(vapply(options_def, `[[`, character(1), "name"), opt_path)]
 }
@@ -126,17 +125,16 @@ resolve_fixed_option <- function(opt, user_input) {
   )
 
   if (!is.null(user_input[[opt$name]])) {
-    if (user_input[[opt$opt_name]] == opt$default) {
+    if (user_input[[opt$opt_name]] == opt$default)
       return(opt$default)
-    }
     # User tried to set a value for a fixed option to a non-default value
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning("Ignoring user-provided value for fixed option {CONST$STYLES$OPTIONS$NAME(opt$name)}.")
     }
   }
-  if (!is.null(opt$default)) {
+  if (!is.null(opt$default))
     return(opt$default)
-  } else if (is.null(opt$default)) {
+  if (is.null(opt$default)) {
     cli::cli_abort("Required option {CONST$STYLES$OPTIONS$NAME(opt$name)} is fixed, but no default is provided.")
   } else {
     return(NULL) # Not required, no default
@@ -208,13 +206,11 @@ prompt_user_for_option_value <- function(opt) {
   val_is_empty <- (!nzchar(input_val) || rlang::is_empty(input_val))
 
   if (val_is_empty) {
-    if (!is.null(opt$default)) {
+    if (!is.null(opt$default))
       return(opt$default)
-    } else if (isTRUE(opt$allow_na)) {
+    if (isTRUE(opt$allow_na))
       return(NA)
-    } else {
-      cli::cli_abort("Required option {CONST$STYLES$OPTIONS$NAME(opt$name)} was left blank. Aborting.")
-    }
+    cli::cli_abort("Required option {CONST$STYLES$OPTIONS$NAME(opt$name)} was left blank. Aborting.")
   }
 
   return(input_val)
@@ -231,33 +227,24 @@ resolve_option_value <- function(
     user_input) {
   is_interactive <- interactive()
 
-  if (isTRUE(opt$fixed)) {
+  if (isTRUE(opt$fixed))
     return(resolve_fixed_option(opt, user_input))
-  }
 
-  if (opt$name %in% names(user_input)) {
-    # 1) If user explicitly provided a value, just return it
+  if (opt$name %in% names(user_input))
     return(user_input[[opt$name]])
-  }
 
   # 2) No user value, check default
   if (!is.null(opt$default)) {
-    # If interactive, prompt to allow override (optional)
-    if (is_interactive && isTRUE(opt$confirm_default)) {
+    if (is_interactive && isTRUE(opt$confirm_default))
       return(prompt_user_for_option_value(opt))
-    } else {
-      # Non-interactive => silently use default
-      return(opt$default)
-    }
+    return(opt$default)
   }
 
   # 3) No user value, no default
   if (is.null(opt$default)) {
-    if (!is_interactive) {
+    if (!is_interactive)
       cli::cli_abort("Required option {CONST$STYLES$OPTIONS$NAME(opt$name)} not provided, and no default is available.")
-    } else {
-      return(prompt_user_for_option_value(opt))
-    }
+    return(prompt_user_for_option_value(opt))
   }
 
   cli::cli_abort("Unreachable code reached.")
@@ -277,18 +264,15 @@ coerce_option_value <- function(val, opt) {
   )
 
   # If the value is NULL, there's nothing to coerce
-  if (is.null(val)) {
+  if (is.null(val))
     return(val)
-  }
 
-  if (is.na(val) && isTRUE(opt$allow_na)) {
+  if (is.na(val) && isTRUE(opt$allow_na))
     return(val)
-  }
 
   # Enumerations, e.g. "enum: red|blue|green", return as is
-  if (startsWith(opt$type, "enum:")) {
+  if (startsWith(opt$type, "enum:"))
     return(val)
-  }
 
   enforce_na_allowed <- function(val, opt) {
     if (is.na(val) && !isTRUE(opt$allow_na)) {

--- a/inst/artma/options/utils.R
+++ b/inst/artma/options/utils.R
@@ -130,13 +130,11 @@ parse_options_file_name <- function(input_string) {
 #' A helper function to map the expected type from an option definition.
 get_expected_type <- function(opt_def) {
   # If an explicit type is given, use that.
-  if (!is.null(opt_def$type)) {
+  if (!is.null(opt_def$type))
     return(opt_def$type)
-  }
   # If action is store_true, assume logical.
-  if (!is.null(opt_def$action) && opt_def$action == "store_true") {
+  if (!is.null(opt_def$action) && opt_def$action == "store_true")
     return("logical")
-  }
   cli::cli_abort("Invalid template definition for the option '{opt_def}'. Could not determine the expected value type.")
 }
 
@@ -163,23 +161,20 @@ validate_option_value <- function(val, opt_type, opt_name, allow_na = FALSE) {
   }
 
   if (is.null(val) || (length(val) == 1 && is.na(val))) {
-    if (!isTRUE(allow_na)) {
+    if (!isTRUE(allow_na))
       return(cli::format_inline("Option {CONST$STYLES$OPTIONS$NAME(opt_name)} cannot be NULL or NA."))
-    } else {
-      return(NULL) # NA/NULL is allowed
-    }
+    return(NULL) # NA/NULL is allowed
   }
 
   # Handle enumerations, e.g. "enum: red|blue|green"
   if (startsWith(opt_type, "enum:")) {
     valid_values <- parse_template_enum_value(opt_type)
-    if (!val %in% valid_values) {
+    if (!val %in% valid_values)
       return(
         cli::format_inline(
           "Option {CONST$STYLES$OPTIONS$NAME(opt_name)} must be one of {.emph {toString(valid_values)}}; got {CONST$STYLES$OPTIONS$VALUE(val)}."
         )
       )
-    }
     return(NULL)
   }
 

--- a/inst/artma/paths.R
+++ b/inst/artma/paths.R
@@ -12,9 +12,8 @@ get_pkg_path <- function() {
   dev_path <- grep(file.path(package_name, "inst$"), box_path, value = TRUE)
 
   if (any(dir.exists(dev_path))) {
-    if (is.vector(dev_path)) {
+    if (is.vector(dev_path))
       return(dev_path[1])
-    }
     return(dev_path)
   }
 


### PR DESCRIPTION
## Summary
- wrap the indentation linter so guard-clause style `if` statements with single expressions are accepted
- restyle guard-clause `if` statements across options, library helpers, and path utilities to drop unnecessary braces
- move the guard clause indentation wrapper into `R/linters.R` so the configuration lives alongside the other custom linters

## Testing
- ./run.sh lint *(fails: Rscript is not installed)*
- ./run.sh test *(fails: Rscript: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb047eef8832a910a1b1754bb15bf