### PR TITLE
refactor: shared method registration and a standard return contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,15 +79,40 @@ Because `box::use()` imports are invisible to R CMD check, every symbol imported
 
 Runtime methods are the main analytical functions users invoke via `artma::artma(methods = c("method_name"))`.
 
-Each method is defined in `inst/artma/methods/<method_name>.R` and **must** export a `run` function with this signature:
+Each method is defined in `inst/artma/methods/<method_name>.R`. The implementation is a plain function taking `(df, ...)`; the exported `run` wrapper is produced by `register_runtime_method()`, which adds the shared caching layer:
 
 ```r
-run <- function(df, ...) {
+box::use(
+  artma / modules / runtime_methods[new_method_result, register_runtime_method]
+)
+
+my_method <- function(df, ...) {
   # Implementation
+  new_method_result(
+    tables = list(summary = summary_df),
+    plots = list(),
+    meta = list()
+  )
 }
+
+run <- register_runtime_method(my_method, stage = "my_method")
+
+box::export(my_method, run)
 ```
 
+`register_runtime_method(impl, stage, ...)` (in `inst/artma/modules/runtime_methods.R`) replaces the old hand-written `cache_cli_runner` trailer; `stage` conventionally matches the implementation name. Export `run` plus the implementation (tests import it); do not export other internals unless another module genuinely reuses them.
+
 The `df` parameter is the preprocessed data frame; additional arguments come from the options system.
+
+#### Standard return contract
+
+Every method returns the value built by `new_method_result()`, a list with three slots:
+
+- `tables`: named list of `data.frame`s to export as CSV. The exporter (`export_method_result` in `inst/artma/output/export.R`) walks this list generically. Keys `summary`/`coefficients`/`table` (or a key equal to the method name) export as `<method>.csv`; any other key exports as `<method>_<key>.csv` (for example the `caliper`/`elliott`/`maive` sub-tables of `p_hacking_tests`).
+- `plots`: named list of plot objects (for example `ggplot`s) for programmatic access and printing. Graphics files are still written by each method during execution, not by the exporter.
+- `meta`: named list of anything else downstream consumers need, such as the BMA model, fit params, skip reasons, or auxiliary frames. For example `bma`/`fma` put their model/data/var_list under `meta`, and the MA table builder and `best_practice_estimate` read them from there.
+
+Methods that ship a custom print method (`box_plot`, `funnel_plot`, `t_stat_histogram`) pass `class =` to `new_method_result()` and read their fields from `meta`/`plots` in `R/print.R`.
 
 Methods are auto-discovered at runtime by scanning `inst/artma/methods/`. Use `artma::methods.list()` to see available methods.
 

--- a/R/artma.R
+++ b/R/artma.R
@@ -360,17 +360,22 @@ invoke_runtime_methods <- function(methods, df, modules_dir = NULL, ...) {
     }
   }
 
-  # Build unified MA table when BMA and/or FMA have produced results
-  bma_result <- results[["bma"]]
-  fma_result <- results[["fma"]]
+  # Build unified MA table when BMA and/or FMA have produced results. Both
+  # methods return the standard contract, so the coefficient frame lives in
+  # `tables$coefficients` and skip reasons under `meta$skipped`.
+  extract_ma_coefficients <- function(result) {
+    if (is.null(result) || !is.null(result$meta$skipped)) {
+      return(NULL)
+    }
+    coefs <- result$tables$coefficients
+    if (is.null(coefs) || !is.data.frame(coefs) || nrow(coefs) == 0) {
+      return(NULL)
+    }
+    coefs
+  }
 
