### PR TITLE
fix: make data config keys deterministic and invalidate the config df cache

### DIFF
--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -21,7 +21,6 @@ CONST <- list(
       VAR_NAME_DESCRIPTION = "var_name_description",
       DATA_TYPE = "data_type",
       GROUP_CATEGORY = "group_category",
-      NA_HANDLING = "na_handling",
       VARIABLE_SUMMARY = "variable_summary",
       EFFECT_SUM_STATS = "effect_sum_stats",
       EQUAL = "equal",

--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -110,9 +110,10 @@ handle_missing_values_with_prompt <- function(df) {
 }
 
 
-
 #' @title Enforce correct data types
-#' @description Enforce correct data types.
+#' @description Enforce correct data types. Every column of the data frame
+#'   must have a corresponding data config entry; a missing entry means the
+#'   config is out of sync with the data and raises an error.
 #' @param df *\[data.frame\]* The data frame to enforce correct data types for
 #' @return *\[data.frame\]* The data frame with the correct data types enforced
 #' @keywords internal
@@ -124,8 +125,26 @@ enforce_data_types <- function(df) {
   }
 
   config <- get_data_config()
-  for (col_name in make.names(colnames(df))) {
-    dtype <- config[[col_name]]$data_type
+  col_names <- colnames(df)
+  col_keys <- make.names(col_names)
+
+  missing_cols <- col_names[!col_keys %in% names(config)]
+  if (length(missing_cols) > 0) {
+    cli::cli_abort(c(
+      "x" = "No data config entry found for column{?s} {.val {missing_cols}}.",
+      "i" = "The data config is out of sync with the data frame.",
+      "i" = "Run {.code artma::config.fix()} to regenerate the config from the data."
+    ))
+  }
+
+  for (i in seq_along(col_names)) {
+    col_name <- col_names[i]
+    dtype <- config[[col_keys[i]]]$data_type
+    if (is.null(dtype) || length(dtype) != 1 || is.na(dtype)) {
+      # Entries merged from sparse overrides may carry no type information;
+      # there is nothing to coerce to in that case.
+      next
+    }
     if (dtype %in% c("int", "dummy")) {
       df[[col_name]] <- as.integer(df[[col_name]])
     } else if (dtype %in% c("float", "perc")) {
@@ -224,7 +243,6 @@ winsorize_data <- function(df) {
 }
 
 
-
 #' @title Preprocess data
 #' @description Preprocess a standardized data frame: removes empty rows, handles
 #'   missing values, enforces data types, winsorizes, and validates values.
@@ -244,4 +262,4 @@ preprocess_data <- function(df) {
     enforce_correct_values()
 }
 
-box::export(preprocess_data)
+box::export(enforce_data_types, preprocess_data)

--- a/inst/artma/data_config/defaults.R
+++ b/inst/artma/data_config/defaults.R
@@ -34,7 +34,6 @@ build_default_config_entry <- function(col_name, col_data) {
     "var_name_description" = col_name_verbose,
     "data_type" = col_data_type,
     "group_category" = NA,
-    "na_handling" = getOption("artma.data.na_handling", NA),
     "variable_summary" = is.numeric(col_data),
     "effect_sum_stats" = NA,
     "equal" = NA,
@@ -82,9 +81,15 @@ build_base_config <- function(df) {
 #' @param b *\[any\]* Second value
 #' @return *\[logical\]* TRUE if values are identical (including both-NA case)
 identical_or_both_na <- function(a, b) {
-  if (is.null(a) && is.null(b)) return(TRUE)
-  if (is.null(a) || is.null(b)) return(FALSE)
-  if (length(a) == 1 && length(b) == 1 && is.na(a) && is.na(b)) return(TRUE)
+  if (is.null(a) && is.null(b)) {
+    return(TRUE)
+  }
+  if (is.null(a) || is.null(b)) {
+    return(FALSE)
+  }
+  if (length(a) == 1 && length(b) == 1 && is.na(a) && is.na(b)) {
+    return(TRUE)
+  }
   identical(a, b)
 }
 
@@ -110,7 +115,9 @@ extract_overrides <- function(entry, default_entry) {
     }
   }
 
-  if (length(overrides) == 0) return(NULL)
+  if (length(overrides) == 0) {
+    return(NULL)
+  }
   overrides
 }
 

--- a/inst/artma/data_config/resolve.R
+++ b/inst/artma/data_config/resolve.R
@@ -4,34 +4,105 @@
 #'   is merged with sparse overrides (from the options file) to produce
 #'   the fully-resolved config that consumers expect.
 
-# Module-level cache for the dataframe only (keyed by source path)
+# Module-level cache for the dataframe. Cache validity is keyed on the source
+# path, the source file modification time, and the column name mapping used
+# to standardize the dataframe.
 .cache_env <- new.env(parent = emptyenv())
+
+#' @title Get Source File Modification Time
+#' @description Returns the modification time of a file as a numeric value,
+#'   or `NA_real_` when the path is unset or the file cannot be inspected.
+#' @param path *\[character\]* Path to the source file.
+#' @return *\[numeric\]* The modification time, or `NA_real_`.
+#' @keywords internal
+get_source_mtime <- function(path) {
+  if (is.null(path) || length(path) != 1 || is.na(path)) {
+    return(NA_real_)
+  }
+  mtime <- tryCatch(file.mtime(path), error = function(e) NA)
+  if (length(mtime) != 1 || is.na(mtime)) {
+    return(NA_real_)
+  }
+  as.numeric(mtime)
+}
+
+#' @title Get Current Column Names Map
+#' @description Reads the current column name mapping from the options
+#'   namespace. Used as part of the cache key so that a changed mapping
+#'   forces re-standardization.
+#' @return *\[list\]* The current column names map (possibly empty).
+#' @keywords internal
+get_current_colnames_map <- function() {
+  box::use(artma / options / utils[get_option_group])
+
+  tryCatch(
+    get_option_group("artma.data.colnames"),
+    error = function(e) list()
+  )
+}
+
+#' @title Standardize a Dataframe for Config Resolution
+#' @description Applies the same column name standardization the data pipeline
+#'   uses, so config keys are canonical no matter which entry point resolves
+#'   the config first. When no complete column mapping is available (e.g., the
+#'   options file has not been configured yet), falls back to syntactic names
+#'   via `make.names`.
+#' @param df *\[data.frame\]* The dataframe to standardize.
+#' @return *\[data.frame\]* The dataframe with standardized column names.
+#' @keywords internal
+standardize_df_for_config <- function(df) {
+  box::use(
+    artma / data / utils[standardize_column_names],
+    artma / libs / core / utils[get_verbosity]
+  )
+
+  tryCatch(
+    standardize_column_names(df, auto_detect = FALSE),
+    error = function(e) {
+      if (get_verbosity() >= 4) {
+        cli::cli_inform(
+          "Could not standardize column names for config resolution ({e$message}); using syntactic column names instead."
+        )
+      }
+      names(df) <- make.names(names(df))
+      df
+    }
+  )
+}
 
 #' @title Prime Dataframe Cache for Config Resolution
 #' @description Stores a dataframe and source path in the module cache so
-#'   subsequent config resolution can reuse an already-read dataframe.
+#'   subsequent config resolution can reuse an already-read dataframe. The
+#'   dataframe is expected to have standardized column names (as produced by
+#'   the data pipeline).
 #' @param df *\[data.frame\]* The dataframe to cache.
 #' @param df_path *\[character, optional\]* Source path associated with the
 #'   dataframe. Defaults to `getOption("artma.data.source_path")`.
 #' @return `NULL`
 prime_df_for_config_cache <- function(
-    df,
-    df_path = getOption("artma.data.source_path")) {
+  df,
+  df_path = getOption("artma.data.source_path")
+) {
   box::use(artma / libs / core / validation[validate])
 
   validate(is.data.frame(df))
 
   .cache_env$cached_df <- df
   .cache_env$cached_path <- df_path
+  .cache_env$cached_mtime <- get_source_mtime(df_path)
+  .cache_env$cached_colnames_map <- get_current_colnames_map()
 
   invisible(NULL)
 }
 
 #' @title Read Dataframe for Config Resolution
-#' @description Reads the dataframe from `artma.data.source_path`, caching it
-#'   in memory to avoid repeated disk reads within a session. The cache is
-#'   invalidated when the source path changes.
-#' @return *\[data.frame\]* The cached or freshly-read dataframe
+#' @description Reads the dataframe from `artma.data.source_path` and
+#'   standardizes its column names, caching the result in memory to avoid
+#'   repeated disk reads within a session. The cache is invalidated when the
+#'   source path changes, when the source file is modified, or when the
+#'   column name mapping changes.
+#' @return *\[data.frame\]* The cached or freshly-read dataframe with
+#'   standardized column names.
 read_df_for_config <- function() {
   box::use(artma / data / read[read_data])
 
@@ -40,22 +111,24 @@ read_df_for_config <- function() {
     cli::cli_abort("Cannot resolve data config: {.code artma.data.source_path} is not set.")
   }
 
-  # Check if cached df is still valid (same source path)
-  if (!is.null(.cache_env$cached_df) && identical(.cache_env$cached_path, df_path)) {
+  current_mtime <- get_source_mtime(df_path)
+  current_map <- get_current_colnames_map()
+
+  cache_is_valid <- !is.null(.cache_env$cached_df) &&
+    identical(.cache_env$cached_path, df_path) &&
+    identical(.cache_env$cached_mtime, current_mtime) &&
+    identical(.cache_env$cached_colnames_map, current_map)
+
+  if (cache_is_valid) {
     return(.cache_env$cached_df)
   }
 
-  df <- read_data(df_path)
+  df <- standardize_df_for_config(read_data(df_path))
   .cache_env$cached_df <- df
   .cache_env$cached_path <- df_path
+  .cache_env$cached_mtime <- current_mtime
+  .cache_env$cached_colnames_map <- current_map
   df
-}
-
-#' @title Invalidate DataFrame Cache
-#' @description Clears the cached dataframe, forcing re-read on next access.
-invalidate_df_cache <- function() {
-  .cache_env$cached_df <- NULL
-  .cache_env$cached_path <- NULL
 }
 
 #' @title Merge Sparse Overrides onto Base Config
@@ -79,7 +152,7 @@ merge_config <- function(base, overrides) {
       base[[var_key]] <- utils::modifyList(base[[var_key]], override_entry)
     } else {
       # Variable not in base (e.g., removed from df or manually added).
-      # Ensure var_name is present — extract_overrides() strips it from
+      # Ensure var_name is present -- extract_overrides() strips it from
       # sparse overrides, so override-only entries may lack the field.
       if (is.null(override_entry$var_name)) {
         override_entry$var_name <- var_key
@@ -94,6 +167,5 @@ merge_config <- function(base, overrides) {
 box::export(
   prime_df_for_config_cache,
   read_df_for_config,
-  invalidate_df_cache,
   merge_config
 )

--- a/tests/testthat/test-data-config-defaults.R
+++ b/tests/testthat/test-data-config-defaults.R
@@ -7,8 +7,7 @@ box::use(
     expect_error,
     test_that,
     expect_length
-  ],
-  withr[local_options]
+  ]
 )
 
 test_that <- getFromNamespace("test_that", "testthat")
@@ -19,7 +18,7 @@ expect_false <- getFromNamespace("expect_false", "testthat")
 expect_error <- getFromNamespace("expect_error", "testthat")
 expect_length <- getFromNamespace("expect_length", "testthat")
 
-# ── identical_or_both_na ─────────────────────────────────────────────────────
+# <U+2500><U+2500> identical_or_both_na <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
 
 test_that("identical_or_both_na: both NA returns TRUE", {
   box::use(artma / data_config / defaults[identical_or_both_na])
@@ -65,14 +64,10 @@ test_that("identical_or_both_na: NULL vs NA returns FALSE", {
   expect_false(identical_or_both_na(NA, NULL))
 })
 
-# ── build_default_config_entry ────────────────────────────────────────────────
+# <U+2500><U+2500> build_default_config_entry <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
 
 test_that("build_default_config_entry: numeric column", {
   box::use(artma / data_config / defaults[build_default_config_entry])
-
-  withr::local_options(list(
-    "artma.data.na_handling" = "remove"
-  ))
 
   col_data <- c(1.5, 2.3, 3.7)
   entry <- build_default_config_entry("my_var", col_data)
@@ -80,7 +75,6 @@ test_that("build_default_config_entry: numeric column", {
   expect_equal(entry$var_name, "my_var")
   expect_equal(entry$var_name_verbose, entry$var_name_description)
   expect_true(entry$variable_summary)
-  expect_equal(entry$na_handling, "remove")
   expect_true(is.na(entry$bma))
   expect_true(is.na(entry$effect_sum_stats))
   expect_true(is.na(entry$equal))
@@ -91,10 +85,6 @@ test_that("build_default_config_entry: numeric column", {
 test_that("build_default_config_entry: character column sets variable_summary FALSE", {
   box::use(artma / data_config / defaults[build_default_config_entry])
 
-  withr::local_options(list(
-    "artma.data.na_handling" = "remove"
-  ))
-
   col_data <- c("a", "b", "c")
   entry <- build_default_config_entry("category", col_data)
 
@@ -102,31 +92,23 @@ test_that("build_default_config_entry: character column sets variable_summary FA
   expect_false(entry$variable_summary)
 })
 
-test_that("build_default_config_entry: entry has all 17 expected fields", {
+test_that("build_default_config_entry: entry has all 16 expected fields", {
   box::use(artma / data_config / defaults[build_default_config_entry])
-
-  withr::local_options(list(
-    "artma.data.na_handling" = "remove"
-  ))
 
   entry <- build_default_config_entry("x", c(1, 2, 3))
   expected_fields <- c(
     "var_name", "var_name_verbose", "var_name_description",
-    "data_type", "group_category", "na_handling", "variable_summary",
+    "data_type", "group_category", "variable_summary",
     "effect_sum_stats", "equal", "gltl", "bma", "bma_reference_var",
     "bma_to_log", "bpe", "bpe_sum_stats", "bpe_equal", "bpe_gltl"
   )
   expect_equal(sort(names(entry)), sort(expected_fields))
 })
 
-# ── build_base_config ─────────────────────────────────────────────────────────
+# <U+2500><U+2500> build_base_config <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
 
 test_that("build_base_config: creates entry for each column", {
   box::use(artma / data_config / defaults[build_base_config])
-
-  withr::local_options(list(
-    "artma.data.na_handling" = "remove"
-  ))
 
   df <- data.frame(
     age = c(25, 30, 35),
@@ -147,10 +129,6 @@ test_that("build_base_config: creates entry for each column", {
 
 test_that("build_base_config: keys are make.names of column names", {
   box::use(artma / data_config / defaults[build_base_config])
-
-  withr::local_options(list(
-    "artma.data.na_handling" = "remove"
-  ))
 
   df <- data.frame(
     a = 1,
@@ -173,7 +151,7 @@ test_that("build_base_config: errors on empty dataframe", {
   expect_error(build_base_config(df), "empty")
 })
 
-# ── extract_overrides ─────────────────────────────────────────────────────────
+# <U+2500><U+2500> extract_overrides <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
 
 test_that("extract_overrides: returns NULL when entry matches defaults", {
   box::use(artma / data_config / defaults[extract_overrides])
@@ -222,9 +200,9 @@ test_that("extract_overrides: detects change from NA to value", {
 test_that("extract_overrides: detects change from value to different value", {
   box::use(artma / data_config / defaults[extract_overrides])
 
-  default <- list(var_name = "x", na_handling = "remove")
-  entry <- list(var_name = "x", na_handling = "impute")
+  default <- list(var_name = "x", gltl = "mean")
+  entry <- list(var_name = "x", gltl = "median")
 
   result <- extract_overrides(entry, default)
-  expect_equal(result$na_handling, "impute")
+  expect_equal(result$gltl, "median")
 })

--- a/tests/testthat/test-data-config-resolve.R
+++ b/tests/testthat/test-data-config-resolve.R
@@ -15,7 +15,7 @@ expect_null <- getFromNamespace("expect_null", "testthat")
 expect_true <- getFromNamespace("expect_true", "testthat")
 expect_length <- getFromNamespace("expect_length", "testthat")
 
-# ── merge_config ──────────────────────────────────────────────────────────────
+# <U+2500><U+2500> merge_config <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
 
 test_that("merge_config: returns base when overrides are empty", {
   box::use(artma / data_config / resolve[merge_config])
@@ -125,22 +125,14 @@ test_that("merge_config: skips non-list override entries", {
   expect_true(is.na(result$x$bma))
 })
 
-# ── invalidate_df_cache ───────────────────────────────────────────────────────
-
-test_that("invalidate_df_cache: clears internal cache state", {
-  box::use(artma / data_config / resolve[invalidate_df_cache])
-
-  # Just verify it runs without error
-  invalidate_df_cache()
-})
+# <U+2500><U+2500> read_df_for_config caching <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
 
 test_that("read_df_for_config uses a primed dataframe cache without re-reading data", {
   box::use(
     artma / data / read[read_data],
     artma / data_config / resolve[
       prime_df_for_config_cache,
-      read_df_for_config,
-      invalidate_df_cache
+      read_df_for_config
     ],
     artma / testing / mocks / index[MOCKS]
   )
@@ -148,6 +140,7 @@ test_that("read_df_for_config uses a primed dataframe cache without re-reading d
   df <- MOCKS$create_mock_df(seed = 42)
   tmp_file <- tempfile(fileext = ".csv")
   utils::write.csv(df, tmp_file, row.names = FALSE)
+  withr::defer(unlink(tmp_file))
 
   withr::local_options(list(
     "artma.data.source_path" = tmp_file,
@@ -158,8 +151,6 @@ test_that("read_df_for_config uses a primed dataframe cache without re-reading d
     "artma.verbose" = 3
   ))
 
-  invalidate_df_cache()
-
   loaded_df <- read_data(tmp_file)
   prime_df_for_config_cache(loaded_df, tmp_file)
 
@@ -168,12 +159,120 @@ test_that("read_df_for_config uses a primed dataframe cache without re-reading d
 
   expect_equal(length(read_msgs), 0L)
   expect_equal(nrow(read_df_for_config()), nrow(loaded_df))
-
-  unlink(tmp_file)
-  invalidate_df_cache()
 })
 
-# ── get_data_config (integration with resolve) ───────────────────────────────
+test_that("read_df_for_config re-reads when the source file changes at the same path", {
+  box::use(
+    artma / data_config / resolve[read_df_for_config],
+    artma / testing / mocks / index[MOCKS]
+  )
+
+  df <- MOCKS$create_mock_df(seed = 42)
+  tmp_file <- tempfile(fileext = ".csv")
+  utils::write.csv(df, tmp_file, row.names = FALSE)
+  withr::defer(unlink(tmp_file))
+
+  withr::local_options(list(
+    "artma.data.source_path" = tmp_file,
+    "artma.data.colnames.study_id" = "study_id",
+    "artma.data.colnames.effect" = "effect",
+    "artma.data.colnames.se" = "se",
+    "artma.data.colnames.n_obs" = "n_obs",
+    "artma.verbose" = 1
+  ))
+
+  first <- read_df_for_config()
+  expect_false("new_moderator" %in% colnames(first))
+
+  # Rewrite the file at the same path with an extra column and bump the
+  # modification time so the change is unambiguous even on coarse filesystems
+  df$new_moderator <- seq_len(nrow(df))
+  utils::write.csv(df, tmp_file, row.names = FALSE)
+  Sys.setFileTime(tmp_file, Sys.time() + 5)
+
+  second <- read_df_for_config()
+  expect_true("new_moderator" %in% colnames(second))
+})
+
+test_that("get_data_config picks up file changes at the same source path", {
+  box::use(
+    artma / data_config / read[get_data_config],
+    artma / testing / mocks / index[MOCKS]
+  )
+
+  df <- MOCKS$create_mock_df(seed = 42)
+  tmp_file <- tempfile(fileext = ".csv")
+  utils::write.csv(df, tmp_file, row.names = FALSE)
+  withr::defer(unlink(tmp_file))
+
+  withr::local_options(list(
+    "artma.data.source_path" = tmp_file,
+    "artma.data.colnames.study_id" = "study_id",
+    "artma.data.colnames.effect" = "effect",
+    "artma.data.colnames.se" = "se",
+    "artma.data.colnames.n_obs" = "n_obs",
+    "artma.data.config" = list(),
+    "artma.verbose" = 1
+  ))
+
+  config_before <- get_data_config()
+  expect_false("new_moderator" %in% names(config_before))
+
+  df$new_moderator <- seq_len(nrow(df))
+  utils::write.csv(df, tmp_file, row.names = FALSE)
+  Sys.setFileTime(tmp_file, Sys.time() + 5)
+
+  config_after <- get_data_config()
+  expect_true("new_moderator" %in% names(config_after))
+})
+
+# <U+2500><U+2500> canonical config keys <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+
+test_that("config keys are standardized regardless of which entry point resolves first", {
+  box::use(
+    artma / data / read[read_data],
+    artma / data / utils[standardize_column_names],
+    artma / data_config / read[get_data_config],
+    artma / data_config / resolve[prime_df_for_config_cache],
+    artma / testing / mocks / index[MOCKS]
+  )
+
+  raw_map <- list(
+    study_id = "study",
+    effect = "coef",
+    se = "stderr",
+    n_obs = "nobs"
+  )
+  df <- MOCKS$create_mock_df(seed = 42, colnames_map = raw_map)
+  tmp_file <- tempfile(fileext = ".csv")
+  utils::write.csv(df, tmp_file, row.names = FALSE)
+  withr::defer(unlink(tmp_file))
+
+  withr::local_options(list(
+    "artma.data.source_path" = tmp_file,
+    "artma.data.colnames.study_id" = "study",
+    "artma.data.colnames.effect" = "coef",
+    "artma.data.colnames.se" = "stderr",
+    "artma.data.colnames.n_obs" = "nobs",
+    "artma.data.config" = list(),
+    "artma.verbose" = 1
+  ))
+
+  # Cold cache: this is what public entry points (config.get) hit first
+  cold_config <- get_data_config()
+
+  expect_true(all(c("study_id", "effect", "se", "n_obs") %in% names(cold_config)))
+  expect_false(any(c("coef", "stderr", "nobs") %in% names(cold_config)))
+
+  # Pipeline path: prepare_data standardizes the df and primes the cache
+  df_std <- standardize_column_names(read_data(tmp_file), auto_detect = FALSE)
+  prime_df_for_config_cache(df_std, tmp_file)
+  primed_config <- get_data_config()
+
+  expect_equal(sort(names(cold_config)), sort(names(primed_config)))
+})
+
+# <U+2500><U+2500> get_data_config (integration with resolve) <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
 
 test_that("get_data_config: returns overrides when df not available", {
   box::use(artma / data_config / read[get_data_config])
@@ -213,7 +312,6 @@ test_that("get_data_config: returns empty list when no config and no df", {
 test_that("get_data_config: merges overrides onto base when df is available", {
   box::use(
     artma / data_config / read[get_data_config],
-    artma / data_config / resolve[invalidate_df_cache],
     artma / testing / mocks / index[MOCKS]
   )
 
@@ -221,6 +319,7 @@ test_that("get_data_config: merges overrides onto base when df is available", {
   df <- MOCKS$create_mock_df(seed = 42)
   tmp_file <- tempfile(fileext = ".csv")
   utils::write.csv(df, tmp_file, row.names = FALSE)
+  withr::defer(unlink(tmp_file))
 
   withr::local_options(list(
     "artma.data.config" = list(
@@ -230,7 +329,6 @@ test_that("get_data_config: merges overrides onto base when df is available", {
     "artma.verbose" = 1,
     "artma.data.na_handling" = "remove"
   ))
-  invalidate_df_cache()
 
   result <- get_data_config()
 
@@ -243,7 +341,4 @@ test_that("get_data_config: merges overrides onto base when df is available", {
 
   # Non-overridden fields should have defaults
   expect_true(is.na(result$se$bma))
-
-  unlink(tmp_file)
-  invalidate_df_cache()
 })

--- a/tests/testthat/test-data-index.R
+++ b/tests/testthat/test-data-index.R
@@ -36,16 +36,11 @@ test_that("prepare_data reads source data only once on a cache-miss execution", 
   ))
 
   box::use(
-    artma / data / index[prepare_data],
-    artma / data_config / resolve[invalidate_df_cache]
+    artma / data / index[prepare_data]
   )
-
-  invalidate_df_cache()
 
   msgs <- testthat::capture_messages(prepare_data())
   read_msgs <- grep("Reading data from", msgs, value = TRUE)
 
   expect_equal(length(read_msgs), 1L)
-
-  invalidate_df_cache()
 })

--- a/tests/testthat/test-data-preprocess.R
+++ b/tests/testthat/test-data-preprocess.R
@@ -19,3 +19,62 @@ expect_false <- getFromNamespace("expect_false", "testthat")
 # handle_extra_columns_with_data have been removed. Those functions were
 # deleted and their responsibilities moved to inst/artma/data/schema_reconcile.R.
 # See tests/testthat/test-data-schema-reconcile.R for the replacement tests.
+
+# <U+2500><U+2500> enforce_data_types <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+
+test_that("enforce_data_types coerces columns according to the config", {
+  box::use(artma / data / preprocess[enforce_data_types])
+
+  # With no dataframe source, get_data_config returns the overrides as-is
+  withr::local_options(list(
+    "artma.data.source_path" = NA,
+    "artma.data.config" = list(
+      x = list(var_name = "x", data_type = "int"),
+      y = list(var_name = "y", data_type = "category"),
+      z = list(var_name = "z", data_type = "float")
+    ),
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(x = c(1, 2), y = c(TRUE, FALSE), z = c("1.5", "2.5"))
+  result <- enforce_data_types(df)
+
+  expect_true(is.integer(result$x))
+  expect_true(is.character(result$y))
+  expect_true(is.numeric(result$z))
+})
+
+test_that("enforce_data_types errors on a column with no config entry", {
+  box::use(artma / data / preprocess[enforce_data_types])
+
+  withr::local_options(list(
+    "artma.data.source_path" = NA,
+    "artma.data.config" = list(
+      x = list(var_name = "x", data_type = "float")
+    ),
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(x = c(1.5, 2.5), y = c("a", "b"))
+
+  expect_error(enforce_data_types(df), "No data config entry")
+})
+
+test_that("enforce_data_types skips entries without type information", {
+  box::use(artma / data / preprocess[enforce_data_types])
+
+  withr::local_options(list(
+    "artma.data.source_path" = NA,
+    "artma.data.config" = list(
+      x = list(var_name = "x", data_type = "float"),
+      y = list(var_name = "y")
+    ),
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(x = c(1.5, 2.5), y = c("a", "b"))
+  result <- enforce_data_types(df)
+
+  expect_true(is.numeric(result$x))
+  expect_equal(result$y, df$y)
+})


### PR DESCRIPTION
## Summary

The resolved data config was not deterministic: depending on which function touched it first, config entries were keyed by raw column names from the source file or by standardized names. The module-level df cache backing config resolution was never invalidated in production, and `enforce_data_types` silently no-oped for columns whose config key was missing.

### Changes

**Canonical config keys** (`inst/artma/data_config/resolve.R`)
- `read_df_for_config()` now standardizes column names with the same `standardize_column_names(auto_detect = FALSE)` the pipeline applies, so base configs are always keyed by standardized names no matter which entry point (`config.get`, `config.set`, `reconcile_schema`, `prepare_data`) resolves the config first. When no complete column mapping is configured yet, it falls back to `make.names` (the previous behavior).

**Cache invalidation** (`inst/artma/data_config/resolve.R`)
- The module df cache is now keyed on source path, file modification time, and the colnames map (mirroring `build_data_cache_signature`). Modifying the file at the same path, or changing the column mapping, forces a re-read.
- `invalidate_df_cache()` had zero non-test callers and is deleted; the mtime keying is the single invalidation pathway.

**Fail loud in `enforce_data_types`** (`inst/artma/data/preprocess.R`)
- A df column with no config entry now raises a clear error pointing at `artma::config.fix()` instead of being skipped. Entries that exist but carry no `data_type` (override-only entries, e.g. computed columns) still skip coercion, since there is no type to coerce to.

**Per-column `na_handling` removed** (`inst/artma/data_config/defaults.R`, `inst/artma/const.R`)
- The field was dead config surface: `handle_missing_values` only ever read the global `artma.data.na_handling` option. Removed from the default entry builder and `CONST$DATA_CONFIG$KEYS`.

**Drive-by fix** (`inst/artma/paths.R`)
- `.find_package_root()` compared `read.dcf(...)[1, 1]` (a named value) to the package name with `identical()`, which never matched, so package root discovery always fell through. This broke module resolution via `PATHS` in any checkout whose directory is not named `artma` (e.g. git worktrees) and was needed to run this PR's tests. One-line `unname()` fix.

### Tests
- Config keys identical whether resolved cold (public API path) or after the pipeline primes the cache with the standardized df.
- Rewriting the source file at the same path invalidates the df cache, both at the `read_df_for_config` and `get_data_config` level.
- `enforce_data_types` errors on a column with no config entry, coerces per config, and skips entries without type info.

Full suite with box.path forced to this checkout's `inst/`: FAIL 0, PASS 1063 (4 pre-existing skips). `make lint`: no lints.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)