### PR TITLE
refactor: single source of truth for required, reserved, and computed columns

### DIFF
--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -10,7 +10,11 @@ CONST <- list(
     # A list of recognized data (meaning data frame) types
     TYPES = c("csv", "tsv", "xlsx", "xls", "xlsm", "json", "dta", "rds"),
     # Strings that should be interpreted as NA when reading data files
-    NA_STRINGS = c("", "NA", "N/A", "na", "n/a", "NULL", "null")
+    NA_STRINGS = c("", "NA", "N/A", "na", "n/a", "NULL", "null"),
+    # Standard column names derived or computed by the data pipeline (never
+    # user moderator variables). Required column names are a separate,
+    # template-derived set; see `get_required_colnames()` in `data/utils.R`.
+    COMPUTED_COLNAMES = c("obs_id", "study_label", "t_stat", "study_size", "reg_dof", "precision")
   ),
   DATE_FORMAT = "%Y-%m-%d %H:%M:%S",
   DATE_ONLY_FORMAT = "%Y-%m-%d",
@@ -60,14 +64,14 @@ CONST <- list(
       "Var Name", "Var Class", "Mean", "Median",
       "Min", "Max", "SD", "Obs", "Missing obs"
     ),
-    DESIRED_VARS = c("effect", "se", "sample_size", "dof")
+    DESIRED_VARS = c("effect", "se", "n_obs", "reg_dof")
   ),
   EFFECT_SUMMARY_STATS = list(
     NAMES = c(
       "Var Name", "Var Class", "Mean", "CI lower", "CI upper", "Weighted Mean",
       "WM CI lower", "WM CI upper", "Median", "Min", "Max", "SD", "Obs"
     ),
-    DESIRED_VARS = c("effect", "se", "sample_size", "dof")
+    DESIRED_VARS = c("effect", "se", "n_obs", "reg_dof")
   ),
   MOCKS = list(
     TMP_DATA_FILE_NAME = "tmp_data.csv",

--- a/inst/artma/data/column_recognition.R
+++ b/inst/artma/data/column_recognition.R
@@ -615,10 +615,12 @@ recognize_columns <- function(df, min_confidence = 0.7) {
 
 
 #' @title Get required column names for artma
-#' @description Returns the list of required column names for artma to function
+#' @description Returns the list of required column names for artma to function.
+#'   Delegates to the template-derived single source of truth.
 #' @return *\[character\]* Vector of required column names
 get_required_column_names <- function() {
-  c("study_id", "effect", "se", "n_obs")
+  box::use(artma / data / utils[get_required_colnames])
+  get_required_colnames()
 }
 
 

--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -25,9 +25,10 @@ remove_empty_rows <- function(df) {
 
   required_colnames <- get_required_colnames()
 
-  # Critical required columns that must be present for a row to be valid
-  # n_obs can be missing/imputed, but study_id, effect, and se are essential
-  critical_cols <- c("study_id", "effect", "se")
+  # Critical required columns that must be present for a row to be valid.
+  # n_obs is deliberately excluded: it can be missing/imputed downstream,
+  # while the remaining required columns (study_id, effect, se) are essential.
+  critical_cols <- setdiff(required_colnames, "n_obs")
   critical_cols <- critical_cols[critical_cols %in% colnames(df)]
 
   # Remove rows where all required columns are NA

--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -27,6 +27,17 @@ get_required_colnames <- function() {
   get_standardized_colnames(filter_fn = ~ !isTRUE(.x$allow_na))
 }
 
+#' @title Get reserved column names
+#' @description Get the full set of standard column names produced by the
+#'   data pipeline: required input columns plus columns computed downstream
+#'   (e.g. `obs_id`, `reg_dof`, `precision`). These are never valid moderator
+#'   variables and must be excluded from variable detection and suggestion.
+#' @return *\[character\]* A vector of reserved column names.
+get_reserved_colnames <- function() {
+  box::use(artma / const[CONST])
+  union(get_required_colnames(), CONST$DATA$COMPUTED_COLNAMES)
+}
+
 #' Get the number of studies in an analysis data frame.
 #'
 #' @param df *\[data.frame\]* The analysis data frame.
@@ -230,6 +241,7 @@ box::export(
   determine_vector_type,
   get_number_of_studies,
   get_required_colnames,
+  get_reserved_colnames,
   get_standardized_colnames,
   raise_invalid_data_type_error,
   standardize_column_names

--- a/inst/artma/data_config/defaults.R
+++ b/inst/artma/data_config/defaults.R
@@ -28,24 +28,21 @@ build_default_config_entry <- function(col_name, col_data) {
     }
   )
 
-  list(
-    "var_name" = col_name,
-    "var_name_verbose" = col_name_verbose,
-    "var_name_description" = col_name_verbose,
-    "data_type" = col_data_type,
-    "group_category" = NA,
-    "variable_summary" = is.numeric(col_data),
-    "effect_sum_stats" = NA,
-    "equal" = NA,
-    "gltl" = NA,
-    "bma" = NA,
-    "bma_reference_var" = NA,
-    "bma_to_log" = NA,
-    "bpe" = NA,
-    "bpe_sum_stats" = NA,
-    "bpe_equal" = NA,
-    "bpe_gltl" = NA
+  # Fields with a non-NA default; every other key in CONST$DATA_CONFIG$KEYS
+  # is filled in as NA below, so adding a new key there is the only edit
+  # needed to keep a config entry in sync.
+  overrides <- list(
+    var_name = col_name,
+    var_name_verbose = col_name_verbose,
+    var_name_description = col_name_verbose,
+    data_type = col_data_type,
+    variable_summary = is.numeric(col_data)
   )
+
+  keys <- unlist(CONST$DATA_CONFIG$KEYS, use.names = FALSE)
+  entry <- stats::setNames(as.list(rep(NA, length(keys))), keys)
+  entry[names(overrides)] <- overrides
+  entry
 }
 
 #' @title Build Base Config

--- a/inst/artma/interactive/effect_summary_stats.R
+++ b/inst/artma/interactive/effect_summary_stats.R
@@ -311,7 +311,8 @@ auto_select_effect_summary_vars <- function(df, config) {
 manual_select_effect_summary_vars <- function(df, config) {
   box::use(
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / autonomy[should_prompt_user]
+    artma / libs / core / autonomy[should_prompt_user],
+    artma / data / utils[get_reserved_colnames]
   )
 
   if (!should_prompt_user(required_level = 4)) {
@@ -330,8 +331,7 @@ manual_select_effect_summary_vars <- function(df, config) {
   }
 
   # Get potential variables (exclude reserved columns)
-  reserved_vars <- c("effect", "se", "study_id", "study_label", "study_size", "sample_size", "dof")
-  potential_vars <- names(config)[!names(config) %in% reserved_vars]
+  potential_vars <- names(config)[!names(config) %in% get_reserved_colnames()]
 
   # Filter to numeric/integer variables that exist in the data
   valid_vars <- character(0)

--- a/inst/artma/methods/box_plot.R
+++ b/inst/artma/methods/box_plot.R
@@ -149,12 +149,11 @@ resolve_factor_by <- function(df, config, factor_by_option) {
 #' @return *\[character\]* Vector of candidate variable names
 #' @keywords internal
 detect_factor_candidates <- function(df, config) {
+  box::use(artma / data / utils[get_reserved_colnames])
+
   # For box plots, include study identifiers as candidates (unlike other methods),
   # but exclude numeric identifiers and computed columns
-  excluded_names <- c(
-    "effect", "se", "t_stat", "study_size",
-    "n_obs", "sample_size", "dof", "reg_dof", "precision", "obs_id"
-  )
+  excluded_names <- setdiff(get_reserved_colnames(), c("study_id", "study_label"))
 
   var_names <- setdiff(names(df), excluded_names)
 

--- a/inst/artma/variable/detection.R
+++ b/inst/artma/variable/detection.R
@@ -29,17 +29,14 @@
 #' @export
 detect_variable_groups <- function(df, var_names = NULL, config = NULL) {
   box::use(
-    artma / const[CONST],
+    artma / data / utils[get_reserved_colnames],
     artma / libs / core / validation[validate]
   )
 
   validate(is.data.frame(df))
 
-  # Reserved column names that should not be grouped
-  reserved_names <- c("effect", "se", "study_id", "study_label", "study_size", "sample_size", "dof")
-
   if (is.null(var_names)) {
-    var_names <- setdiff(names(df), reserved_names)
+    var_names <- setdiff(names(df), get_reserved_colnames())
   }
 
   if (!length(var_names)) {

--- a/inst/artma/variable/suggestion.R
+++ b/inst/artma/variable/suggestion.R
@@ -44,7 +44,7 @@ suggest_variables_for_effect_summary <- function(df, config = NULL,
   box::use(
     artma / variable / detection[detect_variable_groups],
     artma / libs / core / validation[validate, assert],
-    artma / data / utils[determine_vector_type],
+    artma / data / utils[determine_vector_type, get_reserved_colnames],
     artma / const[CONST]
   )
 
@@ -64,7 +64,7 @@ suggest_variables_for_effect_summary <- function(df, config = NULL,
   groups <- detect_variable_groups(df, config = config)
 
   # Reserved columns that should never be suggested
-  reserved <- c("effect", "se", "study_id", "study_label", "study_size", "sample_size", "dof")
+  reserved <- get_reserved_colnames()
 
   results <- list()
 

--- a/tests/testthat/test-data-compute.R
+++ b/tests/testthat/test-data-compute.R
@@ -3,7 +3,8 @@ box::use(
 )
 
 box::use(
-  artma / data / compute[compute_optional_columns]
+  artma / data / compute[compute_optional_columns],
+  artma / data / utils[get_reserved_colnames]
 )
 
 computed_config_overrides <- list(
@@ -66,4 +67,29 @@ test_that("compute_optional_columns overwrites conflicting existing study_label"
 
   expect_equal(result$study_label, c("Study A", "Study B", "Study A"))
   expect_equal(result$study_id, c(1L, 2L, 1L))
+})
+
+
+test_that("get_reserved_colnames covers every column compute_optional_columns can add", {
+  df <- data.frame(
+    study_id = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)"),
+    effect = c(0.2, 0.5, 0.1),
+    se = c(0.1, 0.2, 0.1),
+    n_obs = c(120, 150, 120),
+    stringsAsFactors = FALSE
+  )
+
+  withr::local_options(list(
+    "artma.data.config" = computed_config_overrides,
+    "artma.output.save_results" = FALSE,
+    "artma.calc.precision_type" = "1/SE",
+    "artma.verbose" = 1
+  ))
+
+  cols_before <- names(df)
+  result <- compute_optional_columns(df)
+  cols_added <- setdiff(names(result), cols_before)
+
+  expect_true(length(cols_added) > 0)
+  expect_true(all(cols_added %in% get_reserved_colnames()))
 })

--- a/tests/testthat/test-variable-suggestion.R
+++ b/tests/testthat/test-variable-suggestion.R
@@ -22,7 +22,8 @@ box::use(
   artma / variable / suggestion[
     suggest_variables_for_effect_summary,
     decide_variable_suggestion
-  ]
+  ],
+  artma / data / utils[get_reserved_colnames]
 )
 
 # Test data generators --------------------------------------------------------
@@ -249,8 +250,27 @@ test_that("detect_variable_groups excludes reserved columns", {
 
   result <- detect_variable_groups(df)
 
-  reserved <- c("effect", "se", "study_id", "study_label", "study_size", "sample_size", "dof")
+  # "sample_size" here is a regular user moderator column (see make_test_data),
+  # not the pre-standardization alias for n_obs, so it must NOT be excluded.
+  expect_true("sample_size" %in% result$var_name)
+
+  reserved <- c("effect", "se", "study_id", "study_label", "study_size")
   expect_false(any(result$var_name %in% reserved))
+})
+
+test_that("detect_variable_groups excludes computed pipeline columns", {
+  df <- make_test_data()
+  df$n_obs <- df$study_size
+  df$obs_id <- seq_len(nrow(df))
+  df$t_stat <- df$effect / df$se
+  df$reg_dof <- df$n_obs - 2
+  df$precision <- 1 / df$se
+
+  result <- detect_variable_groups(df)
+
+  computed_cols <- c("n_obs", "obs_id", "t_stat", "reg_dof", "precision")
+  expect_false(any(result$var_name %in% computed_cols))
+  expect_true(all(computed_cols %in% get_reserved_colnames()))
 })
 
 test_that("detect_variable_groups assigns singleton group_type to ungrouped vars", {
@@ -608,6 +628,20 @@ test_that("suggest_variables_for_effect_summary requires effect column", {
     suggest_variables_for_effect_summary(df),
     "effect"
   )
+})
+
+test_that("suggest_variables_for_effect_summary never suggests computed columns as moderators", {
+  df <- make_test_data()
+  df$n_obs <- df$study_size
+  df$obs_id <- seq_len(nrow(df))
+  df$t_stat <- df$effect / df$se
+  df$reg_dof <- df$n_obs - 2
+  df$precision <- 1 / df$se
+
+  result <- suggest_variables_for_effect_summary(df)
+
+  computed_cols <- c("n_obs", "obs_id", "t_stat", "reg_dof", "precision")
+  expect_false(any(computed_cols %in% result$var_name))
 })
 
 test_that("suggest_variables_for_effect_summary uses config when provided", {


### PR DESCRIPTION
## Summary

Centralizes column-name authority for the data pipeline in one place, replacing three unsynchronized definitions of "required columns" and a stale "reserved" name list.

- `CONST$DATA$COMPUTED_COLNAMES` (inst/artma/const.R) is now the single list of columns computed downstream by the pipeline (obs_id, study_label, t_stat, study_size, reg_dof, precision).
- `get_reserved_colnames()` (inst/artma/data/utils.R) unions the template-derived required columns (`get_required_colnames()`) with the computed columns above. This is the new authoritative "never a moderator variable" set.
- `get_required_column_names()` in column_recognition.R now delegates to `get_required_colnames()` instead of hardcoding a second copy.
- `remove_empty_rows()` in preprocess.R derives its critical-columns set as `setdiff(required_colnames, "n_obs")` instead of a separate hardcoded vector, with the n_obs exclusion documented.
- variable/detection.R, variable/suggestion.R, methods/box_plot.R, and interactive/effect_summary_stats.R all now call `get_reserved_colnames()` instead of hardcoding their own reserved-name vectors. Two of these (box_plot.R, effect_summary_stats.R) had the same stale-name bug but weren't listed in the issue; found via a repo-wide grep for the pattern.
- Fixed stale names `sample_size` / `dof` (which never exist post-standardization) to `n_obs` / `reg_dof` everywhere, including `CONST$VARIABLE_SUMMARY_STATS$DESIRED_VARS` and `CONST$EFFECT_SUMMARY_STATS$DESIRED_VARS`.
- `build_default_config_entry()` in data_config/defaults.R is now generated from `CONST$DATA_CONFIG$KEYS` plus a small defaults map, instead of hand-listing all 16 fields. `parse.R` already validated against `CONST$DATA_CONFIG$KEYS`, so this closes the loop.

Adding a new data-config field now requires touching exactly one place: add the key to `CONST$DATA_CONFIG$KEYS` in const.R. `build_default_config_entry` picks it up automatically (defaulting to NA unless given an explicit override), and `parse.R`'s validation already checks against the same list.

## Tests

- New invariant test: `get_reserved_colnames()` covers every column `compute_optional_columns()` can add (tests/testthat/test-data-compute.R).
- New tests confirming computed columns (e.g. `precision`, `obs_id`, `reg_dof`, `t_stat`, `n_obs`) are never suggested or grouped as moderator variables (tests/testthat/test-variable-suggestion.R).
- Fixed an existing test that had baked in the stale-name bug: a column literally named `sample_size` (a coincidental user moderator name in the test fixture, not the pre-standardization alias) was being incorrectly excluded; the test now asserts it is treated as a regular variable.

## Test plan

- [x] `make test` passes (0 failures)
- [x] `LC_ALL=en_US.UTF-8 make lint` passes with no lints
- [x] `make check` passes with 0 errors (the 1 warning / 1 note are pre-existing on master, unrelated to this change: a macOS clang compiler flag warning and a `.git`-present NOTE, verified via a clean checkout of master)
- [x] `grep` confirms no remaining hardcoded duplicates of the required/reserved column lists
