### PR TITLE
refactor: unify file-read dispatch and post-read normalization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,9 @@ Suggests:
     devtools (>= 2.4.5),
     fdrtool (>= 1.2.17),
     fs (>= 1.6.6),
+    haven (>= 2.5.0),
     ivmodel (>= 1.9.0),
+    jsonlite (>= 1.8.0),
     knitr (>= 1.50),
     languageserver (>= 0.3.16),
     lintr (>= 3.2.0),
@@ -58,11 +60,13 @@ Suggests:
     plm (>= 2.6-3),
     quadprog (>= 1.5-8),
     rddensity (>= 2.5),
+    readxl (>= 1.4.0),
     remotes (>= 2.5.0),
     rex (>= 1.2.1),
     rmarkdown (>= 2.30),
     roxygen2 (>= 7.3.3),
-    testthat (>= 3.2.3)
+    testthat (>= 3.2.3),
+    writexl (>= 1.4.0)
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3

--- a/R/data_preview.R
+++ b/R/data_preview.R
@@ -70,7 +70,7 @@ data.preview <- function(
     options_dir = NULL,
     preprocess = TRUE) {
   box::use(
-    artma / data / read[read_data, read_data_raw],
+    artma / data / read[read_data],
     artma / data / index[prepare_data],
     artma / data / preprocess[preprocess_data],
     artma / data / compute[compute_optional_columns],
@@ -107,7 +107,7 @@ data.preview <- function(
 
   # Path + preprocess FALSE: raw read, no options
   if (is.character(data) && length(data) == 1L && isFALSE(preprocess)) {
-    df <- read_data_raw(data)
+    df <- read_data(data)
     view_if_available(df, title = paste0("Preview: ", basename(data)))
     return(invisible(NULL))
   }

--- a/R/globals.R
+++ b/R/globals.R
@@ -81,7 +81,6 @@ utils::globalVariables(c(
   "prompt_save_preference",
   "read",
   "read_data",
-  "read_data_raw",
   "read_options_file",
   "read_template",
   "reset_config_overrides",

--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -7,7 +7,13 @@ CONST <- list(
   PACKAGE_NAME = PACKAGE_NAME,
   PACKAGE_NAME_VERBOSE = PACKAGE_NAME_VERBOSE,
   DATA = list(
-    # A list of recognized data (meaning data frame) types
+    # A list of recognized data (meaning data frame) types.
+    # All formats go through one read dispatch (read_by_type) and one shared
+    # post-read normalization (normalize_read_df: NA-string replacement,
+    # whitespace-to-NA, and type coercion). Text formats (csv, tsv, and Excel,
+    # which is read as text) are fully coerced from strings. json must flatten
+    # to a tabular record set or a clear error is raised. dta and rds keep the
+    # types their native readers return and pass through NA normalization only.
     TYPES = c("csv", "tsv", "xlsx", "xls", "xlsm", "json", "dta", "rds"),
     # Strings that should be interpreted as NA when reading data files
     NA_STRINGS = c("", "NA", "N/A", "na", "n/a", "NULL", "null")

--- a/inst/artma/data/normalize.R
+++ b/inst/artma/data/normalize.R
@@ -1,0 +1,76 @@
+#' @title Replace NA-strings with NA
+#' @description Replace values listed in \code{CONST$DATA$NA_STRINGS} with a real
+#'   \code{NA} across every character (and character-coercible factor) column.
+#'   Numeric and logical columns produced by native readers are left untouched.
+#' @param df *\[data.frame\]* The data frame to normalize
+#' @return *\[data.frame\]* The data frame with NA-strings replaced by NA
+#' @keywords internal
+replace_na_strings <- function(df) {
+  box::use(artma / const[CONST])
+
+  na_strings <- CONST$DATA$NA_STRINGS
+  for (col in colnames(df)) {
+    x <- df[[col]]
+    if (is.character(x)) {
+      x[x %in% na_strings] <- NA_character_
+      df[[col]] <- x
+    } else if (is.factor(x)) {
+      if (any(levels(x) %in% na_strings)) {
+        x <- as.character(x)
+        x[x %in% na_strings] <- NA_character_
+        df[[col]] <- x
+      }
+    }
+  }
+  df
+}
+
+
+#' @title Coerce character columns to their natural R type
+#' @description Convert text columns (as read from a file) to logical, integer,
+#'   or numeric when every non-NA value is consistent with that type. This uses
+#'   \code{utils::type.convert}, the same inference base R applies to CSV
+#'   columns, so a value like \code{"1.5"} becomes numeric and \code{"TRUE"}
+#'   becomes logical regardless of the source format. The resulting types feed
+#'   the \code{determine_vector_type} classification used downstream when
+#'   building the data config. NA-string and whitespace normalization must run
+#'   first so blanks do not block coercion. Columns that are not uniformly
+#'   coercible stay character.
+#' @param df *\[data.frame\]* The data frame whose character columns to coerce
+#' @return *\[data.frame\]* The data frame with columns coerced to natural types
+#' @keywords internal
+coerce_df_columns <- function(df) {
+  for (col in colnames(df)) {
+    x <- df[[col]]
+    if (is.character(x) && any(!is.na(x))) {
+      df[[col]] <- utils::type.convert(x, as.is = TRUE)
+    }
+  }
+  df
+}
+
+
+#' @title Normalize a freshly read data frame
+#' @description Shared post-read normalization applied to every input format:
+#'   replace NA-strings with NA, convert whitespace-only strings to NA, and
+#'   coerce character columns to their natural R type. Running this for all
+#'   formats guarantees that, for example, \code{"NA"} becomes \code{NA} whether
+#'   the file was CSV, Excel, JSON, Stata, or RDS.
+#' @param df *\[data.frame\]* The freshly read data frame
+#' @return *\[data.frame\]* The normalized data frame
+#' @keywords internal
+normalize_read_df <- function(df) {
+  box::use(artma / data / smart_detection[normalize_whitespace_to_na])
+
+  df |>
+    replace_na_strings() |>
+    normalize_whitespace_to_na() |>
+    coerce_df_columns()
+}
+
+
+box::export(
+  replace_na_strings,
+  coerce_df_columns,
+  normalize_read_df
+)

--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -14,39 +14,40 @@ box::use(
 #' @return *\[data.frame\]* The data frame with the empty rows removed
 #' @keywords internal
 remove_empty_rows <- function(df) {
-  box::use(
-    artma / libs / core / utils[get_verbosity],
-    artma / libs / infrastructure / polyfills[map_lgl]
-  )
+  box::use(artma / libs / core / utils[get_verbosity])
 
   if (get_verbosity() >= 4) {
     cli::cli_inform("Removing empty rows...")
   }
 
   required_colnames <- get_required_colnames()
+  required_colnames <- required_colnames[required_colnames %in% colnames(df)]
 
   # Critical required columns that must be present for a row to be valid
   # n_obs can be missing/imputed, but study_id, effect, and se are essential
   critical_cols <- c("study_id", "effect", "se")
   critical_cols <- critical_cols[critical_cols %in% colnames(df)]
 
-  # Remove rows where all required columns are NA
-  all_na_rows <- which(map_lgl(seq_len(nrow(df)), ~ all(is.na(df[., required_colnames, drop = FALSE]))))
-
-  # Also remove rows where all critical columns are missing (even if n_obs has a value)
-  # This catches rows that have n_obs but are missing the essential analysis columns
-  critical_na_rows <- if (length(critical_cols) > 0) {
-    which(map_lgl(seq_len(nrow(df)), ~ all(is.na(df[., critical_cols, drop = FALSE]))))
+  # A row is empty when all required columns are NA, or when all critical
+  # columns are missing (even if n_obs has a value). Both checks are vectorized
+  # with rowSums(is.na(...)) instead of iterating rows.
+  all_required_na <- if (length(required_colnames) > 0) {
+    rowSums(is.na(df[, required_colnames, drop = FALSE])) == length(required_colnames)
   } else {
-    integer(0)
+    rep(FALSE, nrow(df))
   }
 
-  # Combine both sets of rows to remove
-  na_rows <- unique(c(all_na_rows, critical_na_rows))
+  all_critical_na <- if (length(critical_cols) > 0) {
+    rowSums(is.na(df[, critical_cols, drop = FALSE])) == length(critical_cols)
+  } else {
+    rep(FALSE, nrow(df))
+  }
 
-  if (length(na_rows)) {
-    df <- df[-na_rows, ]
-    cli::cli_alert_success("Removed {.val {length(na_rows)}} empty rows.")
+  empty_rows <- all_required_na | all_critical_na
+
+  if (any(empty_rows)) {
+    df <- df[!empty_rows, , drop = FALSE]
+    cli::cli_alert_success("Removed {.val {sum(empty_rows)}} empty rows.")
   }
   df
 }
@@ -256,8 +257,6 @@ preprocess_data <- function(df) {
     remove_empty_rows() |>
     handle_missing_values_with_prompt() |>
     enforce_data_types() |>
-    normalize_whitespace_to_na() |>
-    remove_empty_rows() |>
     winsorize_data() |>
     enforce_correct_values()
 }

--- a/inst/artma/data/read.R
+++ b/inst/artma/data/read.R
@@ -1,272 +1,89 @@
-#' @title Detect column types from text data
-#' @description Analyzes entire columns to determine appropriate R types.
-#' Uses the full column data, not just a sample, for accurate type detection.
-#' @param df *\[data.frame\]* Data frame with all columns as character/text
-#' @return *\[character\]* Vector of R types ("logical", "numeric", "character") for each column
+#' @title Read a data file by type
+#' @description Single dispatch that reads a data file into a raw data frame
+#'   based on its detected type. No normalization or column standardization is
+#'   applied here; callers run \code{normalize_read_df} and
+#'   \code{validate_df_structure} afterwards. Excel files are read entirely as
+#'   text so that column typing happens through the same coercion path as every
+#'   other format (see \code{coerce_df_columns}).
+#' @param path *\[character\]* Path to the data file.
+#' @param type *\[character\]* The data type (file extension) to read as.
+#' @return *\[data.frame\]* The raw data frame with original column names.
 #' @keywords internal
-detect_excel_column_types <- function(df) {
-  box::use(artma / const[CONST])
-
-  n_cols <- ncol(df)
-  types <- character(n_cols)
-
-  for (i in seq_len(n_cols)) {
-    col_data <- df[[i]]
-    col_name <- colnames(df)[i]
-
-    # Remove NA values for analysis
-    non_na <- col_data[!is.na(col_data)]
-
-    # Empty column or all NA
-    if (length(non_na) == 0) {
-      types[i] <- "character"
-      next
-    }
-
-    # Try to detect logical values
-    # Check if all non-NA values are logical-like (TRUE/FALSE, T/F, 1/0, yes/no)
-    logical_patterns <- c("TRUE", "FALSE", "T", "F", "1", "0", "yes", "no", "YES", "NO", "Yes", "No")
-    if (all(non_na %in% logical_patterns) && length(non_na) > 0) {
-      # If all values match logical patterns, treat as logical
-      # This handles columns that are consistently logical throughout
-      types[i] <- "logical"
-      next
-    }
-
-    # Try to coerce to numeric
-    numeric_coerced <- suppressWarnings(as.numeric(non_na))
-    na_after_coercion <- sum(is.na(numeric_coerced))
-    na_before_coercion <- sum(is.na(non_na))
-
-    # If most values can be coerced to numeric, treat as numeric
-    # Allow some non-numeric values (up to 10% or if original had NAs)
-    conversion_rate <- (length(non_na) - na_after_coercion) / length(non_na)
-    if (conversion_rate >= 0.9 || (na_after_coercion == na_before_coercion && length(non_na) > 0)) {
-      types[i] <- "numeric"
-    } else {
-      # Default to character for mixed or non-numeric content
-      types[i] <- "character"
-    }
-  }
-
-  types
-}
-
-#' @title Coerce columns to detected types
-#' @description Safely coerces columns to their detected types, handling NA strings and edge cases.
-#' @param df *\[data.frame\]* Data frame with all columns as character/text
-#' @param types *\[character\]* Vector of R types to coerce to
-#' @return *\[data.frame\]* Data frame with columns coerced to appropriate types
-#' @keywords internal
-coerce_columns_to_types <- function(df, types) {
+read_by_type <- function(path, type) {
   box::use(
-    artma / const[CONST],
-    artma / libs / core / utils[get_verbosity]
+    artma / data / utils[raise_invalid_data_type_error],
+    artma / data / smart_detection[smart_read_csv]
   )
 
-  for (i in seq_len(ncol(df))) {
-    col_name <- colnames(df)[i]
-    target_type <- types[i]
-    col_data <- df[[i]]
-
-    if (target_type == "logical") {
-      # Coerce to logical, handling various representations
-      # First, normalize NA strings
-      na_mask <- col_data %in% CONST$DATA$NA_STRINGS | is.na(col_data)
-
-      # Initialize result vector
-      logical_result <- rep(NA, length(col_data))
-
-      # Convert logical-like strings
-      true_patterns <- c("TRUE", "T", "1", "yes", "YES", "Yes")
-      false_patterns <- c("FALSE", "F", "0", "no", "NO", "No")
-
-      logical_result[col_data %in% true_patterns] <- TRUE
-      logical_result[col_data %in% false_patterns] <- FALSE
-      logical_result[na_mask] <- NA
-
-      df[[i]] <- logical_result
-    } else if (target_type == "numeric") {
-      # Coerce to numeric, handling NA strings
-      na_mask <- col_data %in% CONST$DATA$NA_STRINGS | is.na(col_data)
-      col_data[na_mask] <- NA_character_
-
-      # Convert to numeric, non-coercible values become NA with warning
-      numeric_col <- suppressWarnings(as.numeric(col_data))
-      failed_coercions <- sum(is.na(numeric_col) & !na_mask)
-
-      if (failed_coercions > 0 && get_verbosity() >= 3) {
-        cli::cli_alert_warning(
-          "Column {.val {col_name}}: {failed_coercions} value{?s} could not be coerced to numeric and were set to NA"
-        )
+  df <- switch(type,
+    csv = smart_read_csv(path),
+    tsv = smart_read_csv(path, delim = "\t"),
+    xlsx = ,
+    xls = ,
+    xlsm = {
+      if (!requireNamespace("readxl", quietly = TRUE)) {
+        cli::cli_abort("Package {.pkg readxl} is required to read Excel files. Install with: install.packages('readxl')")
       }
-
-      df[[i]] <- numeric_col
-    } else {
-      # Keep as character, but normalize NA strings
-      na_mask <- col_data %in% CONST$DATA$NA_STRINGS
-      col_data[na_mask] <- NA_character_
-      df[[i]] <- col_data
-    }
-  }
-
-  df
-}
-
-#' @title Read Excel file with consistent NA handling and smart type detection
-#' @description Read Excel files (xlsx, xls, xlsm) with standardized NA string handling.
-#' Uses a two-pass approach: first reads all columns as text, then analyzes entire columns
-#' to determine appropriate types, eliminating type guessing warnings and improving accuracy.
-#' @param path *\[character\]* Path to the Excel file
-#' @return *\[data.frame\]* The data frame with correctly typed columns
-#' @keywords internal
-read_excel_file <- function(path) {
-  box::use(
-    artma / const[CONST],
-    artma / libs / core / utils[get_verbosity]
-  )
-
-  if (!requireNamespace("readxl", quietly = TRUE)) {
-    cli::cli_abort("Package {.pkg readxl} is required to read Excel files. Install with: install.packages('readxl')")
-  }
-
-  if (get_verbosity() >= 4) {
-    cli::cli_inform("Reading Excel file with smart type detection...")
-  }
-
-  # First pass: Read all columns as text to avoid type guessing issues
-  # This ensures we capture all data without warnings, then we'll intelligently determine types
-  df_text <- suppressWarnings(
-    readxl::read_excel(
-      path,
-      col_types = "text", # Read everything as text
-      na = CONST$DATA$NA_STRINGS,
-      trim_ws = TRUE
-    )
-  )
-
-  # Second pass: Detect types from entire columns (not just first 1000 rows)
-  if (get_verbosity() >= 4) {
-    cli::cli_inform("Analyzing column types from full dataset...")
-  }
-  column_types <- detect_excel_column_types(df_text)
-
-  # Third pass: Coerce columns to detected types
-  if (get_verbosity() >= 4) {
-    cli::cli_inform("Coercing columns to detected types...")
-  }
-  df_typed <- coerce_columns_to_types(df_text, column_types)
-
-  df_typed
-}
-
-#' @title Read data
-#' @description Read data from a path. Returns a raw data frame with the
-#'   original column names, validated but not standardized. Column name
-#'   standardization is applied downstream (after schema reconciliation).
-#' @param path *\[str, optional\]* The path to the data source. If NULL, the options data source path is used.
-#' @return *\[data.frame\]* The data frame with original column names.
-read_data <- function(path = NULL) {
-  box::use(
-    artma / data / utils[
-      determine_df_type,
-      raise_invalid_data_type_error
-    ],
-    artma / data / smart_detection[
-      smart_read_csv,
-      validate_df_structure
-    ],
-    artma / libs / core / utils[get_verbosity]
-  )
-
-  path <- if (!is.null(path)) path else getOption("artma.data.source_path")
-
-  if (is.null(path) || !nzchar(path)) {
-    cli::cli_abort("No data source path provided. Please set {.field artma.data.source_path} option.")
-  }
-
-  if (!file.exists(path)) {
-    cli::cli_abort("Data file not found: {.path {path}}")
-  }
-
-  if (get_verbosity() >= 3) {
-    cli::cli_alert_info("Reading data from {.path {path}}")
-  }
-
-  df_type <- determine_df_type(path, should_validate = TRUE)
-
-  # Read based on file type with enhanced handling
-  df <- tryCatch(
-    {
-      switch(df_type,
-        csv = smart_read_csv(path),
-        tsv = smart_read_csv(path, delim = "\t"),
-        xlsx = read_excel_file(path),
-        xls = read_excel_file(path),
-        xlsm = read_excel_file(path),
-        json = {
-          if (!requireNamespace("jsonlite", quietly = TRUE)) {
-            cli::cli_abort("Package {.pkg jsonlite} is required to read JSON files. Install with: install.packages('jsonlite')")
-          }
-          jsonlite::fromJSON(path)
-        },
-        dta = {
-          if (!requireNamespace("haven", quietly = TRUE)) {
-            cli::cli_abort("Package {.pkg haven} is required to read Stata files. Install with: install.packages('haven')")
-          }
-          as.data.frame(haven::read_dta(path))
-        },
-        rds = {
-          obj <- readRDS(path)
-          if (!is.data.frame(obj)) {
-            cli::cli_abort("RDS file does not contain a data frame. Found: {.type {class(obj)}}")
-          }
-          obj
-        },
-        raise_invalid_data_type_error(df_type)
+      # Read every column as text; shared normalization coerces types afterwards.
+      as.data.frame(
+        suppressWarnings(
+          readxl::read_excel(path, col_types = "text", na = character(0), trim_ws = TRUE)
+        ),
+        stringsAsFactors = FALSE
       )
     },
-    error = function(e) {
-      cli::cli_abort(c(
-        "x" = "Failed to read data from {.path {path}}",
-        "i" = "File type: {.val {df_type}}",
-        "i" = "Error: {e$message}"
-      ))
-    }
+    json = {
+      if (!requireNamespace("jsonlite", quietly = TRUE)) {
+        cli::cli_abort("Package {.pkg jsonlite} is required to read JSON files. Install with: install.packages('jsonlite')")
+      }
+      # JSON stays a first-class format but must flatten to a tabular record set.
+      parsed <- jsonlite::fromJSON(path, flatten = TRUE)
+      if (!is.data.frame(parsed)) {
+        cli::cli_abort(c(
+          "x" = "JSON file {.path {path}} did not flatten to a data frame.",
+          "i" = "Provide the data as an array of records (objects with the same fields), for example {.code [{{\"study_id\": 1, \"effect\": 0.5}}]}."
+        ))
+      }
+      parsed
+    },
+    dta = {
+      if (!requireNamespace("haven", quietly = TRUE)) {
+        cli::cli_abort("Package {.pkg haven} is required to read Stata files. Install with: install.packages('haven')")
+      }
+      as.data.frame(haven::read_dta(path))
+    },
+    rds = {
+      obj <- readRDS(path)
+      if (!is.data.frame(obj)) {
+        cli::cli_abort("RDS file does not contain a data frame. Found: {.type {class(obj)}}")
+      }
+      obj
+    },
+    raise_invalid_data_type_error(type)
   )
 
   if (!is.data.frame(df)) {
     cli::cli_abort("Failed to read data from {.path {path}}. Expected a data frame but got {.type {class(df)}}.")
   }
 
-  # Validate and clean structure
-  df <- validate_df_structure(df, path)
-
-  if (get_verbosity() >= 3) {
-    cli::cli_alert_success("Data read successfully: {nrow(df)} rows, {ncol(df)} columns")
-  }
-
   df
 }
 
-#' @title Read data from path without options-dependent standardization
-#' @description Reads a data file using the same type dispatch as read_data but does
-#'   not load options or call standardize_column_names. Used for raw preview when
-#'   preprocess = FALSE.
-#' @param path *\[character\]* Path to the data source (required).
-#' @return *\[data.frame\]* The data frame with validated structure, unchanged column names.
+
+#' @title Read and normalize a data file
+#' @description Read a file through the single \code{read_by_type} dispatch, then
+#'   apply the shared post-read normalization and structural validation. Used by
+#'   both \code{read_data} and the options-file column preprocessing so that both
+#'   paths read a given file identically.
+#' @param path *\[character\]* Path to the data file (required).
+#' @return *\[data.frame\]* The normalized, validated data frame with original
+#'   column names.
 #' @keywords internal
-read_data_raw <- function(path) {
+read_file <- function(path) {
   box::use(
-    artma / data / utils[
-      determine_df_type,
-      raise_invalid_data_type_error
-    ],
-    artma / data / smart_detection[
-      smart_read_csv,
-      validate_df_structure
-    ],
-    artma / libs / core / utils[get_verbosity]
+    artma / data / utils[determine_df_type],
+    artma / data / normalize[normalize_read_df],
+    artma / data / smart_detection[validate_df_structure]
   )
 
   if (is.null(path) || !nzchar(path)) {
@@ -277,42 +94,10 @@ read_data_raw <- function(path) {
     cli::cli_abort("Data file not found: {.path {path}}")
   }
 
-  if (get_verbosity() >= 3) {
-    cli::cli_alert_info("Reading data from {.path {path}} (raw, no standardization)")
-  }
-
   df_type <- determine_df_type(path, should_validate = TRUE)
 
   df <- tryCatch(
-    {
-      switch(df_type,
-        csv = smart_read_csv(path),
-        tsv = smart_read_csv(path, delim = "\t"),
-        xlsx = read_excel_file(path),
-        xls = read_excel_file(path),
-        xlsm = read_excel_file(path),
-        json = {
-          if (!requireNamespace("jsonlite", quietly = TRUE)) {
-            cli::cli_abort("Package {.pkg jsonlite} is required to read JSON files. Install with: install.packages('jsonlite')")
-          }
-          jsonlite::fromJSON(path)
-        },
-        dta = {
-          if (!requireNamespace("haven", quietly = TRUE)) {
-            cli::cli_abort("Package {.pkg haven} is required to read Stata files. Install with: install.packages('haven')")
-          }
-          as.data.frame(haven::read_dta(path))
-        },
-        rds = {
-          obj <- readRDS(path)
-          if (!is.data.frame(obj)) {
-            cli::cli_abort("RDS file does not contain a data frame. Found: {.type {class(obj)}}")
-          }
-          obj
-        },
-        raise_invalid_data_type_error(df_type)
-      )
-    },
+    read_by_type(path, df_type),
     error = function(e) {
       cli::cli_abort(c(
         "x" = "Failed to read data from {.path {path}}",
@@ -322,11 +107,32 @@ read_data_raw <- function(path) {
     }
   )
 
-  if (!is.data.frame(df)) {
-    cli::cli_abort("Failed to read data from {.path {path}}. Expected a data frame but got {.type {class(df)}}.")
+  df <- normalize_read_df(df)
+  validate_df_structure(df, path)
+}
+
+
+#' @title Read data
+#' @description Read data from a path. Returns a raw data frame with the
+#'   original column names, validated and normalized but not standardized.
+#'   Column name standardization is applied downstream (after schema
+#'   reconciliation).
+#' @param path *\[str, optional\]* The path to the data source. If NULL, the options data source path is used.
+#' @return *\[data.frame\]* The data frame with original column names.
+read_data <- function(path = NULL) {
+  box::use(artma / libs / core / utils[get_verbosity])
+
+  path <- if (!is.null(path)) path else getOption("artma.data.source_path")
+
+  if (is.null(path) || !nzchar(path)) {
+    cli::cli_abort("No data source path provided. Please set {.field artma.data.source_path} option.")
   }
 
-  df <- validate_df_structure(df, path)
+  if (get_verbosity() >= 3) {
+    cli::cli_alert_info("Reading data from {.path {path}}")
+  }
+
+  df <- read_file(path)
 
   if (get_verbosity() >= 3) {
     cli::cli_alert_success("Data read successfully: {nrow(df)} rows, {ncol(df)} columns")
@@ -335,4 +141,4 @@ read_data_raw <- function(path) {
   df
 }
 
-box::export(read_data, read_data_raw)
+box::export(read_by_type, read_file, read_data)

--- a/inst/artma/data/smart_detection.R
+++ b/inst/artma/data/smart_detection.R
@@ -47,42 +47,12 @@ detect_delimiter <- function(path, n_lines = 5) {
 }
 
 
-#' @title Detect file encoding
-#' @description Attempt to detect the file encoding
-#' @param path *\[character\]* Path to the file
-#' @return *\[character\]* The detected encoding
-detect_encoding <- function(path) {
-  box::use(artma / libs / core / validation[validate])
-
-  validate(is.character(path), file.exists(path))
-
-  # Try reading with different encodings
-  encodings <- c("UTF-8", "latin1", "ISO-8859-1", "CP1252")
-
-  for (enc in encodings) {
-    test <- tryCatch(
-      {
-        readLines(path, n = 10, encoding = enc, warn = FALSE)
-        enc
-      },
-      error = function(e) NULL
-    )
-    if (!is.null(test)) {
-      return(enc)
-    }
-  }
-
-  "UTF-8" # Fallback
-}
-
-
 #' @title Smart read CSV with auto-detection
-#' @description Read CSV file with automatic delimiter and encoding detection
+#' @description Read CSV file with automatic delimiter detection
 #' @param path *\[character\]* Path to the file
 #' @param delim *\[character, optional\]* Delimiter (auto-detected if NULL)
-#' @param encoding *\[character, optional\]* Encoding (auto-detected if NULL)
 #' @return *\[data.frame\]* The data frame
-smart_read_csv <- function(path, delim = NULL, encoding = NULL) {
+smart_read_csv <- function(path, delim = NULL) {
   box::use(
     artma / const[CONST],
     artma / libs / core / validation[validate],
@@ -98,13 +68,6 @@ smart_read_csv <- function(path, delim = NULL, encoding = NULL) {
     }
   }
 
-  if (is.null(encoding)) {
-    encoding <- detect_encoding(path)
-    if (get_verbosity() >= 4) {
-      cli::cli_inform("Auto-detected encoding: {.val {encoding}}")
-    }
-  }
-
   # Try reading with detected parameters
   df <- tryCatch(
     {
@@ -112,7 +75,6 @@ smart_read_csv <- function(path, delim = NULL, encoding = NULL) {
         path,
         header = TRUE,
         sep = delim,
-        fileEncoding = encoding,
         stringsAsFactors = FALSE,
         na.strings = CONST$DATA$NA_STRINGS,
         strip.white = TRUE,
@@ -240,7 +202,6 @@ validate_df_structure <- function(df, path) {
 
 box::export(
   detect_delimiter,
-  detect_encoding,
   smart_read_csv,
   validate_df_structure,
   normalize_whitespace_to_na

--- a/inst/artma/options/column_preprocessing.R
+++ b/inst/artma/options/column_preprocessing.R
@@ -57,67 +57,15 @@ preprocess_column_mapping <- function(user_input, options_def) {
   tryCatch(
     {
       box::use(
-        artma / data / utils[determine_df_type, raise_invalid_data_type_error],
-        artma / data / smart_detection[smart_read_csv, validate_df_structure],
+        artma / data / read[read_file],
         artma / data / column_recognition[recognize_columns],
         artma / data / interactive_mapping[interactive_column_mapping],
-        artma / const[CONST],
         artma / libs / core / utils[get_verbosity]
       )
 
-      # Read the data based on file type (same logic as read_data but without standardization)
-      df_type <- determine_df_type(data_source_path, should_validate = TRUE)
-
-      # Helper function to read Excel files (inline version of read_excel_file)
-      read_excel_inline <- function(path) {
-        if (!requireNamespace("readxl", quietly = TRUE)) {
-          cli::cli_abort("Package {.pkg readxl} is required to read Excel files. Install with: install.packages('readxl')")
-        }
-        # Read all columns as text first, then we'll handle type detection if needed
-        suppressWarnings(
-          readxl::read_excel(
-            path,
-            col_types = "text",
-            na = CONST$DATA$NA_STRINGS,
-            trim_ws = TRUE
-          )
-        )
-      }
-
-      df <- switch(df_type,
-        csv = smart_read_csv(data_source_path),
-        tsv = smart_read_csv(data_source_path, delim = "\t"),
-        xlsx = read_excel_inline(data_source_path),
-        xls = read_excel_inline(data_source_path),
-        xlsm = read_excel_inline(data_source_path),
-        json = {
-          if (!requireNamespace("jsonlite", quietly = TRUE)) {
-            cli::cli_abort("Package {.pkg jsonlite} is required to read JSON files. Install with: install.packages('jsonlite')")
-          }
-          jsonlite::fromJSON(data_source_path)
-        },
-        dta = {
-          if (!requireNamespace("haven", quietly = TRUE)) {
-            cli::cli_abort("Package {.pkg haven} is required to read Stata files. Install with: install.packages('haven')")
-          }
-          as.data.frame(haven::read_dta(data_source_path))
-        },
-        rds = {
-          obj <- readRDS(data_source_path)
-          if (!is.data.frame(obj)) {
-            cli::cli_abort("RDS file does not contain a data frame. Found: {.type {class(obj)}}")
-          }
-          obj
-        },
-        raise_invalid_data_type_error(df_type)
-      )
-
-      if (!is.data.frame(df)) {
-        cli::cli_abort("Failed to read data from {.path {data_source_path}}. Expected a data frame but got {.type {class(df)}}.")
-      }
-
-      # Validate and clean structure (but don't standardize column names yet)
-      df <- validate_df_structure(df, data_source_path)
+      # Read through the same dispatch and normalization as read_data, without
+      # standardizing column names yet.
+      df <- read_file(data_source_path)
 
       # Recognize columns
       auto_mapping <- recognize_columns(df, min_confidence = 0.7)

--- a/tests/testthat/test-data-preview.R
+++ b/tests/testthat/test-data-preview.R
@@ -85,8 +85,8 @@ test_that("data.preview with path and preprocess FALSE uses raw read (no options
   expect_null(artma::data.preview(tmp_csv, preprocess = FALSE))
 })
 
-test_that("read_data_raw returns data frame without standardizing column names", {
-  box::use(artma / data / read[read_data_raw])
+test_that("read_data returns data frame without standardizing column names", {
+  box::use(artma / data / read[read_data])
 
   withr::local_options(list(artma.verbose = 0))
 
@@ -102,7 +102,7 @@ test_that("read_data_raw returns data frame without standardizing column names",
     row.names = FALSE
   )
 
-  df <- read_data_raw(tmp_csv)
+  df <- read_data(tmp_csv)
 
   expect_true(is.data.frame(df))
   expect_true("MyStudy" %in% names(df))

--- a/tests/testthat/test-data-read.R
+++ b/tests/testthat/test-data-read.R
@@ -1,0 +1,111 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_true,
+    skip_if_not_installed,
+    test_that
+  ]
+)
+
+box::use(
+  artma / data / read[read_by_type, read_file, read_data],
+  artma / data / normalize[normalize_read_df]
+)
+
+# A canonical all-text data frame standing in for the raw output of any reader.
+# Every input format should normalize to the same typed result:
+#   - "N/A", "null", "NA" become NA (CONST$DATA$NA_STRINGS)
+#   - whitespace-only becomes NA
+#   - numeric text is coerced to numeric, identifier text stays character
+raw_text_df <- function() {
+  data.frame(
+    study_id = c("S1", "S2", "S3"),
+    effect = c("1.5", "N/A", "2.5"),
+    se = c("0.1", "0.2", "null"),
+    note = c("ok", "NA", "  "),
+    stringsAsFactors = FALSE
+  )
+}
+
+expect_canonical <- function(df) {
+  expect_equal(df$study_id, c("S1", "S2", "S3"))
+  expect_equal(df$effect, c(1.5, NA, 2.5))
+  expect_equal(df$se, c(0.1, 0.2, NA))
+  expect_equal(df$note, c("ok", NA, NA))
+}
+
+
+test_that("normalize_read_df replaces NA-strings, whitespace, and coerces types", {
+  out <- normalize_read_df(raw_text_df())
+  expect_canonical(out)
+})
+
+
+test_that("read_file normalizes a CSV identically to the canonical result", {
+  withr::local_options(list(artma.verbose = 0))
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(raw_text_df(), tmp, row.names = FALSE)
+
+  expect_canonical(read_file(tmp))
+})
+
+
+test_that("read_file normalizes an RDS identically to the canonical result", {
+  withr::local_options(list(artma.verbose = 0))
+  tmp <- withr::local_tempfile(fileext = ".rds")
+  saveRDS(raw_text_df(), tmp)
+
+  expect_canonical(read_file(tmp))
+})
+
+
+test_that("read_file normalizes an Excel file identically to the canonical result", {
+  skip_if_not_installed("writexl")
+  skip_if_not_installed("readxl")
+  withr::local_options(list(artma.verbose = 0))
+  tmp <- withr::local_tempfile(fileext = ".xlsx")
+  writexl::write_xlsx(raw_text_df(), tmp)
+
+  expect_canonical(read_file(tmp))
+})
+
+
+test_that("read_file normalizes a JSON file identically to the canonical result", {
+  skip_if_not_installed("jsonlite")
+  withr::local_options(list(artma.verbose = 0))
+  tmp <- withr::local_tempfile(fileext = ".json")
+  jsonlite::write_json(raw_text_df(), tmp)
+
+  expect_canonical(read_file(tmp))
+})
+
+
+test_that("read_file normalizes a Stata file identically to the canonical result", {
+  skip_if_not_installed("haven")
+  withr::local_options(list(artma.verbose = 0))
+  tmp <- withr::local_tempfile(fileext = ".dta")
+  haven::write_dta(raw_text_df(), tmp)
+
+  expect_canonical(read_file(tmp))
+})
+
+
+test_that("read_by_type errors clearly when JSON does not flatten to a data frame", {
+  skip_if_not_installed("jsonlite")
+  tmp <- withr::local_tempfile(fileext = ".json")
+  jsonlite::write_json(list(a = list(1, 2), b = "x"), tmp, auto_unbox = TRUE)
+
+  expect_error(read_by_type(tmp, "json"), "did not flatten to a data frame")
+})
+
+
+test_that("read_data and the shared read_file read a file identically", {
+  # Guards against the two call sites (read_data and the options-file column
+  # preprocessing, which both go through read_file) diverging again.
+  withr::local_options(list(artma.verbose = 0))
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(raw_text_df(), tmp, row.names = FALSE)
+
+  expect_equal(read_data(tmp), read_file(tmp))
+})

--- a/tests/testthat/test-data-smart-detection.R
+++ b/tests/testthat/test-data-smart-detection.R
@@ -11,7 +11,6 @@ box::use(
 box::use(
   artma / data / smart_detection[
     detect_delimiter,
-    detect_encoding,
     smart_read_csv,
     validate_df_structure
   ]
@@ -106,16 +105,6 @@ test_that("detect_delimiter handles inconsistent delimiters by choosing most con
 
   delim <- detect_delimiter(tmp_file)
   expect_equal(delim, ";")
-})
-
-
-test_that("detect_encoding returns valid encoding", {
-  tmp_file <- tempfile(fileext = ".csv")
-  writeLines("test,data", tmp_file)
-  on.exit(unlink(tmp_file))
-
-  encoding <- detect_encoding(tmp_file)
-  expect_true(encoding %in% c("UTF-8", "latin1", "ISO-8859-1", "CP1252"))
 })
 
 


### PR DESCRIPTION
Closes #162.

## What changed

File reading was implemented three times and Excel had a bespoke type-inference engine that disagreed with CSV typing. This consolidates everything into one read dispatch and one shared normalization path.

- Extracted `read_by_type(path, type)`: a single format dispatch, wrapped by `read_file(path)` (read + normalize + validate). Both `read_data` and the options-file column preprocessing now go through `read_file`, so they read a given file identically.
- Deleted `read_data_raw` (folded into `read_data`) and the inlined `read_excel_inline` copy in `column_preprocessing.R`.
- Added `inst/artma/data/normalize.R` with `normalize_read_df`: NA-string replacement (`CONST$DATA$NA_STRINGS`), whitespace-to-NA, and type coercion. Every format runs through it, so `"NA"`, `"N/A"`, `"null"` become `NA` whether the source is CSV, Excel, JSON, Stata, or RDS.
- Excel is now read as text and typed through the shared coercion (base `type.convert`, matching how CSV columns get typed). Removed `detect_excel_column_types`, `coerce_columns_to_types`, and `read_excel_file`.
- JSON stays first-class but must flatten to a tabular record set (`fromJSON(flatten = TRUE)`); otherwise a clear error explains the expected shape. `dta`/`rds` keep their native reader types and pass through NA normalization. Documented next to `CONST$DATA$TYPES`.
- Deleted `detect_encoding` (it near-always returned UTF-8); no dependency added to replace it.
- Vectorized `remove_empty_rows` with `rowSums(is.na(...))` and reduced `preprocess_data` to a single normalize/remove pass.
- Added `haven`, `jsonlite`, `readxl`, `writexl` to Suggests (used by the read dispatch and the new fixture tests).

## Tests

New `test-data-read.R` writes a fixture per format (CSV, RDS, Excel, JSON, Stata) from one canonical text data frame and asserts identical normalization, plus a regression test that `read_data` and `read_file` read a file identically, and that malformed JSON errors clearly.

`make test` and `make lint` pass. `make check` is clean apart from two environmental items (a clang header warning from compiling the Rcpp code and the `.git` worktree note).

## Coordination

Touches `remove_empty_rows` in `preprocess.R`, which #163 also edits. Whoever merges second should rebase and keep both the vectorization here and the shared `critical_cols` constant from #163.
