### PR TITLE
test: eliminate flaky-test vectors in the parallel suite

### DIFF
--- a/R/artma.R
+++ b/R/artma.R
@@ -213,6 +213,7 @@ artma <- function(
 #' is printed at the end, and a final warning is emitted if every method failed.
 #' @param methods *\[character\]* A character vector of the methods to invoke.
 #' @param df *\[data.frame\]* The data frame to invoke the methods on.
+#' @param modules_dir *\[character, optional\]* Directory to discover runtime method modules in. Defaults to `NULL`, in which case the standard package methods directory is used. Used mainly for dependency injection in tests.
 #' @param ... *\[any\]* Additional arguments to pass to the methods.
 #' @return *\[list\]* Results of the invocations, indexed by method names.
 #'   Failed methods are omitted; their names and error messages are attached
@@ -223,7 +224,7 @@ artma <- function(
 #' invoke_runtime_methods(c("funnel_plot", "bma", "fma"), df)
 #'
 #' @keywords internal
-invoke_runtime_methods <- function(methods, df, ...) {
+invoke_runtime_methods <- function(methods, df, modules_dir = NULL, ...) {
   box::use(
     artma / const[CONST],
     artma / libs / core / string[pluralize],
@@ -250,7 +251,11 @@ invoke_runtime_methods <- function(methods, df, ...) {
     c(ordered, remaining)
   }
 
-  RUNTIME_METHOD_MODULES <- get_runtime_method_modules() # nolint: box_usage_linter.
+  RUNTIME_METHOD_MODULES <- if (is.null(modules_dir)) { # nolint: box_usage_linter.
+    get_runtime_method_modules()
+  } else {
+    get_runtime_method_modules(modules_dir = modules_dir)
+  }
   supported_methods <- arrange_methods(names(RUNTIME_METHOD_MODULES))
 
   if (is.null(methods)) {

--- a/inst/artma/testing/fixtures/helper_test_cache.R
+++ b/inst/artma/testing/fixtures/helper_test_cache.R
@@ -4,11 +4,21 @@ local_cli_silence <- function(env = parent.frame()) {
   withr::defer(options(old), envir = env)
 }
 
-# Synthetic "expensive" function used in several tests -----------------------
-fake_modeller <- function(x) {
-  cli::cli_alert("Running model on {.val {x}}")
-  Sys.sleep(0.01) # mimic cost
-  x * 2
+# Synthetic "expensive" function used in cache tests --------------------------
+# Returns a fresh modeller together with a call counter so tests can assert on
+# how many times the underlying implementation actually ran, instead of
+# relying on wall-clock sleeps to simulate cost.
+make_fake_modeller <- function() {
+  calls <- 0L
+  modeller <- function(x) {
+    calls <<- calls + 1L
+    cli::cli_alert("Running model on {.val {x}}")
+    x * 2
+  }
+  list(
+    modeller = modeller,
+    calls = function() calls
+  )
 }
 
-box::export(local_cli_silence, fake_modeller)
+box::export(local_cli_silence, make_fake_modeller)

--- a/inst/artma/testing/mocks/mock_df.R
+++ b/inst/artma/testing/mocks/mock_df.R
@@ -10,13 +10,14 @@
 #' @return A data frame object
 #' @export
 create_mock_df <- function(
-    effect_type = NULL,
-    nrow = NULL,
-    n_studies = NULL,
-    with_file_creation = FALSE,
-    file_path = NULL,
-    colnames_map = NULL,
-    seed = NULL) {
+  effect_type = NULL,
+  nrow = NULL,
+  n_studies = NULL,
+  with_file_creation = FALSE,
+  file_path = NULL,
+  colnames_map = NULL,
+  seed = NULL
+) {
   box::use(
     artma / const[CONST],
     artma / libs / core / number[generate_random_vector],
@@ -26,7 +27,9 @@ create_mock_df <- function(
     artma / testing / mocks / mock_utils[create_mock_study_names]
   )
 
-  if (!is.null(seed)) set.seed(seed) else set.seed(CONST$MOCKS$MOCK_DF_SEED)
+  if (is.null(seed)) {
+    seed <- CONST$MOCKS$MOCK_DF_SEED
+  }
 
   colnames_map <- if (is.null(colnames_map)) list() else colnames_map
   assert(is.list(colnames_map), "Column names must be a named list")
@@ -48,13 +51,25 @@ create_mock_df <- function(
   if (is.null(n_studies)) {
     n_studies <- CONST$MOCKS$MOCK_DF_NSTUDIES
   }
-  study_names <- create_mock_study_names(n_studies = n_studies, total_occurrences = nrow)
+  # Run all random generation under a local seed so the caller's RNG stream
+  # is left untouched. withr::with_seed restores .Random.seed afterwards.
+  random_columns <- withr::with_seed(seed, {
+    study_names <- create_mock_study_names(n_studies = n_studies, total_occurrences = nrow)
+    list(
+      study_names = study_names,
+      effect = generate_random_vector(from = -1, to = 1, length.out = nrow),
+      se = generate_random_vector(from = -1, to = 1, length.out = nrow),
+      n_obs = generate_random_vector(from = 10, to = 1000, length.out = nrow, integer = TRUE)
+    )
+  })
+
+  study_names <- random_columns$study_names
   study_id <- as.integer(factor(study_names, levels = unique(study_names)))
   obs_id <- base::seq.int(from = 1, to = nrow, by = 1)
 
-  effect <- generate_random_vector(from = -1, to = 1, length.out = nrow)
-  se <- generate_random_vector(from = -1, to = 1, length.out = nrow)
-  n_obs <- generate_random_vector(from = 10, to = 1000, length.out = nrow, integer = TRUE)
+  effect <- random_columns$effect
+  se <- random_columns$se
+  n_obs <- random_columns$n_obs
 
   base_df <- list(
     obs_id = obs_id,

--- a/man/invoke_runtime_methods.Rd
+++ b/man/invoke_runtime_methods.Rd
@@ -4,12 +4,14 @@
 \alias{invoke_runtime_methods}
 \title{Invoke methods}
 \usage{
-invoke_runtime_methods(methods, df, ...)
+invoke_runtime_methods(methods, df, modules_dir = NULL, ...)
 }
 \arguments{
 \item{methods}{\emph{[character]} A character vector of the methods to invoke.}
 
 \item{df}{\emph{[data.frame]} The data frame to invoke the methods on.}
+
+\item{modules_dir}{\emph{[character, optional]} Directory to discover runtime method modules in. Defaults to \code{NULL}, in which case the standard package methods directory is used. Used mainly for dependency injection in tests.}
 
 \item{...}{\emph{[any]} Additional arguments to pass to the methods.}
 }

--- a/tests/testthat/test-autonomy.R
+++ b/tests/testthat/test-autonomy.R
@@ -22,8 +22,8 @@ test_that("get_autonomy_levels returns all 5 levels", {
 test_that("get_autonomy_level returns NULL when not set (interactive mode)", {
   box::use(artma / libs / core / autonomy[get_autonomy_level])
 
-  # Clear any existing autonomy level
-  options(artma.autonomy.level = NULL)
+  # Clear any existing autonomy level; restore whatever was set on exit
+  withr::local_options(list(artma.autonomy.level = NULL))
 
   # In interactive mode, should return NULL when not set
   # In non-interactive mode, returns 5
@@ -39,15 +39,14 @@ test_that("get_autonomy_level returns NULL when not set (interactive mode)", {
 test_that("set_autonomy_level sets and get_autonomy_level retrieves", {
   box::use(artma / libs / core / autonomy[set_autonomy_level, get_autonomy_level])
 
+  withr::local_options(list(artma.autonomy.level = NULL))
+
   # Test each valid level
   for (level in 1:5) {
     set_autonomy_level(level)
     retrieved <- get_autonomy_level()
     expect_equal(retrieved, as.integer(level))
   }
-
-  # Clean up
-  options(artma.autonomy.level = NULL)
 })
 
 test_that("set_autonomy_level validates input", {
@@ -67,8 +66,8 @@ test_that("is_autonomy_level_set works correctly", {
     set_autonomy_level
   ])
 
-  # Clear level
-  options(artma.autonomy.level = NULL)
+  # Clear the level; restore whatever was set on exit
+  withr::local_options(list(artma.autonomy.level = NULL))
   # In non-interactive mode, get_autonomy_level returns 5 when not set
   # So is_autonomy_level_set will return TRUE in non-interactive mode
   if (interactive()) {
@@ -80,9 +79,6 @@ test_that("is_autonomy_level_set works correctly", {
   # Set level
   set_autonomy_level(4)
   expect_true(is_autonomy_level_set())
-
-  # Clean up
-  options(artma.autonomy.level = NULL)
 })
 
 test_that("should_prompt_user respects autonomy levels", {
@@ -90,6 +86,8 @@ test_that("should_prompt_user respects autonomy levels", {
     should_prompt_user,
     set_autonomy_level
   ])
+
+  withr::local_options(list(artma.autonomy.level = NULL))
 
   # This test only works in interactive mode
   # In non-interactive mode, should_prompt_user always returns FALSE
@@ -113,16 +111,13 @@ test_that("should_prompt_user respects autonomy levels", {
       )
     }
   }
-
-  # Clean up
-  options(artma.autonomy.level = NULL)
 })
 
 test_that("should_prompt_user returns TRUE when level not set (interactive mode)", {
   box::use(artma / libs / core / autonomy[should_prompt_user])
 
-  # Clear level
-  options(artma.autonomy.level = NULL)
+  # Clear the level; restore whatever was set on exit
+  withr::local_options(list(artma.autonomy.level = NULL))
 
   # In interactive mode, should prompt if level not set
   if (interactive()) {
@@ -133,6 +128,8 @@ test_that("should_prompt_user returns TRUE when level not set (interactive mode)
 
 test_that("should_prompt_user returns FALSE in non-interactive mode", {
   box::use(artma / libs / core / autonomy[should_prompt_user, set_autonomy_level])
+
+  withr::local_options(list(artma.autonomy.level = NULL))
 
   # Set a low level
   set_autonomy_level(1)
@@ -146,9 +143,6 @@ test_that("should_prompt_user returns FALSE in non-interactive mode", {
       expect_false(should_prompt_user(required_level = 5))
     }
   )
-
-  # Clean up
-  options(artma.autonomy.level = NULL)
 })
 
 test_that("get_autonomy_description works for all levels", {
@@ -157,6 +151,8 @@ test_that("get_autonomy_description works for all levels", {
     get_autonomy_levels,
     set_autonomy_level
   ])
+
+  withr::local_options(list(artma.autonomy.level = NULL))
 
   levels <- get_autonomy_levels()
 
@@ -173,16 +169,13 @@ test_that("get_autonomy_description works for all levels", {
   desc <- get_autonomy_description()
   expect_true(is.character(desc))
   expect_true(grepl("Level 3", desc))
-
-  # Clean up
-  options(artma.autonomy.level = NULL)
 })
 
 test_that("get_autonomy_description returns 'Not set' when level is NULL (interactive mode)", {
   box::use(artma / libs / core / autonomy[get_autonomy_description])
 
-  # Clear level
-  options(artma.autonomy.level = NULL)
+  # Clear the level; restore whatever was set on exit
+  withr::local_options(list(artma.autonomy.level = NULL))
 
   desc <- get_autonomy_description()
   # In interactive mode, returns "Not set"
@@ -200,8 +193,8 @@ test_that("is_fully_autonomous works correctly", {
     set_autonomy_level
   ])
 
-  # Clear level
-  options(artma.autonomy.level = NULL)
+  # Clear the level; restore whatever was set on exit
+  withr::local_options(list(artma.autonomy.level = NULL))
   # In non-interactive mode, get_autonomy_level returns 5 when not set
   if (interactive()) {
     expect_false(is_fully_autonomous())
@@ -216,9 +209,6 @@ test_that("is_fully_autonomous works correctly", {
   # Set to level 4
   set_autonomy_level(4)
   expect_false(is_fully_autonomous())
-
-  # Clean up
-  options(artma.autonomy.level = NULL)
 })
 
 test_that("get_default_autonomy_level returns 4", {
@@ -231,8 +221,8 @@ test_that("get_default_autonomy_level returns 4", {
 test_that("get_autonomy_level returns 5 in non-interactive mode when not set", {
   box::use(artma / libs / core / autonomy[get_autonomy_level])
 
-  # Clear level
-  options(artma.autonomy.level = NULL)
+  # Clear the level; restore whatever was set on exit
+  withr::local_options(list(artma.autonomy.level = NULL))
 
   # Mock non-interactive mode
   withr::with_options(
@@ -248,7 +238,7 @@ test_that("public API functions work correctly", {
   box::use(artma[autonomy.get, autonomy.set, autonomy.is_set, autonomy.is_full, autonomy.describe, autonomy.levels])
 
   # Test autonomy.get
-  options(artma.autonomy.level = NULL)
+  withr::local_options(list(artma.autonomy.level = NULL))
   # In non-interactive mode, returns 5 when not set
   if (interactive()) {
     expect_null(autonomy.get())
@@ -284,7 +274,4 @@ test_that("public API functions work correctly", {
   # Test autonomy.levels
   levels <- autonomy.levels()
   expect_equal(length(levels), 5)
-
-  # Clean up
-  options(artma.autonomy.level = NULL)
 })

--- a/tests/testthat/test-bma-collinearity.R
+++ b/tests/testthat/test-bma-collinearity.R
@@ -22,6 +22,10 @@ box::use(
   ]
 )
 
+# Deterministic RNG so assertions on matrix rank and collinearity detection
+# do not depend on whatever consumed the RNG stream earlier on this worker.
+set.seed(42)
+
 # Test data setup
 make_test_df <- function() {
   data.frame(

--- a/tests/testthat/test-box-plot-study-label.R
+++ b/tests/testthat/test-box-plot-study-label.R
@@ -1,10 +1,10 @@
 box::use(
-  artma / methods / box_plot[box_plot]
+  testthat[expect_equal, expect_true, test_that]
 )
 
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
+box::use(
+  artma / methods / box_plot[box_plot]
+)
 
 
 test_that("box_plot auto-selects study_label over study_id for grouping", {

--- a/tests/testthat/test-data-auto-detection-confirmation.R
+++ b/tests/testthat/test-data-auto-detection-confirmation.R
@@ -1,4 +1,13 @@
 box::use(
+  testthat[
+    expect_equal,
+    expect_no_error,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
   artma / data / interactive_mapping[
     present_detected_mapping,
     format_mapping_display
@@ -7,12 +16,6 @@ box::use(
     get_required_column_names
   ]
 )
-
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_false <- getFromNamespace("expect_false", "testthat")
-expect_is <- getFromNamespace("expect_is", "testthat")
 
 
 test_that("format_mapping_display groups required and optional correctly", {
@@ -154,7 +157,6 @@ test_that("present_detected_mapping handles required columns only", {
   withr::local_options(list("artma.verbose" = 1))
 
   # Test that function doesn't error with required columns only
-  expect_no_error <- getFromNamespace("expect_no_error", "testthat")
   expect_no_error(
     tryCatch(
       {
@@ -197,7 +199,6 @@ test_that("present_detected_mapping handles mixed required and optional", {
 
   withr::local_options(list("artma.verbose" = 1))
 
-  expect_no_error <- getFromNamespace("expect_no_error", "testthat")
   expect_no_error(
     tryCatch(
       {

--- a/tests/testthat/test-data-cache-signature.R
+++ b/tests/testthat/test-data-cache-signature.R
@@ -113,8 +113,7 @@ test_that("prepare_data hits the cache on a second identical run", {
   box::use(
     artma / data / index[prepare_data_impl],
     artma / data / cache_signatures[build_data_cache_signature],
-    artma / libs / infrastructure / cache[cache_cli_runner],
-    artma / data_config / resolve[invalidate_df_cache]
+    artma / libs / infrastructure / cache[cache_cli_runner]
   )
 
   FIXTURES$local_cli_silence()
@@ -125,9 +124,8 @@ test_that("prepare_data hits the cache on a second identical run", {
 
   withr::local_options(pipeline_options(tmp_file))
 
-  invalidate_df_cache()
-  withr::defer(invalidate_df_cache())
-
+  # The config df cache keys on path + mtime, so entries left behind by other
+  # tests cannot collide with this test's temp file.
   runs <- 0L
   counted_impl <- function() {
     runs <<- runs + 1L
@@ -149,13 +147,11 @@ test_that("prepare_data hits the cache on a second identical run", {
   expect_equal(runs, 1L)
 
   # Run 2 with identical inputs must be a cache hit, not a recomputation.
-  invalidate_df_cache()
   second <- testthat::capture_messages(df_second <- runner())
   expect_equal(runs, 1L)
   expect_identical(df_first, df_second)
 
   # Changing a user-authored preprocessing option must cause a cache miss.
-  invalidate_df_cache()
   withr::local_options(list("artma.data.na_handling" = "median"))
   testthat::capture_messages(runner())
   expect_equal(runs, 2L)

--- a/tests/testthat/test-data-column-recognition.R
+++ b/tests/testthat/test-data-column-recognition.R
@@ -1,4 +1,14 @@
 box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_gte,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
   artma / data / column_recognition[
     get_column_patterns,
     match_column_name,
@@ -14,12 +24,8 @@ box::use(
   ]
 )
 
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_false <- getFromNamespace("expect_false", "testthat")
-expect_gte <- getFromNamespace("expect_gte", "testthat")
-expect_lte <- getFromNamespace("expect_lte", "testthat")
+# Deterministic RNG for the randomly generated example data frames below
+set.seed(42)
 
 
 test_that("get_column_patterns returns valid structure", {

--- a/tests/testthat/test-data-column-resolution.R
+++ b/tests/testthat/test-data-column-resolution.R
@@ -1,4 +1,16 @@
 box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_gte,
+    expect_lt,
+    expect_lte,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
   artma / data / column_recognition[
     analyze_column_values,
     score_candidate_values,
@@ -8,14 +20,6 @@ box::use(
     get_column_patterns
   ]
 )
-
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_false <- getFromNamespace("expect_false", "testthat")
-expect_gte <- getFromNamespace("expect_gte", "testthat")
-expect_lte <- getFromNamespace("expect_lte", "testthat")
-expect_lt <- getFromNamespace("expect_lt", "testthat")
 
 
 # Tests for analyze_column_values

--- a/tests/testthat/test-data-compute.R
+++ b/tests/testthat/test-data-compute.R
@@ -1,10 +1,10 @@
 box::use(
-  artma / data / compute[compute_optional_columns]
+  testthat[expect_equal, expect_true, test_that]
 )
 
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
+box::use(
+  artma / data / compute[compute_optional_columns]
+)
 
 computed_config_overrides <- list(
   obs_id = list(var_name = "obs_id", is_computed = TRUE),

--- a/tests/testthat/test-data-config-defaults.R
+++ b/tests/testthat/test-data-config-defaults.R
@@ -10,15 +10,7 @@ box::use(
   ]
 )
 
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_null <- getFromNamespace("expect_null", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_false <- getFromNamespace("expect_false", "testthat")
-expect_error <- getFromNamespace("expect_error", "testthat")
-expect_length <- getFromNamespace("expect_length", "testthat")
-
-# <U+2500><U+2500> identical_or_both_na <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── identical_or_both_na ─────────────────────────────────────────────────────
 
 test_that("identical_or_both_na: both NA returns TRUE", {
   box::use(artma / data_config / defaults[identical_or_both_na])
@@ -64,7 +56,7 @@ test_that("identical_or_both_na: NULL vs NA returns FALSE", {
   expect_false(identical_or_both_na(NA, NULL))
 })
 
-# <U+2500><U+2500> build_default_config_entry <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── build_default_config_entry ────────────────────────────────────────────────
 
 test_that("build_default_config_entry: numeric column", {
   box::use(artma / data_config / defaults[build_default_config_entry])
@@ -105,7 +97,7 @@ test_that("build_default_config_entry: entry has all 16 expected fields", {
   expect_equal(sort(names(entry)), sort(expected_fields))
 })
 
-# <U+2500><U+2500> build_base_config <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── build_base_config ─────────────────────────────────────────────────────────
 
 test_that("build_base_config: creates entry for each column", {
   box::use(artma / data_config / defaults[build_base_config])
@@ -151,7 +143,7 @@ test_that("build_base_config: errors on empty dataframe", {
   expect_error(build_base_config(df), "empty")
 })
 
-# <U+2500><U+2500> extract_overrides <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── extract_overrides ─────────────────────────────────────────────────────────
 
 test_that("extract_overrides: returns NULL when entry matches defaults", {
   box::use(artma / data_config / defaults[extract_overrides])

--- a/tests/testthat/test-data-config-resolve.R
+++ b/tests/testthat/test-data-config-resolve.R
@@ -9,13 +9,7 @@ box::use(
   withr[local_options]
 )
 
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_null <- getFromNamespace("expect_null", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_length <- getFromNamespace("expect_length", "testthat")
-
-# <U+2500><U+2500> merge_config <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── merge_config ──────────────────────────────────────────────────────────────
 
 test_that("merge_config: returns base when overrides are empty", {
   box::use(artma / data_config / resolve[merge_config])
@@ -125,7 +119,7 @@ test_that("merge_config: skips non-list override entries", {
   expect_true(is.na(result$x$bma))
 })
 
-# <U+2500><U+2500> read_df_for_config caching <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── read_df_for_config caching ────────────────────────────────────────────────
 
 test_that("read_df_for_config uses a primed dataframe cache without re-reading data", {
   box::use(
@@ -226,7 +220,7 @@ test_that("get_data_config picks up file changes at the same source path", {
   expect_true("new_moderator" %in% names(config_after))
 })
 
-# <U+2500><U+2500> canonical config keys <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── canonical config keys ─────────────────────────────────────────────────────
 
 test_that("config keys are standardized regardless of which entry point resolves first", {
   box::use(
@@ -272,7 +266,7 @@ test_that("config keys are standardized regardless of which entry point resolves
   expect_equal(sort(names(cold_config)), sort(names(primed_config)))
 })
 
-# <U+2500><U+2500> get_data_config (integration with resolve) <U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500><U+2500>
+# ── get_data_config (integration with resolve) ───────────────────────────────
 
 test_that("get_data_config: returns overrides when df not available", {
   box::use(artma / data_config / read[get_data_config])

--- a/tests/testthat/test-data-interactive-mapping.R
+++ b/tests/testthat/test-data-interactive-mapping.R
@@ -1,4 +1,14 @@
 box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_no_error,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
   artma / data / interactive_mapping[
     confirm_column_mapping,
     save_column_mapping_to_options,
@@ -6,11 +16,6 @@ box::use(
   ],
   artma / data / column_recognition[get_required_column_names]
 )
-
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_no_error <- getFromNamespace("expect_no_error", "testthat")
 
 
 # Note: interactive_column_mapping and column_mapping_workflow require

--- a/tests/testthat/test-data-preview.R
+++ b/tests/testthat/test-data-preview.R
@@ -1,16 +1,14 @@
 box::use(
   testthat[
+    expect_equal,
     expect_error,
     expect_invisible,
     expect_null,
+    expect_true,
     test_that
   ],
   withr[local_options]
 )
-
-test_that <- getFromNamespace("test_that", "testthat")
-expect_error <- getFromNamespace("expect_error", "testthat")
-expect_invisible <- getFromNamespace("expect_invisible", "testthat")
 
 test_that("data.preview with data frame and preprocess FALSE returns invisibly", {
   withr::local_options(list(artma.verbose = 0))

--- a/tests/testthat/test-data-schema-reconcile.R
+++ b/tests/testthat/test-data-schema-reconcile.R
@@ -1,25 +1,28 @@
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_false <- getFromNamespace("expect_false", "testthat")
-expect_error <- getFromNamespace("expect_error", "testthat")
-expect_null <- getFromNamespace("expect_null", "testthat")
-expect_named <- getFromNamespace("expect_named", "testthat")
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_null,
+    expect_true,
+    test_that
+  ]
+)
 
 base_reconcile_opts <- function(extra = list()) {
   utils::modifyList(
     list(
-      "artma.data.colnames.obs_id"   = NA_character_,
-      "artma.data.colnames.effect"   = "effect_size",
-      "artma.data.colnames.n_obs"    = NA_character_,
+      "artma.data.colnames.obs_id" = NA_character_,
+      "artma.data.colnames.effect" = "effect_size",
+      "artma.data.colnames.n_obs" = NA_character_,
       "artma.data.colnames.precision" = NA_character_,
-      "artma.data.colnames.reg_dof"  = NA_character_,
-      "artma.data.colnames.se"       = "se_col",
+      "artma.data.colnames.reg_dof" = NA_character_,
+      "artma.data.colnames.se" = "se_col",
       "artma.data.colnames.study_id" = "study",
       "artma.data.colnames.study_size" = NA_character_,
-      "artma.data.colnames.t_stat"   = NA_character_,
+      "artma.data.colnames.t_stat" = NA_character_,
       "artma.data.expected_schema_columns" = c("effect_size", "se_col", "study"),
-      "artma.data.config"            = list()
+      "artma.data.config" = list()
     ),
     extra
   )

--- a/tests/testthat/test-data-smart-detection.R
+++ b/tests/testthat/test-data-smart-detection.R
@@ -1,4 +1,14 @@
 box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_no_error,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
   artma / data / smart_detection[
     detect_delimiter,
     detect_encoding,
@@ -6,12 +16,6 @@ box::use(
     validate_df_structure
   ]
 )
-
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_error <- getFromNamespace("expect_error", "testthat")
-expect_no_error <- getFromNamespace("expect_no_error", "testthat")
 
 
 # Helper function to create temp CSV files for testing

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -1,11 +1,11 @@
 box::use(
+  testthat[expect_error, expect_true, test_that]
+)
+
+box::use(
   artma / testing / mocks / index[MOCKS],
   artma / testing / fixtures / index[FIXTURES]
 )
-
-test_that <- getFromNamespace("test_that", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_error <- getFromNamespace("expect_error", "testthat")
 
 # Note: These tests use auto_detect = FALSE to test core logic without interaction.
 # When auto_detect = TRUE, the new confirmation flow is triggered which requires
@@ -13,7 +13,6 @@ expect_error <- getFromNamespace("expect_error", "testthat")
 
 test_that("standardize_column_names handles missing required columns in options correctly", {
   box::use(
-    artma / libs / core / validation[assert],
     artma / data / utils[get_required_colnames, standardize_column_names]
   )
 
@@ -21,46 +20,55 @@ test_that("standardize_column_names handles missing required columns in options 
 
   all_colnames <- names(mock_colnames)
   required_colnames <- get_required_colnames()
-  arbitrary_required_colname <- sample(required_colnames, 1)
-  arbitrary_non_required_colname <- sample(setdiff(all_colnames, required_colnames), 1)
+  non_required_colnames <- setdiff(all_colnames, required_colnames)
 
-  assert(arbitrary_required_colname %in% required_colnames)
-  assert(!arbitrary_non_required_colname %in% required_colnames)
+  # Build the full option list for a scenario, clearing (NULL) every colnames
+  # option that the scenario omits so that state set by a previous scenario
+  # cannot leak into the next one.
+  build_scenario_options <- function(scenario_colnames) {
+    opts <- lapply(stats::setNames(all_colnames, all_colnames), function(col) {
+      scenario_colnames[[col]]
+    })
+    stats::setNames(opts, paste0("artma.data.colnames.", all_colnames))
+  }
 
-  colnames_with_one_required_missing <- mock_colnames[-which(names(mock_colnames) == arbitrary_required_colname)]
-  colnames_with_one_non_required_missing <- mock_colnames[-which(names(mock_colnames) == arbitrary_non_required_colname)]
-
-  scenarios <- list(
-    list(
-      name = "one missing required column",
-      mock_colnames = colnames_with_one_required_missing,
+  # Enumerate every required and non-required column explicitly instead of
+  # sampling an arbitrary one, so each run covers the full space.
+  scenarios <- list()
+  for (required_colname in required_colnames) {
+    scenarios[[length(scenarios) + 1]] <- list(
+      name = paste("missing required column:", required_colname),
+      mock_colnames = mock_colnames[names(mock_colnames) != required_colname],
       expected_error = "Missing mapping for required columns:"
-    ),
-    list(
-      name = "one missing non-required column",
-      mock_colnames = colnames_with_one_non_required_missing,
-      expected_error = NA
-    ),
-    list(
-      name = "all missing columns",
-      mock_colnames = lapply(mock_colnames, function(x) NULL),
-      expected_error = "Missing mapping for required columns:"
-    ),
-    list(
-      name = "all columns present",
-      mock_colnames = mock_colnames,
+    )
+  }
+  for (non_required_colname in non_required_colnames) {
+    scenarios[[length(scenarios) + 1]] <- list(
+      name = paste("missing non-required column:", non_required_colname),
+      mock_colnames = mock_colnames[names(mock_colnames) != non_required_colname],
       expected_error = NA
     )
+  }
+  scenarios[[length(scenarios) + 1]] <- list(
+    name = "all missing columns",
+    mock_colnames = lapply(mock_colnames, function(x) NULL),
+    expected_error = "Missing mapping for required columns:"
+  )
+  scenarios[[length(scenarios) + 1]] <- list(
+    name = "all columns present",
+    mock_colnames = mock_colnames,
+    expected_error = NA
   )
 
   for (scenario in scenarios) {
     mock_df <- MOCKS$create_mock_df(colnames_map = scenario$mock_colnames)
-    FIXTURES$with_custom_colnames(scenario$mock_colnames)
-    expect_error(
-      standardize_column_names(df = mock_df, auto_detect = FALSE),
-      scenario$expected_error,
-      info = paste("Scenario:", scenario$name)
-    )
+    withr::with_options(build_scenario_options(scenario$mock_colnames), {
+      expect_error(
+        standardize_column_names(df = mock_df, auto_detect = FALSE),
+        scenario$expected_error,
+        info = paste("Scenario:", scenario$name)
+      )
+    })
   }
 })
 
@@ -71,22 +79,20 @@ test_that("standardize_column_names handles missing required columns in data cor
 
   required_colnames <- get_required_colnames()
 
-  scenarios <- list(
-    list(
-      name = "one missing required column",
-      missing_colnames = setdiff(required_colnames, sample(required_colnames, 1)),
-      expected_error = "These required columns are absent in the data frame"
-    ),
-    list(
-      name = "more missing non-required columns",
-      missing_colnames = setdiff(required_colnames, sample(required_colnames, 2)),
-      expected_error = "These required columns are absent in the data frame"
-    ),
-    list(
-      name = "all missing columns",
-      missing_colnames = required_colnames,
+  # Enumerate every required column explicitly instead of sampling one, so
+  # each run covers the full space.
+  scenarios <- list()
+  for (required_colname in required_colnames) {
+    scenarios[[length(scenarios) + 1]] <- list(
+      name = paste("missing required column:", required_colname),
+      missing_colnames = required_colname,
       expected_error = "These required columns are absent in the data frame"
     )
+  }
+  scenarios[[length(scenarios) + 1]] <- list(
+    name = "all required columns missing",
+    missing_colnames = required_colnames,
+    expected_error = "These required columns are absent in the data frame"
   )
 
   for (scenario in scenarios) {

--- a/tests/testthat/test-libs-cache.R
+++ b/tests/testthat/test-libs-cache.R
@@ -20,10 +20,13 @@ test_that("capture_cli traps cli conditions and replay_log re-emits them", {
 
   FIXTURES$local_cli_silence()
 
-  res <- capture_cli({
-    cli::cli_alert_info("Hello")
-    42
-  }, emit = FALSE)
+  res <- capture_cli(
+    {
+      cli::cli_alert_info("Hello")
+      42
+    },
+    emit = FALSE
+  )
 
   # ----- value --------------------------------------------------------------
   expect_equal(res$value, 42)
@@ -47,10 +50,13 @@ test_that("capture_cli captures cat helpers and replays them faithfully", {
 
   FIXTURES$local_cli_silence()
 
-  res <- capture_cli({
-    cli::cat_rule("demo")
-    "done"
-  }, emit = FALSE)
+  res <- capture_cli(
+    {
+      cli::cat_rule("demo")
+      "done"
+    },
+    emit = FALSE
+  )
 
   expect_equal(res$value, "done")
   expect_length(res$log, 1L)
@@ -71,10 +77,13 @@ test_that("replay_log skips whitespace-only condition entries", {
 
   FIXTURES$local_cli_silence()
 
-  res <- capture_cli({
-    cli::cli_alert_info("Hello")
-    "done"
-  }, emit = FALSE)
+  res <- capture_cli(
+    {
+      cli::cli_alert_info("Hello")
+      "done"
+    },
+    emit = FALSE
+  )
 
   expect_length(res$log, 1L)
 
@@ -101,13 +110,15 @@ test_that("cache_cli memoises value + log and replays on hit", {
   # use an *ephemeral* cache so tests are self-contained
   tmp_cache <- memoise::cache_filesystem(withr::local_tempdir())
 
-  cached_modeller <- cache_cli(FIXTURES$fake_modeller, cache = tmp_cache)
+  fake_modeller <- FIXTURES$make_fake_modeller()
+  cached_modeller <- cache_cli(fake_modeller$modeller, cache = tmp_cache)
 
   ## --- 1st call: cold ------------------------------------------------------
   first_console <- testthat::capture_messages(
     v1 <- cached_modeller(10)
   )
   expect_equal(v1, 20)
+  expect_equal(fake_modeller$calls(), 1L)
 
   # cache should now contain exactly one key
   expect_length(tmp_cache$keys(), 1L)
@@ -117,6 +128,9 @@ test_that("cache_cli memoises value + log and replays on hit", {
     v2 <- cached_modeller(10)
   )
   expect_equal(v2, 20)
+
+  # the implementation must not run again on a cache hit
+  expect_equal(fake_modeller$calls(), 1L)
 
   # console chatter must be *identical* because we replayed
   expect_identical(first_console, second_console)

--- a/tests/testthat/test-options-column-preprocessing.R
+++ b/tests/testthat/test-options-column-preprocessing.R
@@ -1,11 +1,10 @@
 box::use(
-  artma / options / column_preprocessing[preprocess_column_mapping]
+  testthat[expect_equal, expect_false, expect_true, test_that]
 )
 
-test_that <- getFromNamespace("test_that", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_false <- getFromNamespace("expect_false", "testthat")
+box::use(
+  artma / options / column_preprocessing[preprocess_column_mapping]
+)
 
 
 # Helper to create a mock options_def structure

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -112,10 +112,10 @@ test_that("invoke_runtime_methods isolates a failing method and keeps the rest",
     method_c = list(run = function(df, ...) "c-ok")
   )
   withr::local_options(list(artma.verbose = 0))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame(x = 1:3)
-  results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+  results <- artma:::invoke_runtime_methods(methods = "all", df = df, modules_dir = methods_dir)
 
   expect_setequal(names(results), c("method_a", "method_c"))
   expect_equal(results$method_a, "a-ok")
@@ -132,11 +132,11 @@ test_that("invoke_runtime_methods warns about failed methods when verbosity allo
     method_b = list(run = function(df, ...) cli::cli_abort("boom"))
   )
   withr::local_options(list(artma.verbose = 2))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame(x = 1:3)
   warnings <- capture_warnings(
-    results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+    results <- artma:::invoke_runtime_methods(methods = "all", df = df, modules_dir = methods_dir)
   )
 
   expect_true(any(grepl("method_b", warnings)))
@@ -149,11 +149,11 @@ test_that("invoke_runtime_methods emits a final warning when every method fails"
     method_b = list(run = function(df, ...) cli::cli_abort("second failure"))
   )
   withr::local_options(list(artma.verbose = 2))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame(x = 1:3)
   warnings <- capture_warnings(
-    results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+    results <- artma:::invoke_runtime_methods(methods = "all", df = df, modules_dir = methods_dir)
   )
 
   expect_equal(length(results), 0L)
@@ -170,10 +170,10 @@ test_that("partial results from a run with a failing method are exported", {
     method_c = list(run = function(df, ...) data.frame(estimate = 3))
   )
   withr::local_options(list(artma.verbose = 0))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame(x = 1:3)
-  results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+  results <- artma:::invoke_runtime_methods(methods = "all", df = df, modules_dir = methods_dir)
 
   output_dir <- withr::local_tempdir()
   fs::dir_create(file.path(output_dir, "tables"))

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -19,12 +19,15 @@ mock_methods <- function() {
   )
 }
 
-mock_runtime_method_registry <- function(fake_methods) {
-  box::use(artma / modules / runtime_methods)
-
-  temp_root <- tempfile(pattern = "artma-test-methods-")
-  artma_root <- file.path(temp_root, "artma")
-  methods_dir <- file.path(artma_root, "methods")
+# Write the fake methods into a temporary box module tree and return the
+# methods directory, to be passed to invoke_runtime_methods(modules_dir = ...).
+# All state changes (temp files, the scoped box.path prepend needed for the
+# generated box imports to resolve, and module cache entries) are registered
+# for cleanup in the caller's frame via withr, so they are undone even when a
+# test fails midway. Package bindings such as PATHS are never touched.
+local_mock_methods_dir <- function(fake_methods, env = parent.frame()) {
+  temp_root <- withr::local_tempdir(pattern = "artma-test-methods-", .local_envir = env)
+  methods_dir <- file.path(temp_root, "artma", "methods")
   dir.create(methods_dir, recursive = TRUE, showWarnings = FALSE)
 
   for (name in names(fake_methods)) {
@@ -37,25 +40,7 @@ mock_runtime_method_registry <- function(fake_methods) {
     writeLines(module_code, file_path)
   }
 
-  withr::defer(unlink(temp_root, recursive = TRUE, force = TRUE), envir = parent.frame())
-
-  original_box_path <- getOption("box.path")
-  withr::local_options(list(box.path = c(temp_root, original_box_path)), .local_envir = parent.frame())
-
-  imports_env <- parent.env(environment(runtime_methods$get_runtime_method_modules))
-  original_methods_dir <- imports_env$PATHS$DIR_METHODS
-  unlockBinding("PATHS", imports_env)
-  imports_env$PATHS$DIR_METHODS <- methods_dir
-  lockBinding("PATHS", imports_env)
-
-  withr::defer(
-    {
-      unlockBinding("PATHS", imports_env)
-      imports_env$PATHS$DIR_METHODS <- original_methods_dir
-      lockBinding("PATHS", imports_env)
-    },
-    envir = parent.frame()
-  )
+  withr::local_options(list(box.path = c(temp_root, getOption("box.path"))), .local_envir = env)
 
   withr::defer(
     {
@@ -63,17 +48,23 @@ mock_runtime_method_registry <- function(fake_methods) {
         try(box::unload(sprintf("artma/methods/%s", name)), silent = TRUE)
       }
     },
-    envir = parent.frame()
+    envir = env
   )
+
+  methods_dir
 }
 
 test_that("invoke_runtime_methods handles explicit character vectors", {
   fake_methods <- mock_methods()
   withr::local_options(list(artma.verbose = 0))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame(x = 1:3)
-  results <- artma:::invoke_runtime_methods(methods = c("method_b", "method_a", "method_b"), df = df)
+  results <- artma:::invoke_runtime_methods(
+    methods = c("method_b", "method_a", "method_b"),
+    df = df,
+    modules_dir = methods_dir
+  )
 
   expected_order <- names(fake_methods)[names(fake_methods) %in% c("method_b", "method_a")]
 
@@ -84,10 +75,10 @@ test_that("invoke_runtime_methods handles explicit character vectors", {
 test_that("invoke_runtime_methods expands the all keyword", {
   fake_methods <- mock_methods()
   withr::local_options(list(artma.verbose = 0))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame()
-  results <- artma:::invoke_runtime_methods(methods = "all", df = df)
+  results <- artma:::invoke_runtime_methods(methods = "all", df = df, modules_dir = methods_dir)
 
   expect_setequal(names(results), names(fake_methods))
 })
@@ -95,21 +86,21 @@ test_that("invoke_runtime_methods expands the all keyword", {
 test_that("invoke_runtime_methods surfaces invalid inputs early", {
   fake_methods <- mock_methods()
   withr::local_options(list(artma.verbose = 0))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame()
   expect_error(
-    artma:::invoke_runtime_methods(methods = c("missing", "method_a"), df = df),
+    artma:::invoke_runtime_methods(methods = c("missing", "method_a"), df = df, modules_dir = methods_dir),
     "Invalid runtime methods selected"
   )
 
   expect_error(
-    artma:::invoke_runtime_methods(methods = c("method_a", NA_character_), df = df),
+    artma:::invoke_runtime_methods(methods = c("method_a", NA_character_), df = df, modules_dir = methods_dir),
     "must not contain missing values"
   )
 
   expect_error(
-    artma:::invoke_runtime_methods(methods = numeric(), df = df),
+    artma:::invoke_runtime_methods(methods = numeric(), df = df, modules_dir = methods_dir),
     "Runtime methods must be supplied as a character vector"
   )
 })
@@ -207,12 +198,13 @@ test_that("invoke_runtime_methods forwards BMA result to dependent methods", {
   )
 
   withr::local_options(list(artma.verbose = 0))
-  mock_runtime_method_registry(fake_methods)
+  methods_dir <- local_mock_methods_dir(fake_methods)
 
   df <- data.frame(x = 1:3)
   results <- artma:::invoke_runtime_methods(
     methods = c("best_practice_estimate", "bma"),
-    df = df
+    df = df,
+    modules_dir = methods_dir
   )
 
   expect_named(results, c("bma", "best_practice_estimate"))

--- a/tests/testthat/test-schema-reconcile-integration.R
+++ b/tests/testthat/test-schema-reconcile-integration.R
@@ -1,28 +1,32 @@
-test_that <- getFromNamespace("test_that", "testthat")
-expect_null <- getFromNamespace("expect_null", "testthat")
-expect_equal <- getFromNamespace("expect_equal", "testthat")
-expect_error <- getFromNamespace("expect_error", "testthat")
-expect_true <- getFromNamespace("expect_true", "testthat")
-expect_false <- getFromNamespace("expect_false", "testthat")
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_null,
+    expect_true,
+    test_that
+  ]
+)
 
 # Shared option set for reconcile tests <U+2014> no file persistence, minimal verbosity
 base_opts <- function(extra = list()) {
   utils::modifyList(
     list(
-      "artma.data.colnames.obs_id"   = NA_character_,
-      "artma.data.colnames.effect"   = "effect_size",
-      "artma.data.colnames.n_obs"    = NA_character_,
+      "artma.data.colnames.obs_id" = NA_character_,
+      "artma.data.colnames.effect" = "effect_size",
+      "artma.data.colnames.n_obs" = NA_character_,
       "artma.data.colnames.precision" = NA_character_,
-      "artma.data.colnames.reg_dof"  = NA_character_,
-      "artma.data.colnames.se"       = "se_col",
+      "artma.data.colnames.reg_dof" = NA_character_,
+      "artma.data.colnames.se" = "se_col",
       "artma.data.colnames.study_id" = "study",
       "artma.data.colnames.study_size" = NA_character_,
-      "artma.data.colnames.t_stat"   = NA_character_,
+      "artma.data.colnames.t_stat" = NA_character_,
       "artma.data.expected_schema_columns" = c("effect_size", "se_col", "study"),
-      "artma.data.config"            = list(),
-      "artma.temp.file_name"         = NULL,
-      "artma.temp.dir_name"          = NULL,
-      "artma.verbose"                = 1L
+      "artma.data.config" = list(),
+      "artma.temp.file_name" = NULL,
+      "artma.temp.dir_name" = NULL,
+      "artma.verbose" = 1L
     ),
     extra
   )
@@ -101,8 +105,8 @@ test_that("reconcile_schema auto: skips without error when no colnames are confi
 
   withr::with_options(
     base_opts(list(
-      "artma.data.colnames.effect"   = NA_character_,
-      "artma.data.colnames.se"       = NA_character_,
+      "artma.data.colnames.effect" = NA_character_,
+      "artma.data.colnames.se" = NA_character_,
       "artma.data.colnames.study_id" = NA_character_,
       "artma.data.expected_schema_columns" = NA_character_
     )),
@@ -265,15 +269,15 @@ test_that("reconcile then standardize: produces df with standard column names", 
 
   # Full colnames map covering all required columns
   full_opts <- list(
-    "artma.data.colnames.effect"   = "effect_size",
-    "artma.data.colnames.se"       = "se_col",
+    "artma.data.colnames.effect" = "effect_size",
+    "artma.data.colnames.se" = "se_col",
     "artma.data.colnames.study_id" = "study",
-    "artma.data.colnames.n_obs"    = "n_obs",
+    "artma.data.colnames.n_obs" = "n_obs",
     "artma.data.expected_schema_columns" = c("effect_size", "se_col", "study", "n_obs"),
-    "artma.data.config"            = list(),
-    "artma.temp.file_name"         = NULL,
-    "artma.temp.dir_name"          = NULL,
-    "artma.verbose"                = 1L
+    "artma.data.config" = list(),
+    "artma.temp.file_name" = NULL,
+    "artma.temp.dir_name" = NULL,
+    "artma.verbose" = 1L
   )
 
   withr::with_options(


### PR DESCRIPTION
Closes #171

testthat parallel workers are reused across test files, so any leaked global state (options, RNG, locked bindings) silently changes the behavior of whichever file runs next on that worker. This PR makes the suite hermetic so parallel and serial runs are equivalent.

## The six leak vectors

1. **No-op `withr::local_options()` in `test-options.R`.** The empty call restored nothing, so `options.load(should_set_to_namespace = TRUE)` leaked every `artma.*` option it set (and removed pre-existing ones via `remove_options_with_prefix`). Replaced with a snapshot helper that records the `artma.*` option set before the test and restores exactly that set on exit, even on failure.
2. **Unseeded RNG feeding assertions.** `test-bma-collinearity.R` and `test-data-column-recognition.R` now call `set.seed` at file top, matching the 11 other RNG-using test files. `test-data-utils.R` no longer picks required columns with `sample()`; it enumerates every required and non-required column explicitly. That enumeration exposed a second latent leak: `with_custom_colnames` only sets the keys present in its map, so colname options set by one scenario iteration leaked into the next. Each scenario now runs under `withr::with_options` with every colnames key stated (set or cleared).
3. **Mock builder clobbered the caller's RNG stream.** `create_mock_df` called `set.seed()` unconditionally. All random generation (including `create_mock_study_names`) now runs inside `withr::with_seed`, which restores the caller's `.Random.seed` afterwards.
4. **Tests mutated the locked `PATHS` binding.** `test-run.R` no longer does `unlockBinding("PATHS", ...)`; it injects the temp methods directory through a new `modules_dir` parameter on `invoke_runtime_methods`, which forwards to the existing `modules_dir` parameter of `get_runtime_method_modules` (the pattern `test-runtime-methods.R` already used). The scoped `box.path` prepend remains, via `withr::local_options`, because the box imports generated by `crawl_and_import_modules` can only resolve the temp module tree through `box.path`; withr registers the restore immediately, so it is undone even when a test fails midway.
5. **Raw option cleanup skipped on failure in `test-autonomy.R`.** All 15 trailing `options(artma.autonomy.level = NULL)` cleanups are gone; every test that touches the option now starts with `withr::local_options(list(artma.autonomy.level = NULL))`, which both clears it for the test and restores the pre-test value on exit.
6. **Wall-clock sleep in the shared cache fixture.** `fake_modeller` no longer calls `Sys.sleep`; `make_fake_modeller()` returns a modeller plus a call counter, and the memoisation test now asserts the implementation ran exactly once across the cold and warm calls.

## Hygiene in the same PR

- One testthat import idiom everywhere: `box::use(testthat[...])`. All 17 `getFromNamespace` files converted; redundant duplicate blocks removed. (`getFromNamespace` for unexported `artma` linters is unchanged; that is a different concern.)
- Deleted the dead `tests/testthat/test-data-preprocess.R` (zero tests) and the empty `tests/testthat/setup.R`.
- Renamed `test-schema-reconcile-e2e.R` to `test-schema-reconcile-integration.R`; it is an in-process integration test, not E2E.

## Drive-by fix

`.find_package_root` in `inst/artma/paths.R` compared `read.dcf(...)[1, 1]` with `identical()`, but on recent R versions single bracket extraction keeps the `"Package"` dimname, so the check never matched and the package root was never detected from the working directory. This broke `PATHS` resolution (and with it, half the suite) in any checkout whose directory is not named `artma`, such as git worktrees. Changed to `[[1, 1]]`.

## Coordination notes

- A sibling PR for issue #158 removes `should_set_to_namespace` and reworks the same `test-options.R` tests this PR touches (item 1). Whoever merges second should rebase; the snapshot helper here becomes mostly redundant once #158 lands.
- A sibling PR for issue #152 adds failure-isolation tests around `test-run.R` and `test-runtime-methods.R`. Item 4 touches the same files but is mechanical (parameter injection instead of `PATHS` mutation).

## Verification

- Serial suite (`TESTTHAT_PARALLEL=false`) run 3 times, all green.
- Parallel suite (2 workers, `Config/testthat/parallel: TRUE`) run 3 times, all green.
- Runs were performed with `box.path` pointed at this worktree's `inst/`, with a temporary tripwire in `create_mock_df` confirming both serial and parallel workers actually loaded the worktree copies of the changed `inst/artma/testing` modules (removed before commit).
- `lintr::lint_package()` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
