### PR TITLE
test: silence cli output from cache specs

### DIFF
--- a/tests/testthat/test-libs-cache.R
+++ b/tests/testthat/test-libs-cache.R
@@ -23,7 +23,7 @@ test_that("capture_cli traps cli conditions and replay_log re-emits them", {
   res <- capture_cli({
     cli::cli_alert_info("Hello")
     42
-  })
+  }, emit = FALSE)
 
   # ----- value --------------------------------------------------------------
   expect_equal(res$value, 42)
@@ -50,7 +50,7 @@ test_that("capture_cli captures cat helpers and replays them faithfully", {
   res <- capture_cli({
     cli::cat_rule("demo")
     "done"
-  })
+  }, emit = FALSE)
 
   expect_equal(res$value, "done")
   expect_length(res$log, 1L)


### PR DESCRIPTION
## Summary
- disable CLI emission in cache-related tests to avoid noisy test output

## Testing
- not run (Rscript is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dced8ac51c832aa5ec5cc0f5c2884d