### PR TITLE
ci: consolidate test workflows and gate the E2E installation test

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,15 +1,20 @@
-name: Run Tests
+name: E2E Test
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - ci/consolidate-test-workflows-174
 
 permissions:
   contents: read
 
 jobs:
-  R-CMD-check:
+  test-e2e:
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -22,9 +27,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::testthat, any::devtools
+          needs: check
 
-      - name: Run testthat tests
-        run: |
-          devtools::test(stop_on_failure = TRUE)
-        shell: Rscript {0}
+      - name: Run E2E tests
+        run: make test-e2e

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - ci/consolidate-test-workflows-174
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #174

## Context

Every PR ran the full unit suite three or more times across three workflows, and the E2E installation test (tests/E2E/test-installation.R) was never wired into CI at all.

## Changes

1. Deleted `.github/workflows/test.yaml`. Its job id was literally `R-CMD-check` despite running only `devtools::test`, which collided in name with the real `R-CMD-check.yaml` job and was fully redundant with the matrix check (which already runs the suite on every combo). Deleting it also resolves the mislabeled job id directly, rather than just renaming it.
2. Kept `R-CMD-check.yaml` (the 5-combo OS/R matrix) and `test-coverage.yaml` (codecov reporting) as is. That leaves exactly two workflows that exercise the suite per PR, matching the "at most twice" acceptance criterion. Coverage reporting is a distinct concern from correctness checking, so it stays a separate workflow rather than being folded in.
3. Added `.github/workflows/test-e2e.yaml`, a new workflow running `make test-e2e` (the install-and-run-artma end to end test) on a nightly schedule (03:00 UTC) plus `workflow_dispatch` for manual runs. Set `continue-on-error: true` for a soft launch since this test has never run in CI before and may surface CI-environment issues unrelated to the code itself; failures are still visible in the run log and can be tightened to `false` once it proves stable for a while. Uses `r-lib/actions/setup-r-dependencies` to cache R packages.

## Branch protection

Checked the `master` ruleset (`gh api repos/PetrCala/artma/rulesets/4618619`) and classic branch protection (`gh api repos/PetrCala/artma/branches/master/protection`, 404 Branch not protected). Neither currently configures required status checks, so there is nothing to update or rename. If required status checks get added later, they should reference the `R-CMD-check.yaml` matrix job names (unchanged) and/or `test-coverage`; there is no longer a `test.yaml` job to reference.

## Validation note

`test-e2e.yaml` is schedule/workflow_dispatch only, so it will not run on this PR by default. I temporarily added a `push` trigger scoped to this branch to validate it in CI; I will remove that trigger before merging once confirmed green.
