### PR TITLE
Add tests for indentation guard clause linter

### DIFF
--- a/tests/testthat/test-indentation_guard_clause_linter.R
+++ b/tests/testthat/test-indentation_guard_clause_linter.R
@@ -1,0 +1,34 @@
+box::use(
+  testthat[test_that, expect_length, expect_gt],
+  lintr[lint]
+)
+
+test_that("indentation_guard_clause_linter allows guard clause without braces", {
+  linter <- indentation_guard_clause_linter()
+
+  source_text <- "foo <- function(x) {\n  if (x < 0)\n    stop('negative input')\n\n  x\n}\n"
+
+  lints <- lint(text = source_text, linters = linter)
+
+  expect_length(lints, 0L)
+})
+
+test_that("indentation_guard_clause_linter keeps regular indentation issues", {
+  linter <- indentation_guard_clause_linter()
+
+  source_text <- "foo <- function() {\nif (TRUE)\n  1\n}\n"
+
+  lints <- lint(text = source_text, linters = linter)
+
+  expect_gt(length(lints), 0L)
+})
+
+test_that("indentation_guard_clause_linter requires indentation on guard body", {
+  linter <- indentation_guard_clause_linter()
+
+  source_text <- "if (ready)\nreturn(TRUE)\n"
+
+  lints <- lint(text = source_text, linters = linter)
+
+  expect_gt(length(lints), 0L)
+})


### PR DESCRIPTION
## Summary
- add unit tests covering the custom indentation_guard_clause_linter guard-clause scenarios
- ensure indentation errors still surface when guard-clause conditions are not met

## Testing
- not run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbe4a4d108832aa0ddde79e8a8e992