### PR TITLE
Refactor significance marks option across methods

### DIFF
--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -8,7 +8,8 @@ linear_tests <- function(df) {
     artma / libs / validation[assert, validate, validate_columns],
     artma / libs / utils[get_verbosity],
     artma / libs / linear_tests[run_linear_models],
-    artma / options / index[get_option_group]
+    artma / options / index[get_option_group],
+    artma / options / significance_marks[resolve_add_significance_marks]
   )
 
   validate(is.data.frame(df))
@@ -16,7 +17,7 @@ linear_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.linear_tests")
 
-  add_marks <- opt$add_significance_marks %||% TRUE
+  add_marks <- resolve_add_significance_marks("artma.methods.linear_tests")
   bootstrap_replications <- opt$bootstrap_replications %||% 100L
   conf_level <- opt$conf_level %||% 0.95
   round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))

--- a/inst/artma/methods/nonlinear_tests.R
+++ b/inst/artma/methods/nonlinear_tests.R
@@ -5,7 +5,8 @@ nonlinear_tests <- function(df) {
     artma / libs / validation[validate, validate_columns, assert],
     artma / libs / utils[get_verbosity],
     artma / libs / nonlinear_tests[run_nonlinear_methods],
-    artma / options / index[get_option_group]
+    artma / options / index[get_option_group],
+    artma / options / significance_marks[resolve_add_significance_marks]
   )
 
   validate(is.data.frame(df))
@@ -13,7 +14,7 @@ nonlinear_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.nonlinear_tests")
 
