### PR TITLE
feat: allow configuring runtime method order

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -18,8 +18,27 @@ invoke_runtime_methods <- function(methods, df, ...) {
     artma / modules / runtime_methods[get_runtime_method_modules]
   )
 
+  arrange_methods <- function(method_names) {
+    execution_order <- CONST$RUNTIME_METHODS$EXECUTION_ORDER
+
+    if (is.null(execution_order)) {
+      execution_order <- character()
+    }
+
+    execution_order <- unique(as.character(execution_order[!is.na(execution_order)]))
+
+    if (!length(execution_order)) {
+      return(method_names)
+    }
+
+    ordered <- execution_order[execution_order %in% method_names]
+    remaining <- method_names[!method_names %in% ordered]
+
+    c(ordered, remaining)
+  }
+
   RUNTIME_METHOD_MODULES <- get_runtime_method_modules() # nolint: box_usage_linter.
-  supported_methods <- names(RUNTIME_METHOD_MODULES)
+  supported_methods <- arrange_methods(names(RUNTIME_METHOD_MODULES))
 
   if (is.null(methods)) {
     methods <- utils::select.list(
@@ -73,6 +92,8 @@ invoke_runtime_methods <- function(methods, df, ...) {
   }
 
   methods <- resolve_methods(methods)
+
+  methods <- supported_methods[supported_methods %in% methods]
 
   if (get_verbosity() >= 3) {
     cli::cli_h3("Running the main {.emph {CONST$PACKAGE_NAME}} function")

--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -89,5 +89,12 @@ CONST <- list(
       TYPE = cli::col_cyan,
       DEFAULT = cli::col_yellow
     )
+  ),
+  RUNTIME_METHODS = list(
+    EXECUTION_ORDER = c(
+      "variable_summary_stats",
+      "effect_summary_stats",
+      "linear_tests"
+    )
   )
 )


### PR DESCRIPTION
## Summary
- add a runtime method execution order configuration to CONST so the default call order is centrally managed
- ensure `invoke_runtime_methods()` respects the configured order for prompts and execution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd226d7738832a8cffb6d03af0afba