### PR TITLE
fix: honor the cache TTL option and add a template-to-code option parity test

### DIFF
--- a/inst/artma/libs/infrastructure/cache.R
+++ b/inst/artma/libs/infrastructure/cache.R
@@ -134,8 +134,8 @@ sanitize_replay_args <- function(args) {
 #'   console while recording? Defaults to `TRUE`. When `FALSE`, messages are
 #'   logged silently for later replay.
 #' @return *\[list\]* A list with the following elements:
-#'   * **value** – the value of the evaluated expression
-#'   * **log** – a list of replayable entries. Each entry contains a
+#'   * **value**: the value of the evaluated expression
+#'   * **log**: a list of replayable entries. Each entry contains a
 #'     `kind` describing how it should be replayed (currently either the
 #'     string "condition" for `cli_message` signals or "call" for direct
 #'     `cli::cat_*()` helpers) alongside the metadata required to replay it.
@@ -328,8 +328,8 @@ replay_log <- function(log, ..., .envir = parent.frame()) {
 }
 
 #' @title Cache cli
-#' @description Wrap a function so that its results – including the CLI story it
-#'   produces – are cached and replayed on subsequent calls.
+#' @description Wrap a function so that its results (including the CLI story it
+#'   produces) are cached and replayed on subsequent calls.
 #' @param fun *\[function\]* The function to cache.
 #' @param extra_keys *\[list\]* Additional key material appended to the memoise
 #'   cache key.
@@ -339,14 +339,17 @@ replay_log <- function(log, ..., .envir = parent.frame()) {
 #'   call to decide whether the cached value should be bypassed and recomputed.
 #' @param max_age *\[numeric\]* Maximum age of cached artifacts in seconds.
 #'   Use `Inf` to disable time-based invalidation. When `NULL` (the default) the
-#'   value is sourced from the `artma.cache.max_age` option, falling back to
-#'   `Inf`.
+#'   value is sourced from the `artma.cache.max_age` option (template key
+#'   `cache.max_age`), falling back to 3600 seconds (1 hour). The fallback is
+#'   deliberately finite: cache keys include the package version but not the
+#'   source code, so two development builds sharing a version would otherwise
+#'   serve each other's stale artifacts indefinitely.
 #' @return The wrapped function.
 #' @examples
 #' \dontrun{
-#' # real work here — bookended by cli alerts but not memoised itself
+#' # real work here: bookended by cli alerts but not memoised itself
 #' .run_models_impl <- function(df, formula, seed = 123) {
-#'   cli::cli_alert("Starting model fit…")
+#'   cli::cli_alert("Starting model fit...")
 #'
 #'   set.seed(seed)
 #'   mod <- stats::lm(formula, data = df)
@@ -381,7 +384,7 @@ cache_cli <- function(fun,
   base::force(fun) # lock the original function inside the closure
 
   if (is.null(max_age)) {
-    max_age <- getOption("artma.cache.max_age", Inf)
+    max_age <- getOption("artma.cache.max_age", 3600)
   }
 
   if (!is.numeric(max_age) || length(max_age) != 1L || is.na(max_age)) {
@@ -396,7 +399,7 @@ cache_cli <- function(fun,
     return(fun)
   }
 
-  # — pick / create the cache ------------------------------------------------
+  # pick / create the cache --------------------------------------------------
   if (is.null(cache)) {
     box::use(artma / paths[PATHS])
     cache_dir <- PATHS$DIR_USR_CACHE
@@ -560,7 +563,10 @@ cache_cli <- function(fun,
 #'   memoises results through `cache_cli()`.
 #' @examples
 #' build_signature <- function(data) list(rows = nrow(data))
-#' slow_identity <- function(data) { Sys.sleep(0.1); data }
+#' slow_identity <- function(data) {
+#'   Sys.sleep(0.1)
+#'   data
+#' }
 #'
 #' cached <- cache_cli_runner(
 #'   slow_identity,

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -869,13 +869,13 @@ cache:
       If `TRUE`, use caching to speed up the package.
       If `FALSE`, do not use caching.
 
-  cache_age:
+  max_age:
     type: "integer"
     default: 3600
     help: |
-      The age of the cache in seconds.
+      Maximum age of cached artifacts in seconds.
       Defaults to 3600 seconds (1 hour).
-      If the cache is older than this, it will be invalidated.
+      Cached entries older than this are recomputed on access.
 
 temp:
   # A set of options that are only set at runtime but never stored in the options file.

--- a/tests/testthat/test-libs-cache.R
+++ b/tests/testthat/test-libs-cache.R
@@ -107,6 +107,9 @@ test_that("cache_cli memoises value + log and replays on hit", {
 
   FIXTURES$local_cli_silence()
 
+  # unset the TTL option so the artifact records the sourced default (3600)
+  withr::local_options(list(artma.cache.max_age = NULL))
+
   # use an *ephemeral* cache so tests are self-contained
   tmp_cache <- memoise::cache_filesystem(withr::local_tempdir())
 
@@ -145,7 +148,7 @@ test_that("cache_cli memoises value + log and replays on hit", {
   expect_length(art$log, 1L)
   expect_identical(art$log[[1]]$kind, "condition")
   expect_match(art$log[[1]]$message, "Running model", fixed = TRUE)
-  expect_equal(art$meta$cache$max_age, Inf)
+  expect_equal(art$meta$cache$max_age, 3600)
 })
 
 test_that("invalidate_fun forces recomputation for selected arguments", {
@@ -217,6 +220,53 @@ test_that("cache_cli honours max_age to refresh stale artifacts", {
   second <- testthat::capture_messages(cached(5))
   expect_equal(hits, 2L)
   expect_identical(first, second) # recomputation produces the same console story
+})
+
+test_that("cache_cli sources max_age from the artma.cache.max_age option", {
+  box::use(artma / libs / infrastructure / cache[cache_cli, get_artifact])
+
+  FIXTURES$local_cli_silence()
+
+  # an expired TTL from the options namespace forces recomputation
+  withr::local_options(list(artma.cache.max_age = 0))
+
+  tmp_cache <- memoise::cache_filesystem(withr::local_tempdir())
+
+  hits <- 0L
+  tracked <- function(x) {
+    hits <<- hits + 1L
+    cli::cli_alert_success("call {hits}")
+    x
+  }
+
+  cached <- cache_cli(tracked, cache = tmp_cache)
+
+  testthat::capture_messages(cached(1))
+  expect_equal(hits, 1L)
+
+  testthat::capture_messages(cached(1))
+  expect_equal(hits, 2L)
+
+  key <- tmp_cache$keys()[[1]]
+  art <- get_artifact(tmp_cache, key)
+  expect_equal(art$meta$cache$max_age, 0)
+
+  # a generous TTL from the options namespace keeps the cached value
+  withr::local_options(list(artma.cache.max_age = 3600))
+
+  fresh_cache <- memoise::cache_filesystem(withr::local_tempdir())
+  fresh_hits <- 0L
+  fresh_tracked <- function(x) {
+    fresh_hits <<- fresh_hits + 1L
+    cli::cli_alert_success("fresh call {fresh_hits}")
+    x
+  }
+
+  fresh_cached <- cache_cli(fresh_tracked, cache = fresh_cache)
+
+  testthat::capture_messages(fresh_cached(1))
+  testthat::capture_messages(fresh_cached(1))
+  expect_equal(fresh_hits, 1L)
 })
 
 test_that("cache_cli bypasses caching when disabled via option", {

--- a/tests/testthat/test-options-template-parity.R
+++ b/tests/testthat/test-options-template-parity.R
@@ -1,0 +1,230 @@
+box::use(
+  testthat[expect_equal, expect_true, skip_if_not, test_that]
+)
+
+# The fixtures and other package modules must be loaded here separately to avoid linter issues
+box::use(artma / testing / fixtures / index[FIXTURES])
+
+# This file guards against drift between the options template and the option
+# keys the code actually consumes. Both directions are asserted:
+#   1. every `artma.*` key read in the sources exists in the template, and
+#   2. every template leaf is consumed somewhere in the sources.
+#
+# Consumption evidence is collected with a grep over the package sources:
+#   - literal reads:        getOption("artma.<key>")
+#   - constant-built reads: paste0(CONST$PACKAGE_NAME, ".<key>")
+#   - group reads:          get_option_group("artma.<prefix>") counts for
+#     every template leaf under <prefix>
+# The bare namespace read `get_option_group("artma")` (used by the cache
+# signature builder to enumerate all options generically) is deliberately not
+# counted as evidence that any specific leaf is consumed.
+#
+# Keys the code reads at runtime that are deliberately absent from the
+# template (the template reader strips the `temp` block, and the rest are
+# session state never stored in an options file):
+#   - temp.*            scratch values populated by options.load
+#   - options_file_name populated when an options file is loaded
+#   - welcome.shown     session flag set after the welcome screen is shown
+# Note: data.config, data.source_path, and data.expected_schema_columns are
+# also runtime-populated, but they remain template leaves, so they need no
+# exemption here.
+runtime_only_option_keys <- c("options_file_name", "welcome.shown")
+runtime_only_option_prefixes <- c("temp.")
+
+# Template leaves consumed outside the R options namespace:
+#   - cli.editor is read straight from the YAML options file by
+#     resolve_cli_editor() before any options are loaded
+leaves_consumed_elsewhere <- c("cli.editor")
+
+package_root <- function() {
+  normalizePath(testthat::test_path("..", ".."), winslash = "/", mustWork = FALSE)
+}
+
+parity_source_files <- function(root) {
+  dirs <- c(file.path(root, "R"), file.path(root, "inst", "artma"))
+  unlist(lapply(
+    dirs,
+    list.files,
+    pattern = "\\.R$",
+    recursive = TRUE,
+    full.names = TRUE
+  ))
+}
+
+extract_keys <- function(lines, pattern) {
+  hits <- unlist(
+    regmatches(lines, gregexpr(pattern, lines, perl = TRUE)),
+    use.names = FALSE
+  )
+  if (length(hits) == 0L) {
+    return(character())
+  }
+  sub(pattern, "\\1", hits, perl = TRUE)
+}
+
+collect_consumed_option_keys <- function(files) {
+  exact_pattern <- "getOption\\(\\s*\"artma\\.([A-Za-z0-9_.]+)\""
+  const_pattern <- "paste0\\(CONST\\$PACKAGE_NAME,\\s*\"\\.([A-Za-z0-9_.]+)\"\\)"
+  group_pattern <- "get_option_group\\(\\s*\"artma\\.([A-Za-z0-9_.]+)\""
+
+  exact <- character()
+  groups <- character()
+
+  for (file in files) {
+    lines <- readLines(file, warn = FALSE)
+    lines <- lines[!grepl("^\\s*#", lines)] # skip comments and roxygen docs
+
+    exact <- c(
+      exact,
+      extract_keys(lines, exact_pattern),
+      extract_keys(lines, const_pattern)
+    )
+    groups <- c(groups, extract_keys(lines, group_pattern))
+  }
+
+  list(
+    exact = sort(unique(exact)),
+    groups = sort(unique(groups))
+  )
+}
+
+find_parity_violations <- function(leaves,
+                                   exact_keys,
+                                   group_prefixes,
+                                   runtime_only_keys = runtime_only_option_keys,
+                                   runtime_only_prefixes = runtime_only_option_prefixes,
+                                   consumed_elsewhere = leaves_consumed_elsewhere) {
+  is_runtime_only <- vapply(
+    exact_keys,
+    function(key) {
+      key %in% runtime_only_keys ||
+        any(startsWith(key, runtime_only_prefixes))
+    },
+    logical(1)
+  )
+  unknown_consumed <- setdiff(exact_keys[!is_runtime_only], leaves)
+
+  group_has_leaves <- vapply(
+    group_prefixes,
+    function(prefix) any(leaves == prefix | startsWith(leaves, paste0(prefix, "."))),
+    logical(1)
+  )
+  orphan_groups <- group_prefixes[!group_has_leaves]
+
+  leaf_consumed <- vapply(
+    leaves,
+    function(leaf) {
+      leaf %in% exact_keys ||
+        leaf %in% consumed_elsewhere ||
+        any(leaf == group_prefixes | startsWith(leaf, paste0(group_prefixes, ".")))
+    },
+    logical(1)
+  )
+  unconsumed_leaves <- leaves[!leaf_consumed]
+
+  list(
+    unknown_consumed = sort(unique(unknown_consumed)),
+    orphan_groups = sort(unique(orphan_groups)),
+    unconsumed_leaves = sort(unique(unconsumed_leaves))
+  )
+}
+
+test_that("the parity checker flags drift in both directions", {
+  leaves <- c("cache.max_age", "methods.demo.round_to", "output.dir")
+
+  # an orphan consumed key, an orphan group read, and an unconsumed leaf
+  violations <- find_parity_violations(
+    leaves = leaves,
+    exact_keys = c("cache.max_age", "cache.legacy_age"),
+    group_prefixes = c("methods.demo", "methods.ghost"),
+    runtime_only_keys = character(),
+    runtime_only_prefixes = character(),
+    consumed_elsewhere = character()
+  )
+
+  expect_equal(violations$unknown_consumed, "cache.legacy_age")
+  expect_equal(violations$orphan_groups, "methods.ghost")
+  expect_equal(violations$unconsumed_leaves, "output.dir")
+
+  # full coverage in both directions reports no violations
+  clean <- find_parity_violations(
+    leaves = leaves,
+    exact_keys = c("cache.max_age", "output.dir"),
+    group_prefixes = "methods.demo",
+    runtime_only_keys = character(),
+    runtime_only_prefixes = character(),
+    consumed_elsewhere = character()
+  )
+
+  expect_equal(clean$unknown_consumed, character(0))
+  expect_equal(clean$orphan_groups, character(0))
+  expect_equal(clean$unconsumed_leaves, character(0))
+})
+
+test_that("template leaves and consumed option keys stay in parity", {
+  box::use(artma / options / template[collect_leaf_paths])
+
+  root <- package_root()
+  template_path <- file.path(
+    root, "inst", "artma", "options", "templates", "options_template.yaml"
+  )
+
+  skip_if_not(
+    dir.exists(file.path(root, "R")) && file.exists(template_path),
+    "package sources are not available"
+  )
+
+  leaves <- collect_leaf_paths(template_path)
+  consumed <- collect_consumed_option_keys(parity_source_files(root))
+
+  violations <- find_parity_violations(
+    leaves = leaves,
+    exact_keys = consumed$exact,
+    group_prefixes = consumed$groups
+  )
+
+  expect_equal(violations$unknown_consumed, character(0))
+  expect_equal(violations$orphan_groups, character(0))
+  expect_equal(violations$unconsumed_leaves, character(0))
+})
+
+test_that("options files predating the cache.max_age rename reconcile to the default", {
+  box::use(artma[options.load, options.validate])
+
+  FIXTURES$local_cli_silence()
+
+  # pin the template to this checkout so the test does not depend on the
+  # template shipped with whichever artma build happens to be installed
+  template_path <- file.path(
+    package_root(), "inst", "artma", "options", "templates", "options_template.yaml"
+  )
+  skip_if_not(file.exists(template_path), "package sources are not available")
+
+  tmp_dir <- withr::local_tempdir()
+  legacy <- list(cache = list(cache_age = 100L))
+  yaml::write_yaml(legacy, file.path(tmp_dir, "legacy.yaml"))
+
+  # validation surfaces the renamed key as missing
+  errors <- options.validate(
+    options_file_name = "legacy.yaml",
+    options_dir = tmp_dir,
+    template_path = template_path,
+    failure_action = "return_errors_quiet"
+  )
+  missing_names <- vapply(
+    Filter(function(err) identical(err$type, "missing_option"), errors),
+    function(err) err$opt_def$name,
+    character(1)
+  )
+  expect_true("cache.max_age" %in% missing_names)
+
+  # loading applies the template default; the legacy value does not leak in
+  loaded <- options.load(
+    options_file_name = "legacy.yaml",
+    options_dir = tmp_dir,
+    template_path = template_path,
+    should_validate = TRUE,
+    should_return = TRUE
+  )
+  expect_equal(loaded$`artma.cache.max_age`, 3600)
+})


### PR DESCRIPTION
## What this does

The user-facing cache TTL option was dead: the options template defined `cache.cache_age` while the code read `artma.cache.max_age`, so a configured TTL never reached `cache_cli()`.

- Renames the template key to `cache.max_age` (the name the code and its docs already use) and updates the help text.
- Aligns the `getOption("artma.cache.max_age")` fallback with the template default (3600 seconds). This is also the dev-build staleness decision from the issue: the cache key includes the package version but not the source code, so a finite default TTL keeps two dev builds sharing a version from serving each other's stale artifacts indefinitely. The rationale is documented in the `cache_cli()` docs.
- Adds a test proving the option flows into cache expiry: with `artma.cache.max_age = 0` a warm cache recomputes; with a generous TTL it replays.
- Adds a template-to-code option parity test (`tests/testthat/test-options-template-parity.R`) that greps the sources for `getOption("artma....")`, `get_option_group("artma....")`, and `paste0(CONST$PACKAGE_NAME, "....")` reads and asserts both directions: every consumed key exists in the template, and every template leaf is consumed. Runtime-populated keys (`temp.*`, `options_file_name`, `welcome.shown`) and the one leaf consumed outside the options namespace (`cli.editor`) are whitelisted with documentation. A synthetic-drift test proves the checker catches an artificially introduced orphan key in both directions.
- Verifies the schema reconciliation flow surfaces the rename: an old options file that still has `cache.cache_age` gets a "Missing option: cache.max_age" validation error, and non-interactive `options.load()` fills in the new default (test included).

## Coordination

Issue #157 also edits `inst/artma/libs/infrastructure/cache.R`. The cache.R changes here are kept localized to the TTL default and its docs so that #157 rebases cleanly; this PR should merge first.

## Testing

- `make test`: 0 failures, 1108 passing.
- `make lint`: no findings in the changed files.

Closes #154