-  add_marks <- opt$add_significance_marks %||% TRUE
+  add_marks <- resolve_add_significance_marks("artma.methods.nonlinear_tests")
   round_to_opt <- opt$round_to
   if (length(round_to_opt) == 1 && is.na(round_to_opt)) {
     round_to_opt <- NULL

--- a/inst/artma/options/significance_marks.R
+++ b/inst/artma/options/significance_marks.R
@@ -1,0 +1,55 @@
+box::use(
+  artma / libs / utils[get_verbosity],
+  artma / libs / validation[validate],
+  artma / options / index[get_option_group]
+)
+
+#' Resolve the add_significance_marks option across methods.
+#'
+#' This helper looks up the shared methods option for significance marks,
+#' falling back to any legacy, method-specific option the user may have set.
+#' It enforces type validation and gently warns when deprecated option names
+#' are encountered.
+#'
+#' @param method_path *[character?]* The fully-qualified option prefix for the
+#'   calling method (e.g. "artma.methods.linear_tests"). Provide this to allow
+#'   backwards-compatible lookups of legacy option names.
+#'
+#' @return *[logical]* Whether significance marks should be appended.
+resolve_add_significance_marks <- function(method_path = NULL) {
+  validate(is.null(method_path) || (is.character(method_path) && length(method_path) <= 1))
+
+  shared_options <- get_option_group("artma.methods")
+  shared_value <- shared_options$add_significance_marks
+
+  legacy_value <- NULL
+  if (!is.null(method_path)) {
+    legacy_value <- getOption(paste0(method_path, ".add_significance_marks"))
+  }
+
+  if (is.null(shared_value) && !is.null(legacy_value) && get_verbosity() >= 2) {
+    cli::cli_alert_info(
+      "Using legacy option name {.code {method_path}.add_significance_marks}. Please migrate to {.code artma.methods.add_significance_marks}."
+    )
+  }
+
+  if (!is.null(shared_value) && !is.null(legacy_value) && !identical(shared_value, legacy_value) && get_verbosity() >= 1) {
+    cli::cli_alert_warning(
+      "Ignoring legacy option value {legacy_value} for {.code {method_path}.add_significance_marks} in favour of shared {.code artma.methods.add_significance_marks}."
+    )
+  }
+
+  resolved <- shared_value
+  if (is.null(resolved)) {
+    resolved <- legacy_value
+  }
+  if (is.null(resolved)) {
+    resolved <- TRUE
+  }
+
+  validate(is.logical(resolved), length(resolved) == 1)
+
+  as.logical(resolved)
+}
+
+box::export(resolve_add_significance_marks)

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -128,6 +128,13 @@ calc:
         {cli::symbol$bullet} {.strong ignore}: Ignore zero standard errors
 
 methods:
+  add_significance_marks:
+    type: "logical"
+    default: true
+    help: |
+      If `TRUE`, append significance asterisks to coefficient estimates across all
+      model diagnostics.
+
   variable_summary_stats:
     use_verbose_names:
       type: "logical"
@@ -150,12 +157,6 @@ methods:
         If `TRUE`, return the table in a form that can be used in LaTeX. Defaults to `FALSE`.
 
   linear_tests:
-    add_significance_marks:
-      type: "logical"
-      default: true
-      help: |
-        If `TRUE`, append significance asterisks to coefficient estimates.
-
     bootstrap_replications:
       type: "integer"
       default: 100
@@ -170,12 +171,6 @@ methods:
         Confidence level used for bootstrap intervals. Must lie between 0 and 1.
 
   nonlinear_tests:
-    add_significance_marks:
-      type: "logical"
-      default: true
-      help: |
-        If `TRUE`, append significance asterisks to coefficient estimates.
-
     round_to:
       type: "integer"
       allow_na: true

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -32,7 +32,7 @@ test_that("linear tests return tidy coefficients and summary", {
   df <- make_demo_data()
 
   local_options(
-    "artma.methods.linear_tests.add_significance_marks" = TRUE,
+    "artma.methods.add_significance_marks" = TRUE,
     "artma.methods.linear_tests.bootstrap_replications" = 10L,
     "artma.methods.linear_tests.conf_level" = 0.9,
     "artma.output.number_of_decimals" = 2,
@@ -84,7 +84,7 @@ test_that("linear tests gracefully skip models with missing columns", {
   df$precision <- NULL
 
   local_options(
-    "artma.methods.linear_tests.add_significance_marks" = FALSE,
+    "artma.methods.add_significance_marks" = FALSE,
     "artma.methods.linear_tests.bootstrap_replications" = 0L,
     "artma.methods.linear_tests.conf_level" = 0.95,
     "artma.output.number_of_decimals" = 3,

--- a/tests/testthat/test-options-significance-marks.R
+++ b/tests/testthat/test-options-significance-marks.R
@@ -1,0 +1,39 @@
+box::use(
+  testthat[
+    expect_false,
+    expect_true,
+    test_that
+  ],
+  withr[local_options]
+)
+
+box::use(artma / options / significance_marks[resolve_add_significance_marks])
+
+test_that("shared significance option controls output", {
+  local_options(
+    "artma.verbose" = 0,
+    "artma.methods.add_significance_marks" = FALSE
+  )
+
+  expect_false(resolve_add_significance_marks("artma.methods.linear_tests"))
+})
+
+test_that("legacy option names are still honoured when shared is unset", {
+  local_options(
+    "artma.verbose" = 0,
+    "artma.methods.add_significance_marks" = NULL,
+    "artma.methods.linear_tests.add_significance_marks" = TRUE
+  )
+
+  expect_true(resolve_add_significance_marks("artma.methods.linear_tests"))
+})
+
+test_that("shared option overrides conflicting legacy values", {
+  local_options(
+    "artma.verbose" = 0,
+    "artma.methods.add_significance_marks" = FALSE,
+    "artma.methods.linear_tests.add_significance_marks" = TRUE
+  )
+
+  expect_false(resolve_add_significance_marks("artma.methods.linear_tests"))
+})


### PR DESCRIPTION
## Summary
- introduce a shared `artma.methods.add_significance_marks` option and resolver helper
- update the linear and non-linear diagnostics to use the unified option definition
- extend the option template and tests to cover shared and legacy behaviours

## Testing
- ./run.sh test *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd35751d0c832a9d1f43730e80960a