-  has_bma <- !is.null(bma_result) && is.null(bma_result$skipped) &&
-    !is.null(bma_result$coefficients) && nrow(bma_result$coefficients) > 0
-  has_fma <- !is.null(fma_result) && is.null(fma_result$skipped) &&
-    !is.null(fma_result$coefficients) && nrow(fma_result$coefficients) > 0
-
-  bma_coefs <- if (has_bma) bma_result$coefficients
-  fma_coefs <- if (has_fma) fma_result$coefficients
+  bma_coefs <- extract_ma_coefficients(results[["bma"]])
+  fma_coefs <- extract_ma_coefficients(results[["fma"]])
 
   if (!is.null(bma_coefs) || !is.null(fma_coefs)) {
     box::use(artma / output / ma_table[build_ma_table, display_ma_table])
@@ -384,7 +389,11 @@ invoke_runtime_methods <- function(methods, df, modules_dir = NULL, ...) {
 
     if (!is.null(ma_table)) {
       display_ma_table(ma_table, verbosity = get_verbosity())
-      results[["ma_table"]] <- list(summary = ma_table)
+      results[["ma_table"]] <- list(
+        tables = list(summary = ma_table),
+        plots = list(),
+        meta = list()
+      )
     }
   }
 

--- a/R/print.R
+++ b/R/print.R
@@ -9,7 +9,7 @@ print.artma_box_plot <- function(x, ...) {
   plot_word <- if (n_plots == 1) "plot" else "plots"
 
   cli::cli_text(
-    "<box_plot result: {n_plots} {plot_word}, {x$n_groups} groups, grouped by {.field {x$factor_by}}>"
+    "<box_plot result: {n_plots} {plot_word}, {x$meta$n_groups} groups, grouped by {.field {x$meta$factor_by}}>"
   )
   cli::cli_text("Access plots via {.code $plots[[1]]}, {.code $plots[[2]]}, etc.")
 
@@ -24,12 +24,12 @@ print.artma_box_plot <- function(x, ...) {
 #' @return x invisibly
 #' @export
 print.artma_funnel_plot <- function(x, ...) {
-  median_info <- if (x$used_study_medians) " (study medians)" else ""
+  median_info <- if (isTRUE(x$meta$used_study_medians)) " (study medians)" else ""
 
   cli::cli_text(
-    "<funnel_plot result: {x$n_points} points{median_info}, {x$n_outliers_removed} outliers removed>"
+    "<funnel_plot result: {x$meta$n_points} points{median_info}, {x$meta$n_outliers_removed} outliers removed>"
   )
-  cli::cli_text("Access plot via {.code $plot}")
+  cli::cli_text("Access plot via {.code $plots$funnel_plot}")
 
   invisible(x)
 }
@@ -42,15 +42,15 @@ print.artma_funnel_plot <- function(x, ...) {
 #' @return x invisibly
 #' @export
 print.artma_t_stat_histogram <- function(x, ...) {
-  close_up_info <- if (x$close_up_enabled) " + close-up" else ""
-  mean_info <- round(x$mean_t_stat, 3)
+  close_up_info <- if (isTRUE(x$meta$close_up_enabled)) " + close-up" else ""
+  mean_info <- round(x$meta$mean_t_stat, 3)
 
   cli::cli_text(paste0(
-    "<t_stat_histogram result: {x$n_observations} observations, ",
+    "<t_stat_histogram result: {x$meta$n_observations} observations, ",
     "mean t = {mean_info}{close_up_info}>"
   ))
   cli::cli_text(
-    "Access plots via {.code $plot_main} and {.code $plot_close_up}"
+    "Access plots via {.code $plots$plot_main} and {.code $plots$plot_close_up}"
   )
 
   invisible(x)

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -9,6 +9,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     artma / libs / core / autonomy[get_autonomy_level],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group]
   )
 
@@ -170,31 +171,32 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     stringsAsFactors = FALSE
   )
 
-  result <- list(
-    summary = summary,
-    formula = build_bpe_formula_string(
-      coef_post_mean = coef_post_mean,
-      predictor_values = author_values,
-      include_intercept = include_intercept,
-      round_to = round_to
-    ),
-    overrides = override_table,
-    bma_formula = bma_formula,
-    bma_source = resolved_bma$source,
-    autonomy_level = autonomy_level
+  formula <- build_bpe_formula_string(
+    coef_post_mean = coef_post_mean,
+    predictor_values = author_values,
+    include_intercept = include_intercept,
+    round_to = round_to
   )
-  class(result) <- c("artma_best_practice_estimate", class(result))
 
   if (get_verbosity() >= 3) {
     cli::cli_h3("Best-Practice Estimate")
-    cli::cli_alert_info("BMA source: {.val {result$bma_source}}")
-    cli::cat_print(result$summary)
+    cli::cli_alert_info("BMA source: {.val {resolved_bma$source}}")
+    cli::cat_print(summary)
     if (get_verbosity() >= 4) {
-      cli::cli_alert_info("Author formula: {result$formula}")
+      cli::cli_alert_info("Author formula: {formula}")
     }
   }
 
-  invisible(result)
+  invisible(new_method_result(
+    tables = list(summary = summary),
+    meta = list(
+      formula = formula,
+      overrides = override_table,
+      bma_formula = bma_formula,
+      bma_source = resolved_bma$source,
+      autonomy_level = autonomy_level
+    )
+  ))
 }
 
 resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
@@ -246,33 +248,22 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
 }
 
 normalize_bma_result_input <- function(bma_result) {
-  box::use(artma / libs / core / utils[get_verbosity])
-
   empty <- list(model = NULL, data = NULL, var_list = NULL, params = NULL)
 
   if (!is.list(bma_result)) {
     return(empty)
   }
 
-  if (!is.null(bma_result$model) || !is.null(bma_result$data) || !is.null(bma_result$var_list)) {
-    return(list(
-      model = bma_result$model,
-      data = bma_result$data,
-      var_list = bma_result$var_list,
-      params = bma_result$params
-    ))
-  }
+  # Accept the standard method contract (fields under meta) or a bare meta-like
+  # list for callers that pass one directly.
+  meta <- bma_result$meta %||% bma_result
 
-  if (length(bma_result) > 0 && is.list(bma_result[[1]]) &&
-    (!is.null(bma_result[[1]]$model) || !is.null(bma_result[[1]]$data) || !is.null(bma_result[[1]]$var_list))) {
-    if (get_verbosity() >= 2) {
-      cli::cli_alert_warning("Multiple BMA results were provided; using the first one for BPE.")
-    }
+  if (!is.null(meta$model) || !is.null(meta$data) || !is.null(meta$var_list)) {
     return(list(
-      model = bma_result[[1]]$model,
-      data = bma_result[[1]]$data,
-      var_list = bma_result[[1]]$var_list,
-      params = bma_result[[1]]$params
+      model = meta$model,
+      data = meta$data,
+      var_list = meta$var_list,
+      params = meta$params
     ))
   }
 
@@ -931,14 +922,9 @@ matches_any <- function(label, patterns) {
 
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  best_practice_estimate,
-  stage = "best_practice_estimate",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(best_practice_estimate, stage = "best_practice_estimate")
 
 box::export(best_practice_estimate, run)

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -15,6 +15,7 @@ bma <- function(df) {
     ],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options]
   )
@@ -79,17 +80,17 @@ bma <- function(df) {
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning("No valid BMA variables available. Skipping BMA analysis.")
     }
-    return(list(
-      coefficients = data.frame(
-        variable = character(0),
-        pip = numeric(0),
-        post_mean = numeric(0),
-        post_sd = numeric(0),
-        cond_pos_sign = numeric(0),
-        stringsAsFactors = FALSE
-      ),
-      model = NULL,
-      skipped = prepared$skipped
+    empty_coefs <- data.frame(
+      variable = character(0),
+      pip = numeric(0),
+      post_mean = numeric(0),
+      post_sd = numeric(0),
+      cond_pos_sign = numeric(0),
+      stringsAsFactors = FALSE
+    )
+    return(new_method_result(
+      tables = list(coefficients = empty_coefs),
+      meta = list(model = NULL, skipped = prepared$skipped)
     ))
   }
 
@@ -161,11 +162,20 @@ bma <- function(df) {
     )
   }
 
-  if (length(results) == 1) {
-    invisible(results[[1]])
-  } else {
-    invisible(results)
-  }
+  # Downstream consumers (fma, best_practice_estimate, the MA table builder) use
+  # the first parameter set; the full list is preserved under meta$all.
+  primary <- results[[1]]
+  invisible(new_method_result(
+    tables = list(coefficients = primary$coefficients),
+    meta = list(
+      model = primary$model,
+      data = primary$data,
+      params = primary$params,
+      var_list = primary$var_list,
+      skipped = NULL,
+      all = results
+    )
+  ))
 }
 
 #' Prepare inputs for BMA and FMA workflows
@@ -755,14 +765,10 @@ save_bma_variables_to_data_config <- function(variables, config) {
 
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  bma,
-  stage = "bma",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(bma, stage = "bma")
 
+# prepare_bma_inputs is exported because the fma method reuses it directly.
 box::export(bma, run, prepare_bma_inputs)

--- a/inst/artma/methods/box_plot.R
+++ b/inst/artma/methods/box_plot.R
@@ -9,6 +9,7 @@ box_plot <- function(df) {
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / libs / core / autonomy[should_prompt_user],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
@@ -48,10 +49,10 @@ box_plot <- function(df) {
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning("No suitable grouping variable found. Skipping box plot.")
     }
-    return(invisible(list(
+    return(invisible(new_method_result(
       plots = list(),
-      factor_by = NULL,
-      n_groups = 0L
+      meta = list(factor_by = NULL, n_groups = 0L),
+      class = "artma_box_plot"
     )))
   }
 
@@ -88,9 +89,12 @@ box_plot <- function(df) {
     )
   }
 
-  # Add class for clean printing (print method defined in R/print.R)
-  class(result) <- c("artma_box_plot", class(result))
-  invisible(result)
+  # Class attached for clean printing (print method defined in R/print.R)
+  invisible(new_method_result(
+    plots = result$plots,
+    meta = list(factor_by = factor_by, n_groups = result$n_groups),
+    class = "artma_box_plot"
+  ))
 }
 
 

--- a/inst/artma/methods/effect_summary_stats.R
+++ b/inst/artma/methods/effect_summary_stats.R
@@ -11,6 +11,7 @@ effect_summary_stats <- function(df) {
     artma / data_config / read[get_data_config],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group]
   )
 
@@ -173,7 +174,7 @@ effect_summary_stats <- function(df) {
       }
       empty <- data.frame(matrix(nrow = 0, ncol = length(CONST$EFFECT_SUMMARY_STATS$NAMES)), stringsAsFactors = FALSE)
       colnames(empty) <- CONST$EFFECT_SUMMARY_STATS$NAMES
-      return(empty)
+      return(new_method_result(tables = list(summary = empty)))
     }
   }
 
