### PR TITLE
refactor: strict option access and fail-loud coercion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,16 @@
 
+<a name="unreleased"></a>
+## Unreleased
+
+### Breaking Changes
+
+* Removed the legacy per-method `<method>.add_significance_marks` option fallback. Significance marks are now driven solely by the canonical `methods.add_significance_marks` template key and its default.
+
+### Bug Fixes
+
+* Option reads without a default now fail loud via `require_option`, and option coercion aborts on bad values (non-numeric numerics, fractional integers, out-of-range enums) instead of silently keeping the raw value.
+
+
 <a name="v0.3.3"></a>
 ## [v0.3.3](https://github.com/PetrCala/artma/compare/v0.3.2...v0.3.3)
 

--- a/R/data_config.R
+++ b/R/data_config.R
@@ -94,7 +94,7 @@ config.overrides <- function(options_file_name = NULL, options_dir = NULL) {
     options_file_name = options_file_name,
     options_dir = options_dir,
     FUN = function() {
-      overrides <- getOption("artma.data.config")
+      overrides <- getOption("artma.data.config", list())
       if (!is.list(overrides)) return(list())
       overrides
     }

--- a/inst/artma/data/cache_signatures.R
+++ b/inst/artma/data/cache_signatures.R
@@ -95,7 +95,7 @@ user_authored_config_entries <- function(config) {
 #' @return *\[list\]* A deterministic signature list suitable for
 #'   forwarding to `cache_cli()` wrappers as a `cache_signature` argument.
 build_data_cache_signature <- function() {
-  source_path <- getOption("artma.data.source_path")
+  source_path <- getOption("artma.data.source_path", NULL)
   normalized_path <- NULL
   source_mtime <- NA_real_
 
@@ -114,7 +114,7 @@ build_data_cache_signature <- function() {
     }
   }
 
-  data_config <- user_authored_config_entries(getOption("artma.data.config"))
+  data_config <- user_authored_config_entries(getOption("artma.data.config", NULL))
   artma_options <- drop_pipeline_written_options(get_option_group("artma"))
 
   list(

--- a/inst/artma/data/read.R
+++ b/inst/artma/data/read.R
@@ -122,7 +122,7 @@ read_file <- function(path) {
 read_data <- function(path = NULL) {
   box::use(artma / libs / core / utils[get_verbosity])
 
-  path <- if (!is.null(path)) path else getOption("artma.data.source_path")
+  path <- if (!is.null(path)) path else getOption("artma.data.source_path", NULL)
 
   if (is.null(path) || !nzchar(path)) {
     cli::cli_abort("No data source path provided. Please set {.field artma.data.source_path} option.")

--- a/inst/artma/data/schema_reconcile.R
+++ b/inst/artma/data/schema_reconcile.R
@@ -42,8 +42,8 @@ persist_expected_schema_cols <- function(cols) {
   normalized <- normalize_expected_schema_cols(cols)
   options("artma.data.expected_schema_columns" = normalized)
 
-  options_file_name <- getOption("artma.temp.file_name")
-  options_dir <- getOption("artma.temp.dir_name")
+  options_file_name <- getOption("artma.temp.file_name", NULL)
+  options_dir <- getOption("artma.temp.dir_name", NULL)
   has_options_file <- !is.null(options_file_name) && !is.null(options_dir)
 
   if (!has_options_file) {
@@ -494,8 +494,8 @@ apply_reconciliation <- function(decisions) {
     artma / libs / core / utils[get_verbosity]
   )
 
-  options_file_name <- getOption("artma.temp.file_name")
-  options_dir <- getOption("artma.temp.dir_name")
+  options_file_name <- getOption("artma.temp.file_name", NULL)
+  options_dir <- getOption("artma.temp.dir_name", NULL)
 
   has_options_file <- !is.null(options_file_name) && !is.null(options_dir)
 

--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -106,7 +106,7 @@ standardize_column_names <- function(df, auto_detect = TRUE) {
       final_mapping <- column_mapping_workflow(
         df = df,
         auto_mapping = auto_mapping,
-        options_file_name = getOption("artma.options_file_name"),
+        options_file_name = getOption("artma.options_file_name", NULL),
         force_interactive = (config_setup == "manual")
       )
     } else {
@@ -117,7 +117,7 @@ standardize_column_names <- function(df, auto_detect = TRUE) {
       final_mapping <- column_mapping_workflow(
         df = df,
         auto_mapping = list(),
-        options_file_name = getOption("artma.options_file_name"),
+        options_file_name = getOption("artma.options_file_name", NULL),
         force_interactive = TRUE
       )
     }

--- a/inst/artma/data_config/read.R
+++ b/inst/artma/data_config/read.R
@@ -26,7 +26,7 @@ get_data_config <- function(
   )
 
   # Read sparse overrides from options
-  overrides <- getOption("artma.data.config")
+  overrides <- getOption("artma.data.config", list())
   if (!is.list(overrides)) overrides <- list()
 
   # Try to build base config from the dataframe

--- a/inst/artma/data_config/resolve.R
+++ b/inst/artma/data_config/resolve.R
@@ -77,11 +77,11 @@ standardize_df_for_config <- function(df) {
 #'   the data pipeline).
 #' @param df *\[data.frame\]* The dataframe to cache.
 #' @param df_path *\[character, optional\]* Source path associated with the
-#'   dataframe. Defaults to `getOption("artma.data.source_path")`.
+#'   dataframe. Defaults to `getOption("artma.data.source_path", NULL)`.
 #' @return `NULL`
 prime_df_for_config_cache <- function(
   df,
-  df_path = getOption("artma.data.source_path")
+  df_path = getOption("artma.data.source_path", NULL)
 ) {
   box::use(artma / libs / core / validation[validate])
 
@@ -106,7 +106,7 @@ prime_df_for_config_cache <- function(
 read_df_for_config <- function() {
   box::use(artma / data / read[read_data])
 
-  df_path <- getOption("artma.data.source_path")
+  df_path <- getOption("artma.data.source_path", NULL)
   if (is.null(df_path) || (length(df_path) == 1 && is.na(df_path))) {
     cli::cli_abort("Cannot resolve data config: {.code artma.data.source_path} is not set.")
   }

--- a/inst/artma/data_config/utils.R
+++ b/inst/artma/data_config/utils.R
@@ -4,7 +4,7 @@
 #' @return *\[logical\]* Whether the data config is valid.
 data_config_is_valid <- function(
     config = NULL) {
-  config <- if (is.null(config)) getOption("artma.data.config") else config
+  config <- if (is.null(config)) getOption("artma.data.config", NULL) else config
   # There is potentially room for more checks here
   is.list(config)
 }

--- a/inst/artma/data_config/write.R
+++ b/inst/artma/data_config/write.R
@@ -13,20 +13,12 @@ update_data_config <- function(changes) {
     artma / libs / core / utils[get_verbosity],
     artma / data_config / defaults[build_base_config, extract_overrides],
     artma / data_config / read[get_data_config],
-    artma / data_config / resolve[read_df_for_config]
+    artma / data_config / resolve[read_df_for_config],
+    artma / options / index[require_option]
   )
 
-  options_file_name <- getOption("artma.temp.file_name")
-  options_dir <- getOption("artma.temp.dir_name")
-
-  if (is.null(options_file_name) || is.null(options_dir)) {
-    cli::cli_abort(
-      paste(
-        "There was an error loading the options file -",
-        "the options file name and directory are not set."
-      )
-    )
-  }
+  options_file_name <- require_option("artma.temp.file_name")
+  options_dir <- require_option("artma.temp.dir_name")
 
   validate(is.list(changes))
   if (is.null(changes)) changes <- list()
@@ -113,8 +105,8 @@ fix_data_config <- function(
   base_config <- build_base_config(df)
 
   # Clear all overrides -- the base config is the canonical default
-  options_file_name <- getOption("artma.temp.file_name")
-  options_dir <- getOption("artma.temp.dir_name")
+  options_file_name <- getOption("artma.temp.file_name", NULL)
+  options_dir <- getOption("artma.temp.dir_name", NULL)
 
   if (!is.null(options_file_name) && !is.null(options_dir)) {
     suppressMessages(
@@ -145,19 +137,12 @@ fix_data_config <- function(
 #'   resets all overrides.
 #' @return *\[list\]* The updated fully-resolved data config (invisibly).
 reset_config_overrides <- function(var_name = NULL) {
-  options_file_name <- getOption("artma.temp.file_name")
-  options_dir <- getOption("artma.temp.dir_name")
+  box::use(artma / options / index[require_option])
 
-  if (is.null(options_file_name) || is.null(options_dir)) {
-    cli::cli_abort(
-      paste(
-        "There was an error loading the options file -",
-        "the options file name and directory are not set."
-      )
-    )
-  }
+  options_file_name <- require_option("artma.temp.file_name")
+  options_dir <- require_option("artma.temp.dir_name")
 
-  current_overrides <- getOption("artma.data.config")
+  current_overrides <- getOption("artma.data.config", list())
   if (!is.list(current_overrides)) current_overrides <- list()
 
   if (is.null(var_name)) {

--- a/inst/artma/interactive/save_preference.R
+++ b/inst/artma/interactive/save_preference.R
@@ -105,8 +105,8 @@ save_to_options_file <- function(option_path, value) {
     {
       box::use(artma / options / files[read_options_file, write_options_file, options_file_path])
 
-      options_file_name <- getOption("artma.temp.file_name")
-      options_dir <- getOption("artma.temp.dir_name")
+      options_file_name <- getOption("artma.temp.file_name", NULL)
+      options_dir <- getOption("artma.temp.dir_name", NULL)
 
       if (is.null(options_file_name) || is.null(options_dir)) {
         if (get_verbosity() >= 2) {

--- a/inst/artma/methods/exogeneity_tests.R
+++ b/inst/artma/methods/exogeneity_tests.R
@@ -18,7 +18,7 @@ exogeneity_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.exogeneity_tests")
 
-  add_marks <- resolve_add_significance_marks("artma.methods.exogeneity_tests")
+  add_marks <- resolve_add_significance_marks()
   iv_instrument <- opt$iv_instrument %||% "automatic"
   puniform_alpha <- opt$puniform_alpha %||% 0.05
   puniform_method <- opt$puniform_method %||% "ML"

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -18,7 +18,7 @@ linear_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.linear_tests")
 
-  add_marks <- resolve_add_significance_marks("artma.methods.linear_tests")
+  add_marks <- resolve_add_significance_marks()
   bootstrap_replications <- opt$bootstrap_replications %||% 100L
   conf_level <- opt$conf_level %||% 0.95
   round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))

--- a/inst/artma/methods/nonlinear_tests.R
+++ b/inst/artma/methods/nonlinear_tests.R
@@ -15,7 +15,7 @@ nonlinear_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.nonlinear_tests")
 
-  add_marks <- resolve_add_significance_marks("artma.methods.nonlinear_tests")
+  add_marks <- resolve_add_significance_marks()
   round_to_opt <- opt$round_to
   if (length(round_to_opt) == 1 && is.na(round_to_opt)) {
     round_to_opt <- NULL

--- a/inst/artma/options/index.R
+++ b/inst/artma/options/index.R
@@ -1,6 +1,7 @@
 box::use(
   artma / options / utils[
-    get_option_group
+    get_option_group,
+    require_option
   ],
   artma / options / template[
     flatten_template_options,
@@ -11,5 +12,6 @@ box::use(
 box::export(
   flatten_template_options,
   get_option_group,
-  parse_options_from_template
+  parse_options_from_template,
+  require_option
 )

--- a/inst/artma/options/significance_marks.R
+++ b/inst/artma/options/significance_marks.R
@@ -1,54 +1,18 @@
 box::use(
-  artma / libs / core / utils[get_verbosity],
-  artma / libs / core / validation[validate],
-  artma / options / index[get_option_group]
+  artma / libs / core / validation[validate]
 )
 
-#' Resolve the add_significance_marks option across methods.
+#' Resolve the add_significance_marks option.
 #'
-#' This helper looks up the shared methods option for significance marks,
-#' falling back to any legacy, method-specific option the user may have set.
-#' It enforces type validation and gently warns when deprecated option names
-#' are encountered.
-#'
-#' @param method_path *[character?]* The fully-qualified option prefix for the
-#'   calling method (e.g. "artma.methods.linear_tests"). Provide this to allow
-#'   backwards-compatible lookups of legacy option names.
+#' Reads the single canonical template key `artma.methods.add_significance_marks`.
+#' The template default drives the value when the option is unset, so there is no
+#' per-method legacy fallback and "unset" resolves to the documented default
+#' rather than an implicit TRUE.
 #'
 #' @return *[logical]* Whether significance marks should be appended.
-resolve_add_significance_marks <- function(method_path = NULL) {
-  validate(is.null(method_path) || (is.character(method_path) && length(method_path) <= 1))
-
-  shared_options <- get_option_group("artma.methods")
-  shared_value <- shared_options$add_significance_marks
-
-  legacy_value <- NULL
-  if (!is.null(method_path)) {
-    legacy_value <- getOption(paste0(method_path, ".add_significance_marks"))
-  }
-
-  if (is.null(shared_value) && !is.null(legacy_value) && get_verbosity() >= 2) {
-    cli::cli_alert_info(
-      "Using legacy option name {.code {method_path}.add_significance_marks}. Please migrate to {.code artma.methods.add_significance_marks}."
-    )
-  }
-
-  if (!is.null(shared_value) && !is.null(legacy_value) && !identical(shared_value, legacy_value) && get_verbosity() >= 1) {
-    cli::cli_alert_warning(
-      "Ignoring legacy option value {legacy_value} for {.code {method_path}.add_significance_marks} in favour of shared {.code artma.methods.add_significance_marks}."
-    )
-  }
-
-  resolved <- shared_value
-  if (is.null(resolved)) {
-    resolved <- legacy_value
-  }
-  if (is.null(resolved)) {
-    resolved <- TRUE
-  }
-
+resolve_add_significance_marks <- function() {
+  resolved <- getOption("artma.methods.add_significance_marks", TRUE)
   validate(is.logical(resolved), length(resolved) == 1)
-
   as.logical(resolved)
 }
 

--- a/inst/artma/options/template.R
+++ b/inst/artma/options/template.R
@@ -312,15 +312,20 @@ resolve_option_value <- function(
 
 
 #' @title Coerce an option value
-#' @description A helper function that attempts to coerce an option value to the correct type. If it fails, it passes the value as is.
-#' @param val [any] The value to validate or coerce.
+#' @description Coerce an option value to the type declared in its template
+#'   definition. Coercion is fail-loud: if the value cannot be represented as the
+#'   expected type (a non-numeric in a numeric option, a fractional in an integer
+#'   option, a value outside an enum's members), it aborts naming the option, the
+#'   raw value, and the expected type instead of silently returning the original.
+#' @param val [any] The value to coerce.
 #' @param opt [list] The option definition.
 #' `any` The coerced value.
 #' @keywords internal
 coerce_option_value <- function(val, opt) {
   box::use(
     artma / const[CONST],
-    artma / libs / core / utils[get_verbosity]
+    artma / libs / core / utils[get_verbosity],
+    artma / options / utils[parse_template_enum_value]
   )
 
   # If the value is NULL, there's nothing to coerce
@@ -332,50 +337,72 @@ coerce_option_value <- function(val, opt) {
     return(val)
   }
 
-  # Enumerations, e.g. "enum: red|blue|green", return as is
-  if (startsWith(opt$type, "enum:")) {
-    return(val)
-  }
-
-  enforce_na_allowed <- function(val, opt) {
-    if (any(is.na(val)) && !isTRUE(opt$allow_na)) {
+  enforce_na_allowed <- function(v) {
+    if (any(is.na(v)) && !isTRUE(opt$allow_na)) {
       cli::cli_abort("Option {CONST$STYLES$OPTIONS$NAME(opt$name)} does not allow NA values.")
     }
   }
 
-  tryCatch(
-    {
-      enforce_na_allowed(val, opt)
+  abort_coercion <- function(expected_type) {
+    cli::cli_abort(c(
+      "Cannot coerce option {CONST$STYLES$OPTIONS$NAME(opt$name)} to {CONST$STYLES$OPTIONS$TYPE(expected_type)}.",
+      "x" = "Raw value: {CONST$STYLES$OPTIONS$VALUE(val)}."
+    ))
+  }
 
-      coerced_val <- switch(opt$type,
-        character = as.character(val),
-        integer = as.integer(val),
-        logical = as.logical(val),
-        numeric = as.numeric(val),
-        list = as.list(val),
-        val
-      )
+  enforce_na_allowed(val)
 
-      if (isTRUE(opt$standardize) && opt$type == "character") {
-        standard_val <- make.names(coerced_val)
-        if (standard_val != coerced_val && !is.na(coerced_val)) {
-          if (get_verbosity() >= 2) {
-            cli::cli_alert_warning(
-              "Option {CONST$STYLES$OPTIONS$NAME(opt$name)} does not allow non-standard values. Standardizing from {CONST$STYLES$OPTIONS$VALUE(val)} to {CONST$STYLES$OPTIONS$VALUE(standard_val)}."
-            )
-          }
-        }
-        coerced_val <- standard_val
-      }
+  # Enumerations, e.g. "enum: red|blue|green": coerce to character and validate membership.
+  if (startsWith(opt$type, "enum:")) {
+    coerced_val <- as.character(val)
+    valid_values <- parse_template_enum_value(opt$type)
+    if (!all(coerced_val %in% valid_values)) {
+      cli::cli_abort(c(
+        "Option {CONST$STYLES$OPTIONS$NAME(opt$name)} must be one of {.emph {toString(valid_values)}}.",
+        "x" = "Got: {CONST$STYLES$OPTIONS$VALUE(val)}."
+      ))
+    }
+    return(coerced_val)
+  }
 
-      # In come invalid cases, the coercion will return NA.
-      # We re-throw an error and catch it to return the original value.
-      # This makes it easier to find the invalid value afterwards.
-      enforce_na_allowed(coerced_val, opt)
-      coerced_val
+  coerce_numeric <- function(expected_type, as_fun) {
+    coerced <- suppressWarnings(as_fun(val))
+    # Coercion that manufactures NA out of a non-NA value is a failure, not a
+    # silent downgrade: surface it with the option name and raw value.
+    if (any(is.na(coerced) & !is.na(val))) {
+      abort_coercion(expected_type)
+    }
+    coerced
+  }
+
+  coerced_val <- switch(opt$type,
+    character = as.character(val),
+    integer = {
+      if (!is.numeric(val)) abort_coercion("integer")
+      non_na <- val[!is.na(val)]
+      if (any(non_na != as.integer(non_na))) abort_coercion("integer")
+      as.integer(val)
     },
-    error = function(e) val # Return the original value if coercion fails
+    logical = coerce_numeric("logical", as.logical),
+    numeric = coerce_numeric("numeric", as.numeric),
+    list = as.list(val),
+    val
   )
+
+  if (isTRUE(opt$standardize) && opt$type == "character") {
+    standard_val <- make.names(coerced_val)
+    if (standard_val != coerced_val && !is.na(coerced_val)) {
+      if (get_verbosity() >= 2) {
+        cli::cli_alert_warning(
+          "Option {CONST$STYLES$OPTIONS$NAME(opt$name)} does not allow non-standard values. Standardizing from {CONST$STYLES$OPTIONS$VALUE(val)} to {CONST$STYLES$OPTIONS$VALUE(standard_val)}."
+        )
+      }
+    }
+    coerced_val <- standard_val
+  }
+
+  enforce_na_allowed(coerced_val)
+  coerced_val
 }
 
 #' @title Parse options from a template
@@ -438,6 +465,7 @@ parse_options_from_template <- function(
 }
 
 box::export(
+  coerce_option_value,
   collect_leaf_paths,
   flatten_template_options,
   flatten_user_options,

--- a/inst/artma/options/utils.R
+++ b/inst/artma/options/utils.R
@@ -133,6 +133,28 @@ parse_options_file_name <- function(input_string) {
   str_out
 }
 
+#' @title Require an option value
+#' @description Read an option that must already be set, aborting with a clear,
+#'   named-option message when it is `NULL` (i.e. unset). Use this at call sites
+#'   that read a genuinely required key, so a missing value fails at the boundary
+#'   instead of propagating as a `NULL` dereference deeper in the pipeline.
+#' @param key *\[character\]* The fully-qualified option name (e.g.
+#'   `"artma.data.source_path"`).
+#' @return The option value (never `NULL`).
+#' @export
+require_option <- function(key) {
+  box::use(artma / const[CONST])
+
+  val <- getOption(key)
+  if (is.null(val)) {
+    cli::cli_abort(c(
+      "Required option {CONST$STYLES$OPTIONS$NAME(key)} is not set.",
+      "i" = "This value is populated when options are loaded; ensure options are loaded before this call."
+    ))
+  }
+  val
+}
+
 #' A helper function to map the expected type from an option definition.
 get_expected_type <- function(opt_def) {
   # If an explicit type is given, use that.
@@ -184,7 +206,7 @@ validate_option_value <- function(val, opt_type, opt_name, allow_na = FALSE) {
 
   switch(opt_type,
     character = if (!is.character(val)) format_error(opt_name, "character", val),
-    integer = if (!is.numeric(val)) format_error(opt_name, "numeric/integer", val),
+    integer = if (!is.numeric(val) || any(val != as.integer(val), na.rm = TRUE)) format_error(opt_name, "integer", val),
     logical = if (!is.logical(val)) format_error(opt_name, "logical", val),
     numeric = if (!is.numeric(val)) format_error(opt_name, "numeric", val),
     NULL
@@ -230,6 +252,7 @@ box::export(
   parse_template_enum_value,
   print_options_help_text,
   remove_options_with_prefix,
+  require_option,
   validate_option_value,
   validate_user_input
 )

--- a/inst/artma/output/export.R
+++ b/inst/artma/output/export.R
@@ -10,8 +10,8 @@ is_auto_output_dir <- function(output_dir) {
 persist_auto_output_dir <- function(output_dir) {
   box::use(artma / libs / core / utils[get_verbosity])
 
-  options_file_name <- getOption("artma.temp.file_name")
-  options_dir <- getOption("artma.temp.dir_name")
+  options_file_name <- getOption("artma.temp.file_name", NULL)
+  options_dir <- getOption("artma.temp.dir_name", NULL)
 
   if (is.null(options_file_name) || is.null(options_dir)) {
     if (get_verbosity() >= 4) {

--- a/tests/testthat/test-options-significance-marks.R
+++ b/tests/testthat/test-options-significance-marks.R
@@ -15,25 +15,27 @@ test_that("shared significance option controls output", {
     "artma.methods.add_significance_marks" = FALSE
   )
 
-  expect_false(resolve_add_significance_marks("artma.methods.linear_tests"))
+  expect_false(resolve_add_significance_marks())
 })
 
-test_that("legacy option names are still honoured when shared is unset", {
+test_that("legacy per-method option names are ignored", {
   local_options(
     "artma.verbose" = 0,
     "artma.methods.add_significance_marks" = NULL,
-    "artma.methods.linear_tests.add_significance_marks" = TRUE
+    "artma.methods.linear_tests.add_significance_marks" = FALSE
   )
 
-  expect_true(resolve_add_significance_marks("artma.methods.linear_tests"))
+  # Only the canonical key drives the value; with it unset, the template default
+  # (TRUE) applies rather than the legacy per-method key.
+  expect_true(resolve_add_significance_marks())
 })
 
-test_that("shared option overrides conflicting legacy values", {
+test_that("canonical option overrides any legacy value", {
   local_options(
     "artma.verbose" = 0,
     "artma.methods.add_significance_marks" = FALSE,
     "artma.methods.linear_tests.add_significance_marks" = TRUE
   )
 
-  expect_false(resolve_add_significance_marks("artma.methods.linear_tests"))
+  expect_false(resolve_add_significance_marks())
 })

--- a/tests/testthat/test-options-strict.R
+++ b/tests/testthat/test-options-strict.R
@@ -1,0 +1,111 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_true,
+    skip_if_not,
+    test_that
+  ],
+  withr[local_options]
+)
+
+box::use(
+  artma / options / utils[require_option, validate_option_value],
+  artma / options / template[coerce_option_value],
+  artma / options / significance_marks[resolve_add_significance_marks]
+)
+
+test_that("require_option returns a set value and aborts when unset", {
+  local_options("artma.temp.file_name" = "config.yaml")
+  expect_equal(require_option("artma.temp.file_name"), "config.yaml")
+
+  local_options("artma.temp.dir_name" = NULL)
+  expect_error(
+    require_option("artma.temp.dir_name"),
+    "artma.temp.dir_name"
+  )
+})
+
+test_that("coerce_option_value fails loud on a non-numeric numeric option", {
+  opt <- list(name = "calc.threshold", type = "numeric")
+  expect_error(
+    coerce_option_value("not-a-number", opt),
+    "calc.threshold"
+  )
+  expect_equal(coerce_option_value("3.5", opt), 3.5)
+})
+
+test_that("coerce_option_value rejects fractional integers", {
+  opt <- list(name = "output.number_of_decimals", type = "integer")
+  expect_error(
+    coerce_option_value(3.7, opt),
+    "output.number_of_decimals"
+  )
+  expect_equal(coerce_option_value(3, opt), 3L)
+})
+
+test_that("coerce_option_value validates enum membership", {
+  opt <- list(name = "data.reconcile_mode", type = "enum: ask|auto|strict")
+  expect_error(
+    coerce_option_value("nonsense", opt),
+    "data.reconcile_mode"
+  )
+  expect_equal(coerce_option_value("auto", opt), "auto")
+})
+
+test_that("validate_option_value rejects fractional integers", {
+  expect_false(is.null(validate_option_value(3.7, "integer", "output.number_of_decimals")))
+  expect_true(is.null(validate_option_value(3L, "integer", "output.number_of_decimals")))
+})
+
+test_that("significance marks resolve from the canonical key only", {
+  local_options(
+    "artma.verbose" = 0,
+    "artma.methods.add_significance_marks" = FALSE,
+    "artma.methods.linear_tests.add_significance_marks" = TRUE
+  )
+  # The legacy per-method key is ignored; only the canonical key drives the value.
+  expect_false(resolve_add_significance_marks())
+
+  local_options(
+    "artma.methods.add_significance_marks" = NULL,
+    "artma.methods.linear_tests.add_significance_marks" = FALSE
+  )
+  # With the canonical key unset, the template default (TRUE) applies; the legacy
+  # key does not flip it off.
+  expect_true(resolve_add_significance_marks())
+})
+
+# Grep-based enforcement: every literal `getOption("artma.<key>")` in the package
+# sources must pass an explicit default (or go through require_option). A bare
+# read returns NULL off the runtime_setup path and fails far from the cause.
+test_that("no getOption(\"artma.*\") reads omit a default", {
+  root <- normalizePath(testthat::test_path("..", ".."), winslash = "/", mustWork = FALSE)
+  dirs <- c(file.path(root, "R"), file.path(root, "inst", "artma"))
+  skip_if_not(all(dir.exists(dirs)), "package sources are not available")
+
+  files <- unlist(lapply(
+    dirs,
+    list.files,
+    pattern = "\\.R$",
+    recursive = TRUE,
+    full.names = TRUE
+  ))
+
+  # A single-argument read: getOption("artma.<key>") with the closing paren
+  # right after the key string (optional surrounding whitespace).
+  no_default_pattern <- "getOption\\(\\s*\"artma\\.[A-Za-z0-9_.]+\"\\s*\\)"
+
+  offenders <- character()
+  for (file in files) {
+    lines <- readLines(file, warn = FALSE)
+    lines <- lines[!grepl("^\\s*#", lines)] # skip comments and roxygen docs
+    hits <- grep(no_default_pattern, lines, perl = TRUE, value = TRUE)
+    if (length(hits) > 0L) {
+      offenders <- c(offenders, paste0(basename(file), ": ", trimws(hits)))
+    }
+  }
+
+  expect_equal(offenders, character(0))
+})


### PR DESCRIPTION
Closes #170

## What changed

Option reads and coercion no longer fail silently.

- **`require_option(key)`** added in `inst/artma/options/utils.R` (re-exported from `options/index.R`). It aborts with the named option when a genuinely required, runtime-populated value is unset, instead of leaking `NULL` into a `file.exists(NULL)`-style failure deeper in the pipeline. Used where a missing value is truly an error (the data-config write paths that already hand-rolled the same abort).
- **No-default read sweep.** Every `getOption("artma.*")` read now passes an explicit default or goes through `require_option`. Runtime-populated keys (`temp.*`, `data.config`, `data.source_path`, `options_file_name`) that are legitimately optional at their call site keep NULL-as-sentinel via an explicit `NULL`/`list()` default; the rest already matched the template default. A grep-based test enforces this going forward.
- **Fail-loud coercion.** `coerce_option_value` aborts with the option name, raw value, and expected type when coercion cannot represent the value (non-numeric numerics, out-of-range enums). Enums and lists are now coerced too (enum membership is validated) rather than passed through untouched.
- **Strict integer validation.** Both `coerce_option_value` and `validate_option_value` reject fractional values for `integer` options (`3.7` no longer passes), then coerce to integer.
- **Significance marks canonicalized.** `resolve_add_significance_marks()` reads only the template key `methods.add_significance_marks` and lets the template default drive the value. The private per-method legacy fallback (which defaulted to TRUE when unset, making "unset" indistinguishable from "on") is removed. Noted in NEWS.md.

## Tests

New `test-options-strict.R` covers: `require_option` aborts naming the option, a string in a numeric option aborts, `3.7` is rejected for integer, enum membership is enforced, significance-marks resolution uses the canonical key only, and a grep guard that no `getOption("artma.*")` read omits a default.

`make test` (0 failures), `LC_ALL=en_US.UTF-8 make lint` (clean), and `make check` (0 errors; the lone WARNING is an unrelated clang header warning and the NOTE is the worktree `.git` dir) all pass locally.