### PR TITLE
fix: locate the package root when the checkout is not named artma

### DIFF
--- a/inst/artma/paths.R
+++ b/inst/artma/paths.R
@@ -13,7 +13,8 @@ box::use(
         base::read.dcf(desc, fields = "Package"),
         error = function(...) NULL
       )
-      if (!is.null(pkg_record) && identical(pkg_record[1, 1], package_name)) {
+      # [[ drops the "Package" dimname that [1, 1] keeps; a named value never passes identical()
+      if (!is.null(pkg_record) && nrow(pkg_record) >= 1 && identical(pkg_record[[1, 1]], package_name)) {
         return(current)
       }
     }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,14 @@
+# Make box imports resolve to this checkout's inst/ directory, ahead of any
+# box.path inherited from the environment (e.g. an .Rprofile pointing at a
+# different checkout). Runs in every testthat worker before test files load,
+# so the tests always exercise the code they sit next to.
+local({
+  inst_dir <- normalizePath(
+    testthat::test_path("..", "..", "inst"),
+    winslash = "/",
+    mustWork = FALSE
+  )
+  if (dir.exists(inst_dir)) {
+    options(box.path = unique(c(inst_dir, getOption("box.path"))))
+  }
+})

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -1,0 +1,52 @@
+box::use(
+  testthat[
+    test_that,
+    expect_identical,
+    expect_null
+  ]
+)
+
+# .find_package_root is internal to the module, so reach it through the box namespace
+.get_find_package_root <- function() {
+  box::use(artma / paths)
+  attr(paths, "namespace")$.find_package_root
+}
+
+test_that(".find_package_root finds the root even when the directory is not named after the package", {
+  find_package_root <- .get_find_package_root()
+
+  root <- withr::local_tempdir(pattern = "artma-worktree-")
+  writeLines("Package: artma", file.path(root, "DESCRIPTION"))
+  nested <- file.path(root, "tests", "testthat")
+  dir.create(nested, recursive = TRUE)
+
+  expect_identical(
+    find_package_root("artma", start = nested),
+    tools::file_path_as_absolute(root)
+  )
+})
+
+test_that(".find_package_root returns NULL when no matching DESCRIPTION exists", {
+  find_package_root <- .get_find_package_root()
+
+  root <- withr::local_tempdir(pattern = "artma-other-")
+  writeLines("Package: notartma", file.path(root, "DESCRIPTION"))
+
+  expect_null(find_package_root("artma", start = root))
+})
+
+test_that("get_pkg_path falls back to the working directory before find.package", {
+  box::use(artma / paths[get_pkg_path])
+
+  root <- withr::local_tempdir(pattern = "artma-clone-")
+  writeLines("Package: artma", file.path(root, "DESCRIPTION"))
+  dir.create(file.path(root, "inst", "artma"), recursive = TRUE)
+
+  withr::local_options(list(box.path = NULL))
+  withr::local_dir(root)
+
+  expect_identical(
+    get_pkg_path(),
+    file.path(tools::file_path_as_absolute(root), "inst")
+  )
+})


### PR DESCRIPTION
## Summary

- `.find_package_root()` in `inst/artma/paths.R` compared `identical(pkg_record[1, 1], package_name)`. On R 4.4/4.5, subsetting the 1x1 matrix returned by `read.dcf()` with `[1, 1]` keeps the "Package" dimname, so `identical()` never matched and the function always returned `NULL`. `get_pkg_path()` then fell through to `find.package()`, which points every `PATHS$DIR_*` constant at the installed package (or the dev root without `inst`) whenever the checkout directory is not literally named `artma`, such as git worktrees. Symptom: `box::use(artma/testing/mocks/index)` failed with "Non-existent directory when importing modules".
- Fix: compare with `pkg_record[[1, 1]]`, which drops the dimname. Also guard with `nrow()` so an empty DESCRIPTION file cannot abort the directory walk-up.
- `tests/testthat/setup.R` now prepends the checkout's `inst/` directory to `box.path` in every testthat worker, so tests always exercise the modules of the checkout they sit in rather than ones resolved from an inherited `box.path` (e.g. an `.Rprofile` pinned to a different checkout).
- New regression tests in `tests/testthat/test-paths.R`: root found from a nested directory in a checkout not named `artma`, `NULL` when the DESCRIPTION names another package, and `get_pkg_path()` resolving the working-directory root before the `find.package()` fallback.

## Test plan

- `devtools::test()`: FAIL 0, PASS 1054 (the new tests fail against the unfixed code and pass with the fix)
- Manually verified from this worktree that `PATHS$DIR_MOCKS` resolves inside the worktree and `box::use(artma/testing/mocks/index)` imports cleanly
- Lint and styler clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)