@@ -298,18 +299,13 @@ effect_summary_stats <- function(df) {
     cli::cat_print(out)
   }
 
-  invisible(out)
+  invisible(new_method_result(tables = list(summary = out)))
 }
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  effect_summary_stats,
-  stage = "effect_summary_stats",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(effect_summary_stats, stage = "effect_summary_stats")
 
 box::export(effect_summary_stats, run)

--- a/inst/artma/methods/exogeneity_tests.R
+++ b/inst/artma/methods/exogeneity_tests.R
@@ -8,6 +8,7 @@ exogeneity_tests <- function(df) {
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
     artma / econometric / exogeneity[run_exogeneity_tests],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
@@ -82,18 +83,20 @@ exogeneity_tests <- function(df) {
     }
   }
 
-  invisible(results)
+  invisible(new_method_result(
+    tables = list(summary = results$summary),
+    meta = list(
+      iv = results$iv,
+      puniform = results$puniform,
+      skipped = results$skipped
+    )
+  ))
 }
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  exogeneity_tests,
-  stage = "exogeneity_tests",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(exogeneity_tests, stage = "exogeneity_tests")
 
 box::export(exogeneity_tests, run)

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -10,6 +10,7 @@ fma <- function(df, bma_result = NULL) {
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / methods / bma[prepare_bma_inputs],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group]
   )
 
