### PR TITLE
fix: enforce guard clause indentation width

### DIFF
--- a/R/linters.R
+++ b/R/linters.R
@@ -47,6 +47,15 @@ indentation_guard_clause_linter <- function(indent = 2L, ...) {
           if (is.null(current_line) || !grepl("^\\s", current_line) || !nzchar(trimws(current_line)))
             return(TRUE)
 
+          prev_indent <- attr(regexpr("^\\s*", prev_line), "match.length")
+          current_indent <- attr(regexpr("^\\s*", current_line), "match.length")
+
+          if (is.na(prev_indent) || is.na(current_indent))
+            return(TRUE)
+
+          if (!isTRUE(current_indent == prev_indent + indent))
+            return(TRUE)
+
           FALSE
         },
         logical(1)

--- a/tests/testthat/test-indentation_guard_clause_linter.R
+++ b/tests/testthat/test-indentation_guard_clause_linter.R
@@ -32,3 +32,13 @@ test_that("indentation_guard_clause_linter requires indentation on guard body", 
 
   expect_gt(length(lints), 0L)
 })
+
+test_that("indentation_guard_clause_linter flags over-indented guard body", {
+  linter <- indentation_guard_clause_linter()
+
+  source_text <- "if (ready)\n    return(TRUE)\n"
+
+  lints <- lint(text = source_text, linters = linter)
+
+  expect_gt(length(lints), 0L)
+})


### PR DESCRIPTION
## Summary
- ensure the guard-clause wrapper only suppresses indentation lints when the body is indented by exactly one indent level
- add a regression test that fails when guard clause bodies are over-indented

## Testing
- `TESTTHAT_CPUS=1 ./run.sh test` *(fails: Error in !trace_length(trace) : invalid argument type)*
- `./run.sh lint` *(fails: Error in !trace_length(trace) : invalid argument type)*

------
https://chatgpt.com/codex/tasks/task_e_68dbeb256254832aa6df4bba8fcff444