### PR TITLE
fix: replace the homemade digest hash and stop the data cache invalidating itself

### DIFF
--- a/inst/artma/data/cache_signatures.R
+++ b/inst/artma/data/cache_signatures.R
@@ -1,16 +1,97 @@
 box::use(
-  artma / options / utils[get_option_group]
+  artma / options / index[get_option_group]
 )
+
+# Option keys under the "artma." prefix that the data pipeline itself writes
+# while `prepare_data()` runs. They must never feed the cache signature:
+# including them would let the first run rewrite its own cache key, so a
+# second identical run could never hit the cache.
+#
+# - "data.config": `update_config_with_computed_columns()` appends computed
+#   column entries during the run. User-authored entries still feed the
+#   signature; see `user_authored_config_entries()`.
+# - "data.expected_schema_columns": the schema baseline persisted by
+#   `persist_expected_schema_cols()` during schema reconciliation.
+# - "data.source_path": runtime-populated; captured separately as a
+#   normalized path plus the file modification time.
+PIPELINE_WRITTEN_OPTION_KEYS <- c(
+  "data.config",
+  "data.expected_schema_columns",
+  "data.source_path"
+)
+
+# Prefixes of runtime session bookkeeping keys (never user-authored), e.g.
+# "temp.file_name" and "temp.dir_name".
+RUNTIME_OPTION_PREFIXES <- c(
+  "temp."
+)
+
+#' @title Sort a named list by name
+#' @description Byte-order sorting keeps the signature independent of the
+#'   order in which options were set and of the session locale.
+#' @keywords internal
+sort_by_name <- function(x) {
+  nms <- names(x)
+  if (is.null(nms)) {
+    return(x)
+  }
+  x[order(nms, method = "radix")]
+}
+
+#' @title Drop options written by the pipeline itself
+#' @description Filters a flat option group (names relative to the "artma."
+#'   prefix) down to user-authored entries by removing the keys listed in
+#'   `PIPELINE_WRITTEN_OPTION_KEYS` and the prefixes in
+#'   `RUNTIME_OPTION_PREFIXES`.
+#' @keywords internal
+drop_pipeline_written_options <- function(opts) {
+  if (!is.list(opts) || length(opts) == 0L) {
+    return(list())
+  }
+
+  keys <- names(opts)
+  drop <- keys %in% PIPELINE_WRITTEN_OPTION_KEYS
+  for (prefix in RUNTIME_OPTION_PREFIXES) {
+    drop <- drop | startsWith(keys, prefix)
+  }
+
+  sort_by_name(opts[!drop])
+}
+
+#' @title Keep user-authored data config entries
+#' @description Entries flagged `is_computed = TRUE` are appended to the data
+#'   config by the pipeline itself and are excluded so they cannot invalidate
+#'   the cache key of the run that produced them.
+#' @keywords internal
+user_authored_config_entries <- function(config) {
+  if (!is.list(config) || length(config) == 0L) {
+    return(list())
+  }
+
+  computed <- vapply(
+    config,
+    function(entry) is.list(entry) && isTRUE(entry$is_computed),
+    logical(1)
+  )
+
+  sort_by_name(config[!computed])
+}
 
 #' @title Build cache signature for data-dependent workflows
 #' @description
-#' Construct a list that captures the most relevant inputs influencing
-#' downstream data computations. The signature combines the configured data
-#' source path (and its modification time when available), hashes of the
-#' current data configuration and project options, and the installed package
-#' version. It is suitable for reuse across modules that rely on the prepared
-#' dataset to ensure cached artefacts are refreshed when any of these inputs
-#' change.
+#' Construct a deterministic list of the user-controlled inputs that influence
+#' data preparation: the configured data source (normalized path plus file
+#' modification time), the user-authored part of the data config, the
+#' remaining user-authored `artma.*` options, and the installed package
+#' version. The list is forwarded to `cache_cli()` wrappers as the
+#' `cache_signature` argument and `memoise` hashes it as part of the cache
+#' key, so no explicit hashing happens here.
+#'
+#' Options that the pipeline itself writes while running (computed column
+#' entries in `data.config`, the `data.expected_schema_columns` baseline, and
+#' `temp.*` session bookkeeping) are excluded. Hashing them would make run 1
+#' change its own signature, so an identical run 2 would always miss the
+#' cache.
 #' @return *\[list\]* A deterministic signature list suitable for
 #'   forwarding to `cache_cli()` wrappers as a `cache_signature` argument.
 build_data_cache_signature <- function() {
@@ -33,21 +114,14 @@ build_data_cache_signature <- function() {
     }
   }
 
