### PR TITLE
fix: tidy linear tests console table

### DIFF
--- a/inst/artma/libs/linear_tests.R
+++ b/inst/artma/libs/linear_tests.R
@@ -497,9 +497,9 @@ build_summary_table <- function(coefficients, digits) {
   )
 
   summary <- data.frame(
-    Metric = row_labels,
     stringsAsFactors = FALSE,
-    check.names = FALSE
+    check.names = FALSE,
+    row.names = row_labels
   )
 
   for (model in models) {
@@ -529,7 +529,6 @@ build_summary_table <- function(coefficients, digits) {
     summary[[column_name]] <- col_values
   }
 
-  attr(summary, "row.names") <- row_labels
   summary
 }
 

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -48,14 +48,20 @@ linear_tests <- function(df) {
     cli::cli_h2("Linear model tests")
 
     if (nrow(results$summary) > 0) {
-      formatted <- format(results$summary, justify = "right")
-      header <- paste(c("", colnames(formatted)), collapse = "  ")
-      body <- vapply(
-        seq_len(nrow(formatted)),
-        function(idx) paste(c(rownames(formatted)[idx], formatted[idx, ]), collapse = "  "),
-        character(1)
+      summary_table <- data.frame(
+        Metric = rownames(results$summary),
+        results$summary,
+        check.names = FALSE,
+        stringsAsFactors = FALSE
       )
-      cli::cli_verbatim(paste(c(header, body), collapse = "\n"))
+
+      summary_table[] <- lapply(summary_table, function(column) {
+        column[is.na(column) | column == ""] <- "—"
+        column
+      })
+
+      table_text <- cli::format_table(summary_table, width = cli::console_width())
+      cli::cli_verbatim(table_text)
     } else {
       cli::cli_alert_warning("No linear models were successfully estimated.")
     }


### PR DESCRIPTION
## Summary
- remove the redundant Metric column from the linear tests summary output
- render the linear tests summary with cli::format_table for clearer console output and explicit placeholders for missing values

## Testing
- ./run.sh test --filter linear *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1babfe68832a9e5c3db90381e5e5