@@ -81,22 +82,14 @@ fma <- function(df, bma_result = NULL) {
     if (!is.list(result)) {
       return(list())
     }
-    if (!is.null(result$model) || !is.null(result$data) || !is.null(result$var_list)) {
+    # Accept the standard method contract (fields under meta) or a bare
+    # meta-like list for callers that pass one directly.
+    meta <- result$meta %||% result
+    if (!is.null(meta$model) || !is.null(meta$data) || !is.null(meta$var_list)) {
       return(list(
-        model = result$model,
-        data = result$data,
-        var_list = result$var_list
-      ))
-    }
-    if (length(result) > 0 && is.list(result[[1]]) &&
-      (!is.null(result[[1]]$model) || !is.null(result[[1]]$data) || !is.null(result[[1]]$var_list))) {
-      if (get_verbosity() >= 2) {
-        cli::cli_alert_warning("Multiple BMA results supplied. Using the first one for FMA.")
-      }
-      return(list(
-        model = result[[1]]$model,
-        data = result[[1]]$data,
-        var_list = result[[1]]$var_list
+        model = meta$model,
+        data = meta$data,
+        var_list = meta$var_list
       ))
     }
     list()
@@ -121,17 +114,16 @@ fma <- function(df, bma_result = NULL) {
       if (get_verbosity() >= 2) {
         cli::cli_alert_warning("No valid BMA variables available. Skipping FMA analysis.")
       }
-      return(list(
-        coefficients = data.frame(
-          variable = character(0),
-          coefficient = numeric(0),
-          se = numeric(0),
-          p_value = numeric(0),
-          stringsAsFactors = FALSE
-        ),
-        weights = numeric(0),
-        model = NULL,
-        skipped = prepared$skipped
+      empty_coefs <- data.frame(
+        variable = character(0),
+        coefficient = numeric(0),
+        se = numeric(0),
+        p_value = numeric(0),
+        stringsAsFactors = FALSE
+      )
+      return(new_method_result(
+        tables = list(coefficients = empty_coefs),
+        meta = list(weights = numeric(0), model = NULL, skipped = prepared$skipped)
       ))
     }
 
@@ -154,25 +146,22 @@ fma <- function(df, bma_result = NULL) {
     print_results = effective_print
   )
 
-  list(
-    coefficients = fma_results$coefficients,
-    weights = fma_results$weights,
-    model = bma_model,
-    data = bma_data,
-    params = bma_params,
-    var_list = bma_var_list
+  new_method_result(
+    tables = list(coefficients = fma_results$coefficients),
+    meta = list(
+      weights = fma_results$weights,
+      model = bma_model,
+      data = bma_data,
+      params = bma_params,
+      var_list = bma_var_list
+    )
   )
 }
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  fma,
-  stage = "fma",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(fma, stage = "fma")
 
 box::export(fma, run)

--- a/inst/artma/methods/funnel_plot.R
+++ b/inst/artma/methods/funnel_plot.R
@@ -7,6 +7,7 @@ funnel_plot <- function(df) {
   box::use(
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
@@ -66,11 +67,14 @@ funnel_plot <- function(df) {
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning("All observations filtered as outliers. Skipping funnel plot.")
     }
-    return(invisible(list(
-      plot = NULL,
-      n_points = 0L,
-      n_outliers_removed = n_outliers,
-      used_study_medians = use_study_medians
+    return(invisible(new_method_result(
+      plots = list(funnel_plot = NULL),
+      meta = list(
+        n_points = 0L,
+        n_outliers_removed = n_outliers,
+        used_study_medians = use_study_medians
+      ),
+      class = "artma_funnel_plot"
     )))
   }
 
@@ -111,14 +115,15 @@ funnel_plot <- function(df) {
     )
   }
 
-  result <- list(
-    plot = plot,
-    n_points = nrow(plot_data),
-    n_outliers_removed = n_outliers,
-    used_study_medians = use_study_medians
-  )
-  class(result) <- c("artma_funnel_plot", class(result))
-  invisible(result)
+  invisible(new_method_result(
+    plots = list(funnel_plot = plot),
+    meta = list(
+      n_points = nrow(plot_data),
+      n_outliers_removed = n_outliers,
+      used_study_medians = use_study_medians
+    ),
+    class = "artma_funnel_plot"
+  ))
 }
 
 
@@ -440,14 +445,9 @@ export_funnel_plot <- function(plot, export_path, graph_scale) {
 
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  funnel_plot,
-  stage = "funnel_plot",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(funnel_plot, stage = "funnel_plot")
 
 box::export(funnel_plot, run)

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -8,6 +8,7 @@ linear_tests <- function(df) {
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
     artma / econometric / linear[run_linear_models],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
@@ -72,18 +73,20 @@ linear_tests <- function(df) {
     }
   }
 
-  invisible(results)
+  invisible(new_method_result(
+    tables = list(summary = results$summary),
+    meta = list(
+      coefficients = results$coefficients,
+      skipped = results$skipped,
+      options = results$options
+    )
+  ))
 }
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  linear_tests,
-  stage = "linear_tests",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(linear_tests, stage = "linear_tests")
 
 box::export(linear_tests, run)

--- a/inst/artma/methods/nonlinear_tests.R
+++ b/inst/artma/methods/nonlinear_tests.R
@@ -5,6 +5,7 @@ nonlinear_tests <- function(df) {
     artma / libs / core / validation[validate, validate_columns, assert],
     artma / libs / core / utils[get_verbosity],
     artma / econometric / nonlinear[run_nonlinear_methods],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
@@ -84,18 +85,20 @@ nonlinear_tests <- function(df) {
     }
   }
 
-  invisible(results)
+  invisible(new_method_result(
+    tables = list(summary = results$summary),
+    meta = list(
+      coefficients = results$coefficients,
+      skipped = results$skipped,
+      options = results$options
+    )
+  ))
 }
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  nonlinear_tests,
-  stage = "nonlinear_tests",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(nonlinear_tests, stage = "nonlinear_tests")
 
 box::export(nonlinear_tests, run)

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -10,6 +10,7 @@ p_hacking_tests <- function(df) {
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
     artma / econometric / p_hacking[run_p_hacking_tests],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
@@ -174,18 +175,20 @@ p_hacking_tests <- function(df) {
     }
   }
 
-  invisible(results)
+  invisible(new_method_result(
+    tables = list(
+      caliper = results$caliper,
+      elliott = results$elliott,
+      maive = results$maive
+    ),
+    meta = list(skipped = results$skipped)
+  ))
 }
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  p_hacking_tests,
-  stage = "p_hacking_tests",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(p_hacking_tests, stage = "p_hacking_tests")
 
 box::export(p_hacking_tests, run)

--- a/inst/artma/methods/prima_facie_graphs.R
+++ b/inst/artma/methods/prima_facie_graphs.R
@@ -9,6 +9,7 @@ prima_facie_graphs <- function(df) {
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / libs / core / autonomy[should_prompt_user],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / variable / detection[detect_variable_groups],
     artma / visualization / options[get_visualization_options],
@@ -54,7 +55,7 @@ prima_facie_graphs <- function(df) {
         "No suitable variable groups found for prima facie graphs. Skipping."
       )
     }
-    return(invisible(list(plots = list(), groups = character(0))))
+    return(invisible(new_method_result(meta = list(groups = character(0)))))
   }
 
   plots <- list()
@@ -94,7 +95,7 @@ prima_facie_graphs <- function(df) {
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning("No prima facie graphs could be created.")
     }
-    return(invisible(list(plots = list(), groups = character(0))))
+    return(invisible(new_method_result(meta = list(groups = character(0)))))
   }
 
   if (get_verbosity() >= 3) {
@@ -118,9 +119,10 @@ prima_facie_graphs <- function(df) {
     )
   }
 
-  result <- list(plots = plots, groups = group_names)
-  class(result) <- c("artma_prima_facie_graphs", class(result))
-  invisible(result)
+  invisible(new_method_result(
+    plots = plots,
+    meta = list(groups = group_names)
+  ))
 }
 
 
@@ -373,14 +375,9 @@ export_prima_facie_plots <- function(plots, group_names, export_path, graph_scal
 
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  prima_facie_graphs,
-  stage = "prima_facie_graphs",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(prima_facie_graphs, stage = "prima_facie_graphs")
 
 box::export(prima_facie_graphs, run)

--- a/inst/artma/methods/t_stat_histogram.R
+++ b/inst/artma/methods/t_stat_histogram.R
@@ -10,6 +10,7 @@ t_stat_histogram <- function(df) {
   box::use(
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[
@@ -155,17 +156,20 @@ t_stat_histogram <- function(df) {
     0L
   }
 
-  result <- list(
-    plot_main = main_result$plot,
-    plot_close_up = close_up_plot,
-    n_observations = nrow(df),
-    n_outliers_main = main_result$n_outliers,
-    n_outliers_close_up = close_up_outliers,
-    mean_t_stat = mean(df$t_stat, na.rm = TRUE),
-    close_up_enabled = close_up_enabled
-  )
-  class(result) <- c("artma_t_stat_histogram", class(result))
-  invisible(result)
+  invisible(new_method_result(
+    plots = list(
+      plot_main = main_result$plot,
+      plot_close_up = close_up_plot
+    ),
+    meta = list(
+      n_observations = nrow(df),
+      n_outliers_main = main_result$n_outliers,
+      n_outliers_close_up = close_up_outliers,
+      mean_t_stat = mean(df$t_stat, na.rm = TRUE),
+      close_up_enabled = close_up_enabled
+    ),
+    class = "artma_t_stat_histogram"
+  ))
 }
 
 
@@ -554,14 +558,9 @@ export_t_stat_histograms <- function(main_plot,
 
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  t_stat_histogram,
-  stage = "t_stat_histogram",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(t_stat_histogram, stage = "t_stat_histogram")
 
 box::export(t_stat_histogram, run)

--- a/inst/artma/methods/variable_summary_stats.R
+++ b/inst/artma/methods/variable_summary_stats.R
@@ -11,6 +11,7 @@ variable_summary_stats <- function(df) {
     artma / const[CONST],
     artma / libs / core / validation[assert],
     artma / data_config / read[get_data_config],
+    artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / libs / core / utils[get_verbosity]
   )
@@ -29,7 +30,7 @@ variable_summary_stats <- function(df) {
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning("No variables selected to compute summary statistics for.")
     }
-    return(data.frame())
+    return(new_method_result(tables = list(summary = data.frame())))
   }
 
   # Initialize output data frame
@@ -87,18 +88,13 @@ variable_summary_stats <- function(df) {
     cli::cli_alert_warning("Missing data for {.val {length(missing_data_vars)}} variables: {.val {missing_data_vars}}")
   }
 
-  invisible(df_out)
+  invisible(new_method_result(tables = list(summary = df_out)))
 }
 
 box::use(
-  artma / libs / infrastructure / cache[cache_cli_runner],
-  artma / data / cache_signatures[build_data_cache_signature]
+  artma / modules / runtime_methods[register_runtime_method]
 )
 
-run <- cache_cli_runner(
-  variable_summary_stats,
-  stage = "variable_summary_stats",
-  key_builder = function(...) build_data_cache_signature()
-)
+run <- register_runtime_method(variable_summary_stats, stage = "variable_summary_stats")
 
-box::export(run)
+box::export(variable_summary_stats, run)

--- a/inst/artma/modules/runtime_methods.R
+++ b/inst/artma/modules/runtime_methods.R
@@ -7,6 +7,65 @@ box::use(
 # Modules can opt out of runtime registration by setting this flag to FALSE.
 RUNTIME_METHOD_MARKER <- ".__runtime_method__"
 
+#' @title Standard runtime method return contract
+#' @description
+#' Build the value every runtime method returns. The contract has three slots:
+#'
+#' * `tables`: a named list of `data.frame`s destined for CSV export. The
+#'   exporter walks this list; keys become filename suffixes (see
+#'   `export_method_result`).
+#' * `plots`: a named list of plot objects (for example `ggplot`s) for
+#'   programmatic access and printing. Graphics files are written by the method
+#'   during execution, not by this contract.
+#' * `meta`: a named list of anything else a downstream consumer needs (the BMA
+#'   model, fit parameters, skip reasons, auxiliary frames, and so on).
+#'
+#' @param tables *\[list\]* Named list of `data.frame`s to export.
+#' @param plots *\[list\]* Named list of plot objects.
+#' @param meta *\[list\]* Named list of method-specific extras.
+#' @param class *\[character, optional\]* Extra S3 class(es) to prepend, used by
+#'   methods that ship a bespoke print method.
+#' @return *\[list\]* A list with `tables`, `plots`, and `meta` elements.
+new_method_result <- function(tables = list(), plots = list(), meta = list(), class = NULL) {
+  if (!is.list(tables) || !is.list(plots) || !is.list(meta)) {
+    cli::cli_abort("`tables`, `plots`, and `meta` must all be lists.")
+  }
+
+  result <- list(tables = tables, plots = plots, meta = meta)
+
+  if (!is.null(class)) {
+    class(result) <- c(class, class(result))
+  }
+
+  result
+}
+
+#' @title Register a runtime method
+#' @description
+#' Wrap a method implementation in the shared caching layer and return the
+#' `run` function every method file exports. This replaces the per-file
+#' registration trailer that previously duplicated the `cache_cli_runner`
+#' wiring across all method modules.
+#' @param impl *\[function\]* The method implementation (its `run` worker).
+#' @param stage *\[character\]* Stage label used for cache keys and the cache
+#'   hit notice. Conventionally matches the implementation's name.
+#' @param key_builder *\[function, optional\]* Cache signature builder. Defaults
+#'   to the standard data cache signature.
+#' @param ... *\[any\]* Extra arguments forwarded to `cache_cli_runner`.
+#' @return *\[function\]* The cached `run` wrapper.
+register_runtime_method <- function(impl, stage, key_builder = NULL, ...) {
+  box::use(
+    artma / libs / infrastructure / cache[cache_cli_runner],
+    artma / data / cache_signatures[build_data_cache_signature]
+  )
+
+  if (is.null(key_builder)) {
+    key_builder <- function(...) build_data_cache_signature()
+  }
+
+  cache_cli_runner(impl, stage = stage, key_builder = key_builder, ...)
+}
+
 module_has_run <- function(module) {
   is.function(module[["run"]])
 }
@@ -95,5 +154,7 @@ get_runtime_method_modules <- function(
 box::export(
   get_runtime_method_modules,
   module_should_be_runtime_method,
+  new_method_result,
+  register_runtime_method,
   RUNTIME_METHOD_MARKER
 )

--- a/inst/artma/output/export.R
+++ b/inst/artma/output/export.R
@@ -110,8 +110,9 @@ save_table <- function(df, name, output_dir) {
 #'
 #' @description
 #' Iterates over a named list of method results and exports each method's
-#' tabular data as CSV files. Graphics-only methods are skipped (they are
-#' handled by per-method export during execution).
+#' tabular data (the `tables` slot of the standard return contract) as CSV
+#' files. Graphics are written by each method during execution, so plot-only
+#' methods simply contribute no tables here.
 #'
 #' @param results *\[list\]* Named list of method results from `invoke_runtime_methods()`.
 #' @param output_dir *\[character\]* The base output directory.
@@ -134,42 +135,51 @@ export_results <- function(results, output_dir) {
   write_last_export_marker(output_dir)
 }
 
+#' Resolve the CSV basename for a table in the standard return contract
+#'
+#' @description
+#' A table keyed with a generic label (`summary`, `coefficients`, `table`), an
+#' empty key, or the method name itself is written as `<method_name>.csv`. Any
+#' other key is treated as a sub-table and written as `<method_name>_<key>.csv`
+#' (for example the caliper/elliott/maive tables of `p_hacking_tests`).
+#'
+#' @param method_name *\[character\]* The method name.
+#' @param key *\[character\]* The table's name within the `tables` list.
+#' @return *\[character\]* The CSV basename (without extension).
+#' @keywords internal
+resolve_table_basename <- function(method_name, key) {
+  generic_keys <- c("summary", "coefficients", "table")
+  if (is.null(key) || is.na(key) || !nzchar(key) ||
+    identical(key, method_name) || key %in% generic_keys) {
+    return(method_name)
+  }
+  paste0(method_name, "_", key)
+}
+
 #' Export a single method's result
 #'
-#' @param result The method's return value.
+#' @description
+#' A generic walk over the standard return contract. Every `data.frame` in the
+#' result's `tables` slot is written as a CSV; everything else (`plots`, `meta`)
+#' is ignored here. There are no per-method branches.
+#'
+#' @param result The method's return value (a `list` with a `tables` slot).
 #' @param method_name *\[character\]* The method name.
 #' @param output_dir *\[character\]* The base output directory.
 #' @keywords internal
 export_method_result <- function(result, method_name, output_dir) {
-  if (is.data.frame(result)) {
-    save_table(result, method_name, output_dir)
-    return(invisible())
-  }
-
   if (!is.list(result)) return(invisible())
 
-  # Methods with $summary
-  if (!is.null(result$summary) && is.data.frame(result$summary)) {
-    save_table(result$summary, method_name, output_dir)
-    return(invisible())
-  }
+  tables <- result$tables
+  if (!is.list(tables) || length(tables) == 0L) return(invisible())
 
-  # Methods with $coefficients (bma, fma)
-  if (!is.null(result$coefficients) && is.data.frame(result$coefficients)) {
-    save_table(result$coefficients, method_name, output_dir)
-    return(invisible())
+  table_names <- names(tables)
+  for (i in seq_along(tables)) {
+    tbl <- tables[[i]]
+    if (!is.data.frame(tbl)) next
+    key <- if (is.null(table_names)) NULL else table_names[[i]]
+    save_table(tbl, resolve_table_basename(method_name, key), output_dir)
   }
-
-  # p_hacking_tests: multiple sub-tables
-  sub_tables <- c("caliper", "elliott", "maive")
-  exported_any <- FALSE
-  for (sub in sub_tables) {
-    if (!is.null(result[[sub]]) && is.data.frame(result[[sub]])) {
-      save_table(result[[sub]], paste0(method_name, "_", sub), output_dir)
-      exported_any <- TRUE
-    }
-  }
-  if (exported_any) return(invisible())
 
   invisible()
 }

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -83,17 +83,20 @@ test_that("best_practice_estimate uses provided BMA result and returns structure
   bma_result <- bma(df)
   result <- best_practice_estimate(df, bma_result = bma_result)
 
+  expect_named(result, c("tables", "plots", "meta"))
+  expect_named(result$tables, "summary")
   expect_named(
-    result,
-    c("summary", "formula", "overrides", "bma_formula", "bma_source", "autonomy_level")
+    result$meta,
+    c("formula", "overrides", "bma_formula", "bma_source", "autonomy_level"),
+    ignore.order = TRUE
   )
-  expect_equal(result$bma_source, "provided")
-  expect_true(is.data.frame(result$summary))
-  expect_true(nrow(result$summary) >= 1)
-  expect_true("estimate" %in% colnames(result$summary))
-  expect_true(is.data.frame(result$overrides))
+  expect_equal(result$meta$bma_source, "provided")
+  expect_true(is.data.frame(result$tables$summary))
+  expect_true(nrow(result$tables$summary) >= 1)
+  expect_true("estimate" %in% colnames(result$tables$summary))
+  expect_true(is.data.frame(result$meta$overrides))
 
-  overrides <- stats::setNames(result$overrides$override, result$overrides$variable)
+  overrides <- stats::setNames(result$meta$overrides$override, result$meta$overrides$variable)
   expect_equal(overrides[["se"]], "0")
   expect_equal(overrides[["citations"]], "max")
   expect_equal(overrides[["first_lag_instrument"]], "0")
@@ -142,7 +145,7 @@ test_that("best_practice_estimate accepts logical BPE overrides from config", {
   bma_result <- bma(df)
   result <- best_practice_estimate(df, bma_result = bma_result)
 
-  overrides <- stats::setNames(result$overrides$override, result$overrides$variable)
+  overrides <- stats::setNames(result$meta$overrides$override, result$meta$overrides$variable)
   expect_equal(overrides[["top_journal"]], "1")
   expect_equal(overrides[["first_lag_instrument"]], "0")
   expect_false(is.na(overrides[["se"]]))

--- a/tests/testthat/test-box-plot-study-label.R
+++ b/tests/testthat/test-box-plot-study-label.R
@@ -27,5 +27,5 @@ test_that("box_plot auto-selects study_label over study_id for grouping", {
   result <- box_plot(df)
 
   expect_true(is.list(result))
-  expect_equal(result$factor_by, "study_label")
+  expect_equal(result$meta$factor_by, "study_label")
 })

--- a/tests/testthat/test-effect-summary-stats-integration.R
+++ b/tests/testthat/test-effect-summary-stats-integration.R
@@ -118,7 +118,7 @@ test_that("effect_summary_stats handles empty config gracefully in non-interacti
   )
 
   # Should return empty result without error (non-interactive)
-  result <- effect_summary_stats(df)
+  result <- effect_summary_stats(df)$tables$summary
 
   expect_true(is.data.frame(result))
   expect_equal(nrow(result), 0)
@@ -170,7 +170,7 @@ test_that("effect_summary_stats processes configured variables correctly", {
     "artma.verbose" = 1
   )
 
-  result <- effect_summary_stats(df)
+  result <- effect_summary_stats(df)$tables$summary
 
   expect_true(is.data.frame(result))
   expect_true(nrow(result) > 0)
@@ -243,7 +243,7 @@ test_that("update_config_with_selections integrates with effect_summary_stats", 
     "artma.verbose" = 1
   )
 
-  result <- effect_summary_stats(df)
+  result <- effect_summary_stats(df)$tables$summary
 
   expect_true(is.data.frame(result))
   expect_true(nrow(result) > 0)
@@ -282,7 +282,7 @@ test_that("effect_summary_stats handles missing data gracefully", {
 
   # Should handle NA values without error
   expect_no_error({
-    result <- effect_summary_stats(df)
+    result <- effect_summary_stats(df)$tables$summary
   })
 })
 
@@ -315,7 +315,7 @@ test_that("effect_summary_stats handles non-numeric variables correctly", {
   )
 
   # Should warn about non-numeric variable
-  result <- effect_summary_stats(df)
+  result <- effect_summary_stats(df)$tables$summary
 
   expect_true(is.data.frame(result))
   # Category should be skipped, only "All Data" should appear
@@ -429,7 +429,7 @@ test_that("full workflow: suggestion -> config -> analysis works end-to-end", {
       "artma.verbose" = 1
     )
 
-    result <- effect_summary_stats(df)
+    result <- effect_summary_stats(df)$tables$summary
 
     # Verify we got results
     expect_true(is.data.frame(result))

--- a/tests/testthat/test-effect-summary-stats.R
+++ b/tests/testthat/test-effect-summary-stats.R
@@ -44,7 +44,7 @@ test_that("effect summary stats computes segmented summaries", {
     score = c(1, 2, 3, 4, 5)
   )
 
-  result <- effect_summary_stats(df)
+  result <- effect_summary_stats(df)$tables$summary
 
   expect_named(result, c(
     "Var Name", "Var Class", "Mean", "CI lower", "CI upper",
@@ -87,7 +87,7 @@ test_that("formal output hides presentation columns", {
     group = c(1, 1, 0)
   )
 
-  result <- effect_summary_stats(df)
+  result <- effect_summary_stats(df)$tables$summary
 
   expect_named(result, c(
     "Var Name", "Mean", "CI lower", "CI upper",

--- a/tests/testthat/test-funnel-plot.R
+++ b/tests/testthat/test-funnel-plot.R
@@ -45,9 +45,15 @@ test_that("funnel_plot creates a plot with required columns", {
   result <- funnel_plot(df)
 
   expect_s3_class(result, "artma_funnel_plot")
-  expect_named(result, c("plot", "n_points", "n_outliers_removed", "used_study_medians"))
-  expect_true(ggplot2::is_ggplot(result$plot))
-  expect_identical(result$used_study_medians, FALSE)
+  expect_named(result, c("tables", "plots", "meta"))
+  expect_named(result$plots, "funnel_plot")
+  expect_named(
+    result$meta,
+    c("n_points", "n_outliers_removed", "used_study_medians"),
+    ignore.order = TRUE
+  )
+  expect_true(ggplot2::is_ggplot(result$plots$funnel_plot))
+  expect_identical(result$meta$used_study_medians, FALSE)
 })
 
 
@@ -66,8 +72,8 @@ test_that("funnel_plot respects use_study_medians option", {
   df <- create_test_data(n = 100)
   result <- funnel_plot(df)
 
-  expect_identical(result$used_study_medians, TRUE)
-  expect_equal(result$n_points, 10)
+  expect_identical(result$meta$used_study_medians, TRUE)
+  expect_equal(result$meta$n_points, 10)
 })
 
 
@@ -91,8 +97,8 @@ test_that("funnel_plot filters outliers correctly", {
 
   result <- funnel_plot(df)
 
-  expect_true(result$n_outliers_removed > 0)
-  expect_true(result$n_points < nrow(df))
+  expect_true(result$meta$n_outliers_removed > 0)
+  expect_true(result$meta$n_points < nrow(df))
 })
 
 
@@ -111,8 +117,8 @@ test_that("funnel_plot with no outlier filtering keeps all points", {
   df <- create_test_data(n = 50)
   result <- funnel_plot(df)
 
-  expect_equal(result$n_outliers_removed, 0)
-  expect_equal(result$n_points, 50)
+  expect_equal(result$meta$n_outliers_removed, 0)
+  expect_equal(result$meta$n_points, 50)
 })
 
 
@@ -134,7 +140,7 @@ test_that("funnel_plot handles different themes", {
     df <- create_test_data(n = 20)
     result <- funnel_plot(df)
 
-    expect_true(ggplot2::is_ggplot(result$plot))
+    expect_true(ggplot2::is_ggplot(result$plots$funnel_plot))
   }
 })
 
@@ -154,7 +160,7 @@ test_that("funnel_plot handles precision_to_log option", {
   df <- create_test_data(n = 20)
   result <- funnel_plot(df)
 
-  expect_true(ggplot2::is_ggplot(result$plot))
+  expect_true(ggplot2::is_ggplot(result$plots$funnel_plot))
   expect_s3_class(result, "artma_funnel_plot")
 })
 
@@ -179,6 +185,6 @@ test_that("funnel_plot returns empty result when all data filtered", {
 
   result <- funnel_plot(df)
 
-  expect_null(result$plot)
-  expect_equal(result$n_points, 0)
+  expect_null(result$plots$funnel_plot)
+  expect_equal(result$meta$n_points, 0)
 })

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -47,22 +47,24 @@ test_that("linear tests return tidy coefficients and summary", {
 
   res <- linear_tests(df)
 
+  expect_named(res, c("tables", "plots", "meta"))
+  expect_named(res$tables, "summary")
   expect_named(
-    res,
-    c("coefficients", "summary", "skipped", "options"),
+    res$meta,
+    c("coefficients", "skipped", "options"),
     ignore.order = TRUE
   )
 
   expect_equal(
-    sort(unique(res$coefficients$model)),
+    sort(unique(res$meta$coefficients$model)),
     sort(c(
       "ols", "fe", "be", "re", "ols_study_weighted", "ols_precision_weighted"
     ))
   )
 
-  expect_equal(nrow(res$coefficients), 12L)
+  expect_equal(nrow(res$meta$coefficients), 12L)
   expect_named(
-    res$coefficients,
+    res$meta$coefficients,
     c(
       "estimate", "std_error", "statistic", "p_value", "term", "model",
       "model_label", "n_obs", "term_label", "bootstrap_lower",
@@ -72,17 +74,17 @@ test_that("linear tests return tidy coefficients and summary", {
     )
   )
 
-  expect_gt(nrow(res$summary), 0)
+  expect_gt(nrow(res$tables$summary), 0)
   expect_equal(
-    rownames(res$summary),
+    rownames(res$tables$summary),
     c(
       "Publication Bias", "(Std. Error)", "Bootstrap CI (PB)",
       "Effect Beyond Bias", "(Std. Error)", "Bootstrap CI (Effect)",
       "Total Observations"
     )
   )
-  expect_true(all(res$coefficients$significance %in% c("", "*", "**", "***")))
-  expect_equal(res$options$bootstrap_replications, 10L)
+  expect_true(all(res$meta$coefficients$significance %in% c("", "*", "**", "***")))
+  expect_equal(res$meta$options$bootstrap_replications, 10L)
 })
 
 test_that("linear tests gracefully skip models with missing columns", {
@@ -99,9 +101,9 @@ test_that("linear tests gracefully skip models with missing columns", {
 
   res <- linear_tests(df)
 
-  expect_false("ols_precision_weighted" %in% res$coefficients$model)
-  expect_true("ols_precision_weighted" %in% names(res$skipped))
-  expect_true(grepl("Missing required columns", res$skipped$ols_precision_weighted$reason))
+  expect_false("ols_precision_weighted" %in% res$meta$coefficients$model)
+  expect_true("ols_precision_weighted" %in% names(res$meta$skipped))
+  expect_true(grepl("Missing required columns", res$meta$skipped$ols_precision_weighted$reason))
 })
 
 test_that("panel models are skipped with a clear message when plm is unavailable", {

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -49,33 +49,35 @@ test_that("nonlinear tests return tidy coefficients and summary", {
 
   res <- suppressWarnings(nonlinear_tests(df))
 
+  expect_named(res, c("tables", "plots", "meta"))
+  expect_named(res$tables, "summary")
   expect_named(
-    res,
-    c("coefficients", "summary", "skipped", "options"),
+    res$meta,
+    c("coefficients", "skipped", "options"),
     ignore.order = TRUE
   )
 
-  expect_gt(nrow(res$coefficients), 0L)
+  expect_gt(nrow(res$meta$coefficients), 0L)
   expect_named(
-    res$coefficients,
+    res$meta$coefficients,
     c(
       "model", "model_label", "term", "estimate", "std_error", "p_value",
       "n_obs_total", "n_obs_model", "estimate_formatted", "std_error_formatted"
     )
   )
-  expect_setequal(unique(res$coefficients$term), c("publication_bias", "effect"))
-  expect_true(all(res$coefficients$n_obs_total == nrow(df)))
+  expect_setequal(unique(res$meta$coefficients$term), c("publication_bias", "effect"))
+  expect_true(all(res$meta$coefficients$n_obs_total == nrow(df)))
 
-  expect_gt(nrow(res$summary), 0L)
+  expect_gt(nrow(res$tables$summary), 0L)
   expect_equal(
-    rownames(res$summary),
+    rownames(res$tables$summary),
     c(
       "Publication Bias", "(Std. Error)", "Effect Beyond Bias",
       "(Std. Error)", "Total observations", "Model observations"
     )
   )
-  expect_equal(res$summary$Metric, rownames(res$summary))
-  expect_equal(res$options$round_to, 2L)
+  expect_equal(res$tables$summary$Metric, rownames(res$tables$summary))
+  expect_equal(res$meta$options$round_to, 2L)
 })
 
 test_that("nonlinear methods record skipped models when input is insufficient", {

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -165,9 +165,9 @@ test_that("partial results from a run with a failing method are exported", {
   box::use(artma / output / export[export_results])
 
   fake_methods <- list(
-    method_a = list(run = function(df, ...) data.frame(estimate = 1)),
+    method_a = list(run = function(df, ...) list(tables = list(summary = data.frame(estimate = 1)))),
     method_b = list(run = function(df, ...) cli::cli_abort("boom")),
-    method_c = list(run = function(df, ...) data.frame(estimate = 3))
+    method_c = list(run = function(df, ...) list(tables = list(summary = data.frame(estimate = 3))))
   )
   withr::local_options(list(artma.verbose = 0))
   methods_dir <- local_mock_methods_dir(fake_methods)

--- a/tests/testthat/test-t-stat-histogram.R
+++ b/tests/testthat/test-t-stat-histogram.R
@@ -47,15 +47,16 @@ test_that("t_stat_histogram creates both plots with defaults", {
   result <- t_stat_histogram(df)
 
   expect_s3_class(result, "artma_t_stat_histogram")
-  expect_named(result, c(
-    "plot_main", "plot_close_up", "n_observations",
-    "n_outliers_main", "n_outliers_close_up",
+  expect_named(result, c("tables", "plots", "meta"))
+  expect_named(result$plots, c("plot_main", "plot_close_up"))
+  expect_named(result$meta, c(
+    "n_observations", "n_outliers_main", "n_outliers_close_up",
     "mean_t_stat", "close_up_enabled"
   ))
-  expect_true(ggplot2::is_ggplot(result$plot_main))
-  expect_true(ggplot2::is_ggplot(result$plot_close_up))
-  expect_identical(result$close_up_enabled, TRUE)
-  expect_equal(result$n_observations, 200)
+  expect_true(ggplot2::is_ggplot(result$plots$plot_main))
+  expect_true(ggplot2::is_ggplot(result$plots$plot_close_up))
+  expect_identical(result$meta$close_up_enabled, TRUE)
+  expect_equal(result$meta$n_observations, 200)
 })
 
 
@@ -77,9 +78,9 @@ test_that("t_stat_histogram works without close-up", {
   df <- create_test_data()
   result <- t_stat_histogram(df)
 
-  expect_true(ggplot2::is_ggplot(result$plot_main))
-  expect_null(result$plot_close_up)
-  expect_identical(result$close_up_enabled, FALSE)
+  expect_true(ggplot2::is_ggplot(result$plots$plot_main))
+  expect_null(result$plots$plot_close_up)
+  expect_identical(result$meta$close_up_enabled, FALSE)
 })
 
 
@@ -104,7 +105,7 @@ test_that("t_stat_histogram handles all themes", {
     df <- create_test_data(n = 50)
     result <- t_stat_histogram(df)
 
-    expect_true(ggplot2::is_ggplot(result$plot_main))
+    expect_true(ggplot2::is_ggplot(result$plots$plot_main))
   }
 })
 
@@ -127,8 +128,8 @@ test_that("t_stat_histogram filters outliers by cutoff", {
   df <- data.frame(t_stat = c(-100, -2, 0, 1, 3, 100))
   result <- t_stat_histogram(df)
 
-  expect_equal(result$n_outliers_main, 2L)
-  expect_equal(result$n_observations, 6)
+  expect_equal(result$meta$n_outliers_main, 2L)
+  expect_equal(result$meta$n_observations, 6)
 })
 
 
@@ -150,7 +151,7 @@ test_that("t_stat_histogram supports multiple critical values", {
   df <- create_test_data(n = 100)
   result <- t_stat_histogram(df)
 
-  expect_true(ggplot2::is_ggplot(result$plot_main))
+  expect_true(ggplot2::is_ggplot(result$plots$plot_main))
 })
 
 
@@ -172,7 +173,7 @@ test_that("t_stat_histogram works without mean line and density", {
   df <- create_test_data(n = 50)
   result <- t_stat_histogram(df)
 
-  expect_true(ggplot2::is_ggplot(result$plot_main))
+  expect_true(ggplot2::is_ggplot(result$plots$plot_main))
   expect_s3_class(result, "artma_t_stat_histogram")
 })
 
@@ -195,5 +196,5 @@ test_that("t_stat_histogram reports correct mean", {
   df <- data.frame(t_stat = c(-2, 0, 2, 4))
   result <- t_stat_histogram(df)
 
-  expect_equal(result$mean_t_stat, 1)
+  expect_equal(result$meta$mean_t_stat, 1)
 })


### PR DESCRIPTION
## Summary

Implements #166. Removes the copy-pasted registration trailer from all 13 runtime methods, introduces one standard return contract, and rewrites the exporter as a generic walk with no per-method branches.

## What changed

- **Registration helper.** New `register_runtime_method(impl, stage, ...)` and `new_method_result(tables, plots, meta, class)` in `inst/artma/modules/runtime_methods.R`. Each method trailer drops from a ~10-line `cache_cli_runner` + `build_data_cache_signature` block to 2 to 3 lines. The helper reuses the existing `cache_cli_runner` signature, so caching behavior is unchanged.
- **Standard contract.** Every method now returns `list(tables, plots, meta)`:
  - `tables`: named `data.frame`s exported as CSV.
  - `plots`: plot objects for programmatic access and printing.
  - `meta`: method-specific extras (BMA model, params, skip reasons, auxiliary frames).
  Method-specific richness moved under `meta`, so `fma`, `best_practice_estimate`, and the MA table builder still get what they need (they now read `bma_result$meta$model` / `results$bma$tables$coefficients`).
- **Generic exporter.** `export_method_result` is a single walk over `tables`; the `is.data.frame -> $summary -> $coefficients -> hardcoded caliper/elliott/maive` cascade is gone. A `resolve_table_basename` helper keeps every existing CSV filename stable: generic keys (`summary`/`coefficients`/`table` or the method name) export as `<method>.csv`, any other key as `<method>_<key>.csv` (so `p_hacking_tests_caliper.csv` etc. are unchanged, even when only one sub-test runs).
- **Normalized exports.** Every method file now exports `impl + run`. `bma` still exports `prepare_bma_inputs` because the `fma` method reuses it directly (noted in a comment).
- **Docs, print methods, tests.** The contract is documented in CLAUDE.md. The `box_plot`/`funnel_plot`/`t_stat_histogram` print methods read from `meta`/`plots`. Tests asserting old return shapes were updated.

## Output stability

Tabular output filenames are unchanged for all existing methods. Graphics continue to be written by each method during execution (unchanged filenames and dimensions); the unified exporter handles tabular output only, and `plots` in the contract carries the plot objects for programmatic use.

## Testing

- `make test`: 0 failures (1076 pass).
- `LC_ALL=en_US.UTF-8 make lint`: no lints.
- `make check`: 0 errors. The lone WARNING is an environmental C++ warning from R's own headers (`R_ext/Boolean.h`), and the NOTE is the worktree `.git` dir; neither is introduced here.