-  box::use(artma / libs / infrastructure / polyfills[digest])
-
-  overrides <- getOption("artma.data.config")
-  if (!is.list(overrides)) {
-    overrides <- list()
-  }
-
-  config_hash <- digest(overrides, algo = "xxhash64")
-  artma_options_hash <- digest(get_option_group("artma"), algo = "xxhash64")
+  data_config <- user_authored_config_entries(getOption("artma.data.config"))
+  artma_options <- drop_pipeline_written_options(get_option_group("artma"))
 
   list(
     source_path = normalized_path,
     source_mtime = source_mtime,
-    config_hash = config_hash,
-    artma_options_hash = artma_options_hash,
+    data_config = data_config,
+    artma_options = artma_options,
     package_version = as.character(utils::packageVersion("artma"))
   )
 }

--- a/inst/artma/data/index.R
+++ b/inst/artma/data/index.R
@@ -65,6 +65,7 @@ box::use(
 
 box::export(
   prepare_data,
+  prepare_data_impl, # exported so tests can wrap it with an isolated cache
   read_data,
   recognize_columns,
   get_required_column_names,

--- a/inst/artma/libs/infrastructure/polyfills.R
+++ b/inst/artma/libs/infrastructure/polyfills.R
@@ -5,7 +5,6 @@
 #' - stringr (string manipulation)
 #' - purrr (functional programming)
 #' - glue (string interpolation)
-#' - digest (hashing for cache keys)
 #' - usethis (file editing)
 #'
 #' All functions maintain API compatibility with the original packages.
@@ -201,41 +200,6 @@ glue_collapse <- function(x, sep = "", width = Inf, last = "") {
   } else {
     paste(x, collapse = sep)
   }
-}
-
-# Hashing (digest replacement) ----
-
-#' Create hash for caching
-#' @description Replacement for digest::digest()
-#' Uses serialize + base R hashing for cache keys
-#' @param object Object to hash
-#' @param algo Algorithm (ignored, always uses same method)
-#' @param ... Additional arguments (for compatibility)
-#' @return Hash string
-#' @export
-digest <- function(object, algo = "xxhash64", ...) {
-  # Serialize the object to raw bytes
-  raw_bytes <- serialize(object, connection = NULL, ascii = FALSE)
-
-  # Create a simple hash using base R
-  # We'll use a combination of length and checksum for speed
-  # Use modulo arithmetic throughout to avoid integer overflow
-  hash_high <- 0
-  hash_low <- 0
-
-  # Process bytes in chunks to avoid overflow
-  for (i in seq_along(raw_bytes)) {
-    val <- as.numeric(raw_bytes[i])
-    # Update hash_low
-    hash_low <- (hash_low + val * (i %% 1000)) %% (2^31 - 1)
-    # Update hash_high
-    hash_high <- (hash_high + val * (i %% 997)) %% (2^31 - 1)
-  }
-
-  # Convert to hex string (16 characters for consistency with xxhash64)
-  hex_hash <- sprintf("%08x%08x", as.integer(hash_high), as.integer(hash_low))
-
-  hex_hash
 }
 
 # File utilities (usethis replacement) ----

--- a/tests/testthat/test-data-cache-signature.R
+++ b/tests/testthat/test-data-cache-signature.R
@@ -1,0 +1,162 @@
+box::use(
+  testthat[test_that, expect_equal, expect_false, expect_identical],
+  artma / testing / fixtures / index[FIXTURES],
+  artma / testing / mocks / index[MOCKS]
+)
+
+# Computed-column config entries as the pipeline writes them. Seeding these
+# keeps prepare_data() from persisting data-config updates to a runtime
+# options file, which unit tests do not have.
+precomputed_config_overrides <- function() {
+  list(
+    obs_id = list(var_name = "obs_id", is_computed = TRUE),
+    study_id = list(var_name = "study_id", is_computed = TRUE),
+    study_label = list(var_name = "study_label", is_computed = TRUE),
+    t_stat = list(var_name = "t_stat", is_computed = TRUE),
+    study_size = list(var_name = "study_size", is_computed = TRUE),
+    reg_dof = list(var_name = "reg_dof", is_computed = TRUE),
+    precision = list(var_name = "precision", is_computed = TRUE)
+  )
+}
+
+pipeline_options <- function(tmp_file) {
+  list(
+    "artma.cache.use_cache" = TRUE,
+    "artma.data.source_path" = tmp_file,
+    "artma.data.colnames.study_id" = "study_id",
+    "artma.data.colnames.effect" = "effect",
+    "artma.data.colnames.se" = "se",
+    "artma.data.colnames.n_obs" = "n_obs",
+    "artma.data.config" = precomputed_config_overrides(),
+    "artma.data.config_setup" = "auto",
+    "artma.data.expected_schema_columns" = NULL,
+    "artma.data.na_handling" = "remove",
+    "artma.data.reconcile_mode" = "auto",
+    "artma.calc.se_zero_handling" = "ignore",
+    "artma.temp.file_name" = NULL,
+    "artma.temp.dir_name" = NULL,
+    "artma.verbose" = 1
+  )
+}
+
+test_that("build_data_cache_signature ignores options written by the pipeline", {
+  box::use(artma / data / cache_signatures[build_data_cache_signature])
+
+  tmp_file <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(data.frame(x = 1), tmp_file, row.names = FALSE)
+
+  withr::local_options(list(
+    "artma.data.source_path" = tmp_file,
+    "artma.data.config" = list(
+      gdp = list(var_name = "gdp", effect_sum_stats = TRUE)
+    ),
+    "artma.data.expected_schema_columns" = NULL,
+    "artma.data.na_handling" = "remove",
+    "artma.temp.file_name" = NULL,
+    "artma.temp.dir_name" = NULL
+  ))
+
+  before <- build_data_cache_signature()
+
+  # Simulate what prepare_data() writes during a run: computed column entries
+  # in the data config, the schema baseline, and session bookkeeping.
+  mutated_config <- getOption("artma.data.config")
+  mutated_config$precision <- list(var_name = "precision", is_computed = TRUE)
+  mutated_config$obs_id <- list(var_name = "obs_id", is_computed = TRUE)
+
+  withr::local_options(list(
+    "artma.data.config" = mutated_config,
+    "artma.data.expected_schema_columns" = c("gdp", "effect", "se"),
+    "artma.temp.file_name" = "unit-test.yaml",
+    "artma.temp.dir_name" = withr::local_tempdir()
+  ))
+
+  after <- build_data_cache_signature()
+
+  expect_identical(before, after)
+})
+
+test_that("build_data_cache_signature reacts to user-authored inputs", {
+  box::use(artma / data / cache_signatures[build_data_cache_signature])
+
+  tmp_file <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(data.frame(x = 1), tmp_file, row.names = FALSE)
+
+  withr::local_options(list(
+    "artma.data.source_path" = tmp_file,
+    "artma.data.config" = list(
+      gdp = list(var_name = "gdp", effect_sum_stats = TRUE)
+    ),
+    "artma.data.na_handling" = "remove"
+  ))
+
+  baseline <- build_data_cache_signature()
+
+  # A preprocessing option changes the signature
+  changed_option <- withr::with_options(
+    list("artma.data.na_handling" = "median"),
+    build_data_cache_signature()
+  )
+  expect_false(identical(baseline, changed_option))
+
+  # A user-authored data config entry changes the signature
+  changed_config <- withr::with_options(
+    list("artma.data.config" = list(
+      gdp = list(var_name = "gdp", effect_sum_stats = FALSE)
+    )),
+    build_data_cache_signature()
+  )
+  expect_false(identical(baseline, changed_config))
+})
+
+test_that("prepare_data hits the cache on a second identical run", {
+  box::use(
+    artma / data / index[prepare_data_impl],
+    artma / data / cache_signatures[build_data_cache_signature],
+    artma / libs / infrastructure / cache[cache_cli_runner],
+    artma / data_config / resolve[invalidate_df_cache]
+  )
+
+  FIXTURES$local_cli_silence()
+
+  df <- MOCKS$create_mock_df(seed = 42)
+  tmp_file <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(df, tmp_file, row.names = FALSE)
+
+  withr::local_options(pipeline_options(tmp_file))
+
+  invalidate_df_cache()
+  withr::defer(invalidate_df_cache())
+
+  runs <- 0L
+  counted_impl <- function() {
+    runs <<- runs + 1L
+    prepare_data_impl()
+  }
+
+  # Same wiring as prepare_data in artma/data/index.R, but with an isolated
+  # in-memory cache so the test does not touch the user cache directory.
+  runner <- cache_cli_runner(
+    counted_impl,
+    stage = "prepare_data",
+    key_builder = function(...) build_data_cache_signature(),
+    cache = memoise::cache_memory()
+  )
+
+  # Run 1 computes; it also writes artma.data.expected_schema_columns, which
+  # must not feed the cache key.
+  first <- testthat::capture_messages(df_first <- runner())
+  expect_equal(runs, 1L)
+
+  # Run 2 with identical inputs must be a cache hit, not a recomputation.
+  invalidate_df_cache()
+  second <- testthat::capture_messages(df_second <- runner())
+  expect_equal(runs, 1L)
+  expect_identical(df_first, df_second)
+
+  # Changing a user-authored preprocessing option must cause a cache miss.
+  invalidate_df_cache()
+  withr::local_options(list("artma.data.na_handling" = "median"))
+  testthat::capture_messages(runner())
+  expect_equal(runs, 2L)
+})

--- a/tests/testthat/test-polyfills.R
+++ b/tests/testthat/test-polyfills.R
@@ -156,30 +156,6 @@ test_that("glue_collapse joins strings", {
   expect_equal(result, "a")
 })
 
-test_that("digest creates consistent hashes", {
-  box::use(artma / libs / infrastructure / polyfills[digest])
-
-  # Test basic hashing
-  obj1 <- list(a = 1, b = 2)
-  hash1 <- digest(obj1)
-  expect_type(hash1, "character")
-  expect_equal(nchar(hash1), 16) # Should be 16 hex characters
-
-  # Test consistency - same object should produce same hash
-  hash2 <- digest(obj1)
-  expect_equal(hash1, hash2)
-
-  # Test different objects produce different hashes
-  obj2 <- list(a = 1, b = 3)
-  hash3 <- digest(obj2)
-  expect_false(hash1 == hash3)
-
-  # Test with different data types
-  expect_type(digest(1:10), "character")
-  expect_type(digest("test"), "character")
-  expect_type(digest(data.frame(x = 1:3)), "character")
-})
-
 test_that("edit_file validates file existence", {
   box::use(artma / libs / infrastructure / polyfills[edit_file])
 


### PR DESCRIPTION
## Summary

The cache key for prepared data had two problems:

1. It was hashed with a homemade `digest()` polyfill in `inst/artma/libs/infrastructure/polyfills.R`: a weighted modular sum with weak collision resistance that silently ignored its `algo` argument. A collision could return the wrong prepared data frame. The explicit hashing was also redundant, since the signature list is handed to `memoise`, which hashes its arguments itself.
2. `build_data_cache_signature()` hashed options that `prepare_data()` writes during the run: `update_config_with_computed_columns()` appends computed column entries to `data.config`, and schema reconciliation persists `data.expected_schema_columns`. Run 1 therefore changed its own cache key, so an identical run 2 always missed the cache.

## Changes

- Delete the `digest` polyfill and its unit test. `cache_signatures.R` now passes raw filtered lists in the signature and lets `memoise` do the hashing.
- Exclude pipeline-written option keys from the signature, documented in `cache_signatures.R`:
  - computed (`is_computed = TRUE`) entries in `data.config` (user-authored entries still feed the key)
  - `data.expected_schema_columns`
  - `data.source_path` (keyed separately as normalized path plus file mtime)
  - `temp.*` session bookkeeping
- Sort signature components by name (radix order) so the key builder is deterministic regardless of option insertion order or locale.
- Import `get_option_group` from `artma/options/index` to converge with the sibling change for issue #158.
- Export `prepare_data_impl` from `artma/data/index` so tests can wrap it with an isolated in-memory cache.
- New regression tests in `tests/testthat/test-data-cache-signature.R`:
  - the signature is invariant to the options the pipeline writes during a run
  - the signature changes when user-authored inputs change
  - two identical `prepare_data` runs execute once (second run is a cache hit) and changing `artma.data.na_handling` causes a miss

## Testing

- Full test suite with `box.path` forced to this branch's `inst/`: 0 failures, 1051 passes, 6 skips (the warnings are pre-existing locale warnings from reading the options template YAML, also present on untouched tests).
- `make lint` passes; the only style notes are pre-existing ones in two untouched test files.

Note for reviewers: verifying this in a git worktree surfaced an unrelated bug in `inst/artma/paths.R` (`.find_package_root()` compares a named `read.dcf` scalar with `identical()`, which is always FALSE on R 4.4+, so `PATHS` falls back to `find.package()` and resolves the wrong tree when the checkout dir is not named `artma`). Left out of scope here.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)