### PR TITLE
fix: isolate runtime method failures and always export partial results

### DIFF
--- a/R/artma.R
+++ b/R/artma.R
@@ -21,6 +21,8 @@
 #'
 #' @return *\[list\]* A named list containing results from each method, indexed by
 #'   method name. The structure of each result depends on the specific method.
+#'   Methods that fail are omitted from the list; their names and error messages
+#'   are attached as the `failed_methods` attribute.
 #'
 #' @details
 #' The `artma()` function is the primary way to interact with the artma package.
@@ -50,6 +52,16 @@
 #' directly. The data will still be preprocessed and validated according to your
 #' options configuration. This is useful when you already have data loaded in R or
 #' want to analyze data programmatically.
+#'
+#' ## Method Failures
+#'
+#' A method that throws an error does not abort the run. The failing method is
+#' skipped with a warning, the remaining methods still execute, and results from
+#' the methods that succeeded are exported as usual. A summary of successes and
+#' failures is printed at the end of the run. The run itself never signals an
+#' error because of a method failure; when every requested method fails, a final
+#' warning is emitted instead. Failed method names and their error messages are
+#' available in the `failed_methods` attribute of the returned list.
 #'
 #' @examples
 #' \dontrun{
@@ -193,10 +205,18 @@ artma <- function(
 
 #' @title Invoke methods
 #' @description Pass a vector of runtime methods to invoke, together with a data frame to invoke these methods on, and invoke them.
+#'
+#' Method failures are isolated: a method that throws an error is skipped with
+#' a warning and the remaining methods still run. The run only aborts for
+#' invalid input (for example, unknown method names), never because a method
+#' failed. When at least one method fails, a summary of successes and failures
+#' is printed at the end, and a final warning is emitted if every method failed.
 #' @param methods *\[character\]* A character vector of the methods to invoke.
 #' @param df *\[data.frame\]* The data frame to invoke the methods on.
 #' @param ... *\[any\]* Additional arguments to pass to the methods.
 #' @return *\[list\]* Results of the invocations, indexed by method names.
+#'   Failed methods are omitted; their names and error messages are attached
+#'   as the `failed_methods` attribute (a named character vector).
 #'
 #' Internal example:
 #' df <- data.frame(...)
@@ -298,6 +318,9 @@ invoke_runtime_methods <- function(methods, df, ...) {
   }
 
   results <- list()
+  succeeded_methods <- character()
+  failed_methods <- character()
+
   for (method_name in methods) {
     if (get_verbosity() >= 3) {
       cli::cli_inform("{cli::symbol$bullet} Running the {.code {method_name}} method...")
@@ -311,7 +334,25 @@ invoke_runtime_methods <- function(methods, df, ...) {
       method_args$bma_result <- results[["bma"]]
     }
 
-    results[[method_name]] <- do.call(RUNTIME_METHOD_MODULES[[method_name]]$run, method_args)
+    method_failed <- FALSE
+    method_result <- tryCatch(
+      do.call(RUNTIME_METHOD_MODULES[[method_name]]$run, method_args),
+      error = function(e) {
+        method_failed <<- TRUE
+        failed_methods[[method_name]] <<- conditionMessage(e)
+        if (get_verbosity() >= 2) {
+          cli::cli_warn(
+            "Method {.code {method_name}} failed and was skipped: {conditionMessage(e)}"
+          )
+        }
+        NULL
+      }
+    )
+
+    if (!method_failed) {
+      succeeded_methods <- c(succeeded_methods, method_name)
+      results[[method_name]] <- method_result
+    }
   }
 
   # Build unified MA table when BMA and/or FMA have produced results
@@ -339,6 +380,30 @@ invoke_runtime_methods <- function(methods, df, ...) {
     if (!is.null(ma_table)) {
       display_ma_table(ma_table, verbosity = get_verbosity())
       results[["ma_table"]] <- list(summary = ma_table)
+    }
+  }
+
+  if (length(failed_methods) > 0L) {
+    attr(results, "failed_methods") <- failed_methods
+
+    if (get_verbosity() >= 3) {
+      cli::cli_h3("Method run summary")
+      if (length(succeeded_methods) > 0L) {
+        cli::cli_inform(c(
+          "v" = "Succeeded: {.code {succeeded_methods}}"
+        ))
+      }
+      for (failed_name in names(failed_methods)) {
+        cli::cli_inform(c(
+          "x" = "Failed: {.code {failed_name}} ({failed_methods[[failed_name]]})"
+        ))
+      }
+    }
+
+    if (length(succeeded_methods) == 0L && get_verbosity() >= 2) {
+      cli::cli_warn(
+        "All {length(methods)} requested {pluralize('method', length(methods))} failed. No method results were produced."
+      )
     }
   }
 

--- a/man/artma.Rd
+++ b/man/artma.Rd
@@ -37,6 +37,8 @@ after exporting results. Defaults to \code{FALSE}.}
 \value{
 \emph{[list]} A named list containing results from each method, indexed by
 method name. The structure of each result depends on the specific method.
+Methods that fail are omitted from the list; their names and error messages
+are attached as the \code{failed_methods} attribute.
 }
 \description{
 Main entry point for the artma package. This function orchestrates the complete
@@ -73,6 +75,17 @@ When \code{data} is provided, it bypasses the data reading step and uses your da
 directly. The data will still be preprocessed and validated according to your
 options configuration. This is useful when you already have data loaded in R or
 want to analyze data programmatically.
+}
+
+\subsection{Method Failures}{
+
+A method that throws an error does not abort the run. The failing method is
+skipped with a warning, the remaining methods still execute, and results from
+the methods that succeeded are exported as usual. A summary of successes and
+failures is printed at the end of the run. The run itself never signals an
+error because of a method failure; when every requested method fails, a final
+warning is emitted instead. Failed method names and their error messages are
+available in the \code{failed_methods} attribute of the returned list.
 }
 }
 \examples{

--- a/man/invoke_runtime_methods.Rd
+++ b/man/invoke_runtime_methods.Rd
@@ -15,6 +15,8 @@ invoke_runtime_methods(methods, df, ...)
 }
 \value{
 \emph{[list]} Results of the invocations, indexed by method names.
+Failed methods are omitted; their names and error messages are attached
+as the \code{failed_methods} attribute (a named character vector).
 
 Internal example:
 df <- data.frame(...)
@@ -22,5 +24,11 @@ invoke_runtime_methods(c("funnel_plot", "bma", "fma"), df)
 }
 \description{
 Pass a vector of runtime methods to invoke, together with a data frame to invoke these methods on, and invoke them.
+
+Method failures are isolated: a method that throws an error is skipped with
+a warning and the remaining methods still run. The run only aborts for
+invalid input (for example, unknown method names), never because a method
+failed. When at least one method fails, a summary of successes and failures
+is printed at the end, and a final warning is emitted if every method failed.
 }
 \keyword{internal}

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1,4 +1,15 @@
-box::use(testthat[test_that, expect_equal, expect_error, expect_setequal, expect_named])
+box::use(
+  testthat[
+    capture_warnings,
+    expect_equal,
+    expect_error,
+    expect_match,
+    expect_named,
+    expect_setequal,
+    expect_true,
+    test_that
+  ]
+)
 
 mock_methods <- function() {
   list(
@@ -101,6 +112,85 @@ test_that("invoke_runtime_methods surfaces invalid inputs early", {
     artma:::invoke_runtime_methods(methods = numeric(), df = df),
     "Runtime methods must be supplied as a character vector"
   )
+})
+
+test_that("invoke_runtime_methods isolates a failing method and keeps the rest", {
+  fake_methods <- list(
+    method_a = list(run = function(df, ...) "a-ok"),
+    method_b = list(run = function(df, ...) cli::cli_abort("boom")),
+    method_c = list(run = function(df, ...) "c-ok")
+  )
+  withr::local_options(list(artma.verbose = 0))
+  mock_runtime_method_registry(fake_methods)
+
+  df <- data.frame(x = 1:3)
+  results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+
+  expect_setequal(names(results), c("method_a", "method_c"))
+  expect_equal(results$method_a, "a-ok")
+  expect_equal(results$method_c, "c-ok")
+
+  failed <- attr(results, "failed_methods")
+  expect_named(failed, "method_b")
+  expect_match(unname(failed[["method_b"]]), "boom")
+})
+
+test_that("invoke_runtime_methods warns about failed methods when verbosity allows", {
+  fake_methods <- list(
+    method_a = list(run = function(df, ...) "a-ok"),
+    method_b = list(run = function(df, ...) cli::cli_abort("boom"))
+  )
+  withr::local_options(list(artma.verbose = 2))
+  mock_runtime_method_registry(fake_methods)
+
+  df <- data.frame(x = 1:3)
+  warnings <- capture_warnings(
+    results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+  )
+
+  expect_true(any(grepl("method_b", warnings)))
+  expect_equal(results$method_a, "a-ok")
+})
+
+test_that("invoke_runtime_methods emits a final warning when every method fails", {
+  fake_methods <- list(
+    method_a = list(run = function(df, ...) cli::cli_abort("first failure")),
+    method_b = list(run = function(df, ...) cli::cli_abort("second failure"))
+  )
+  withr::local_options(list(artma.verbose = 2))
+  mock_runtime_method_registry(fake_methods)
+
+  df <- data.frame(x = 1:3)
+  warnings <- capture_warnings(
+    results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+  )
+
+  expect_equal(length(results), 0L)
+  expect_setequal(names(attr(results, "failed_methods")), c("method_a", "method_b"))
+  expect_true(any(grepl("All 2 requested methods failed", warnings)))
+})
+
+test_that("partial results from a run with a failing method are exported", {
+  box::use(artma / output / export[export_results])
+
+  fake_methods <- list(
+    method_a = list(run = function(df, ...) data.frame(estimate = 1)),
+    method_b = list(run = function(df, ...) cli::cli_abort("boom")),
+    method_c = list(run = function(df, ...) data.frame(estimate = 3))
+  )
+  withr::local_options(list(artma.verbose = 0))
+  mock_runtime_method_registry(fake_methods)
+
+  df <- data.frame(x = 1:3)
+  results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+
+  output_dir <- withr::local_tempdir()
+  fs::dir_create(file.path(output_dir, "tables"))
+  export_results(results, output_dir)
+
+  expect_true(file.exists(file.path(output_dir, "tables", "method_a.csv")))
+  expect_true(file.exists(file.path(output_dir, "tables", "method_c.csv")))
+  expect_equal(length(list.files(file.path(output_dir, "tables"))), 2L)
 })
 
 test_that("invoke_runtime_methods forwards BMA result to dependent methods", {


### PR DESCRIPTION
## Summary

A single failing runtime method used to abort the whole `artma::artma()` run and discard every result computed before it. The lower layers already isolate failures per sub-model; this brings the same isolation to the top-level orchestrator.

## Changes

- `invoke_runtime_methods()` wraps each method invocation in `tryCatch`. A failing method is skipped: its name and error message are recorded, a `cli::cli_warn` is emitted at verbosity 2 and above, and the loop continues with the next method.
- Because the orchestrator now always returns, the export step in `artma()` always runs and exports whatever results exist.
- When at least one method fails, a summary of successes and failures (with reasons) is printed at the end of the run at verbosity 3 and above. This is plain cli output; no prompts.
- Exit contract: the run never signals an error because a method failed. Each failure produces a warning, and a final warning is emitted when every requested method fails. Failed method names and error messages are attached to the returned list as the `failed_methods` attribute (a named character vector). Documented in the roxygen docs of both `artma()` and `invoke_runtime_methods()`.
- The implementation stays a simple loop-level change so issue #167 (skip on missing columns) can build on it.

## Tests

New tests in `tests/testthat/test-run.R` using the existing fake method registry:

- method 2 of 3 throws: methods 1 and 3 still produce results, the failure lands in `failed_methods` with its message
- the per-method failure warning is emitted when verbosity allows
- all methods failing produces empty results, a populated `failed_methods` attribute, and a final warning
- partial results from a run with a failing method export correctly via `export_results()` (CSVs written only for the surviving methods)

`test-run.R`: 21 assertions pass. Full suite with the worktree `box.path` forced: PASS 981, FAIL 6; the same 6 failures occur on the base commit without this change (pre-existing, unrelated to this PR). Lint reports no findings in the changed files.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)