### PR TITLE
test: cover p_hacking and exogeneity estimators with value-level assertions

### DIFF
--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -765,5 +765,11 @@ build_elliott_summary <- function(elliott_tests, pvalues, options) {
 
 box::export(
   run_caliper_tests,
-  run_p_hacking_tests
+  run_p_hacking_tests,
+  run_single_caliper,
+  compute_pvalues,
+  prepare_maive_data,
+  maive_p_from_coef,
+  run_binomial,
+  run_fisher
 )

--- a/tests/testthat/helper-mocking.R
+++ b/tests/testthat/helper-mocking.R
@@ -1,0 +1,39 @@
+# Test helpers for simulating absent optional packages.
+#
+# Several estimators guard their calls to Suggests packages with
+# `requireNamespace(pkg)` and take a skip / abort path when the package is
+# missing. Those packages are installed in CI, so the only way to exercise the
+# skip path is to make `requireNamespace` report them as absent. The guards live
+# inside `box` module namespaces (locked, and resolving `requireNamespace` from
+# `base`), so the mock is installed on the `base` binding itself and restored
+# when the calling frame exits.
+
+#' Pretend a set of packages is not installed for the duration of the caller.
+#'
+#' @param pkgs *[character]* Package names that `requireNamespace` should report
+#'   as absent. Every other package resolves normally.
+#' @param .local_envir *[environment]* Frame whose exit restores the original
+#'   binding. Defaults to the calling frame.
+#' @return Invisibly `NULL`. Registers a `withr::defer` cleanup.
+local_pretend_packages_absent <- function(pkgs, .local_envir = parent.frame()) {
+  original <- base::requireNamespace
+  unlockBinding("requireNamespace", baseenv())
+  assign(
+    "requireNamespace", # nolint: object_name_linter.
+    function(package, ...) {
+      if (package %in% pkgs) {
+        return(FALSE)
+      }
+      original(package, ...)
+    },
+    envir = baseenv()
+  )
+  withr::defer(
+    {
+      assign("requireNamespace", original, envir = baseenv()) # nolint: object_name_linter.
+      lockBinding("requireNamespace", baseenv())
+    },
+    envir = .local_envir
+  )
+  invisible(NULL)
+}

--- a/tests/testthat/test-econometric-exogeneity.R
+++ b/tests/testthat/test-econometric-exogeneity.R
@@ -1,0 +1,185 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_true,
+    skip_if_not_installed,
+    test_that
+  ],
+  withr[local_options],
+  artma / econometric / exogeneity[
+    run_iv_regression,
+    run_puniform_star,
+    find_best_instrument,
+    run_exogeneity_tests
+  ]
+)
+
+# A meta-analysis DGP with a known effect and a valid instrument.
+#
+#   se_i        = 2 / sqrt(n_obs_i) + noise      (relevance: se depends on n_obs)
+#   effect_i    = mu + bias * se_i + eps_i       (mu and bias are recoverable)
+#
+# An IV regression of effect on se, instrumented by a function of n_obs, should
+# recover the intercept (effect beyond bias ~ mu) and the slope (publication
+# bias ~ bias).
+make_exogeneity_df <- function(seed = 2024, n = 300, mu = 0.5, bias = 1.0) {
+  set.seed(seed)
+  n_obs <- sample(30:600, n, replace = TRUE)
+  se <- 2 / sqrt(n_obs) + abs(rnorm(n, 0, 0.01))
+  effect <- mu + bias * se + rnorm(n, 0, 0.05)
+  data.frame(
+    effect = effect,
+    se = se,
+    study_id = rep(seq_len(60), length.out = n),
+    n_obs = n_obs,
+    study_size = n_obs
+  )
+}
+
+default_exogeneity_options <- function(...) {
+  defaults <- list(
+    iv_instrument = "automatic",
+    add_significance_marks = TRUE,
+    round_to = 3L,
+    puniform_alpha = 0.05,
+    puniform_method = "ML"
+  )
+  utils::modifyList(defaults, list(...))
+}
+
+# run_iv_regression ---------------------------------------------------------
+
+test_that("run_iv_regression recovers the effect and bias from a known DGP", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  df <- make_exogeneity_df()
+  res <- run_iv_regression(df, iv_instrument = "1/sqrt(n_obs)")
+
+  expect_equal(res$coefficients$term, c("effect", "publication_bias"))
+  effect_est <- res$coefficients$estimate[res$coefficients$term == "effect"]
+  bias_est <- res$coefficients$estimate[res$coefficients$term == "publication_bias"]
+
+  # Recovers mu = 0.5 and bias = 1.0 within sampling error.
+  expect_equal(effect_est, 0.5, tolerance = 0.05)
+  expect_equal(bias_est, 1.0, tolerance = 0.2)
+  # Strong instrument: Anderson-Rubin F well above conventional weak thresholds.
+  expect_true(res$ar_fstat > 30)
+})
+
+test_that("run_iv_regression auto-selects the sample-size instrument", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  df <- make_exogeneity_df()
+  res <- run_iv_regression(df, iv_instrument = "automatic")
+
+  expect_equal(res$instrument_name, "1/sqrt(n_obs)")
+  expect_equal(nrow(res$coefficients), 2L)
+})
+
+test_that("run_iv_regression rejects an instrument without n_obs", {
+  skip_if_not_installed("AER")
+  df <- make_exogeneity_df()
+  expect_error(run_iv_regression(df, iv_instrument = "1/sqrt(study_size)"))
+})
+
+# find_best_instrument ------------------------------------------------------
+
+test_that("find_best_instrument returns one of the candidate instruments", {
+  skip_if_not_installed("AER")
+  local_options(artma.verbose = 1)
+
+  df <- make_exogeneity_df()
+  instruments <- list(1 / sqrt(df$n_obs), 1 / df$n_obs, log(df$n_obs))
+  names_verbose <- c("1/sqrt(n_obs)", "1/n_obs", "log(n_obs)")
+
+  best <- find_best_instrument(df, instruments, names_verbose)
+  expect_true(all(best %in% names_verbose))
+})
+
+# run_puniform_star ---------------------------------------------------------
+
+test_that("run_puniform_star returns NA estimates without enough significant studies", {
+  set.seed(7)
+  n <- 40
+  # z-scores well below 1.96: no study is significant, so the estimator bails.
+  df <- data.frame(
+    effect = rnorm(n, 0.001, 0.001),
+    se = rep(1, n),
+    study_id = rep(seq_len(10), length.out = n),
+    study_size = sample(20:50, n, replace = TRUE),
+    n_obs = sample(20:50, n, replace = TRUE)
+  )
+
+  res <- run_puniform_star(df)
+
+  expect_equal(res$coefficients$term, c("effect", "publication_bias_test"))
+  expect_true(is.na(res$coefficients$estimate[1]))
+  expect_true(is.na(res$test_p_value))
+})
+
+test_that("run_puniform_star returns a finite estimate with significant studies", {
+  set.seed(11)
+  n <- 120
+  df <- data.frame(
+    effect = rnorm(n, 0.4, 0.03),
+    se = rep(0.05, n),
+    study_id = rep(seq_len(30), each = 4),
+    study_size = sample(50:200, n, replace = TRUE),
+    n_obs = sample(50:200, n, replace = TRUE)
+  )
+
+  res <- run_puniform_star(df)
+  expect_true(is.finite(res$coefficients$estimate[1]))
+})
+
+# run_exogeneity_tests ------------------------------------------------------
+
+test_that("run_exogeneity_tests assembles IV and p-uniform results", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  df <- make_exogeneity_df()
+  res <- run_exogeneity_tests(df, default_exogeneity_options())
+
+  expect_true(all(c("iv", "puniform", "summary") %in% names(res)))
+  expect_true(is.data.frame(res$summary))
+  expect_equal(nrow(res$summary), 6L)
+  expect_true("IV" %in% colnames(res$summary))
+
+  effect_est <- res$iv$coefficients$estimate[res$iv$coefficients$term == "effect"]
+  expect_equal(effect_est, 0.5, tolerance = 0.05)
+})
+
+test_that("run_exogeneity_tests skips gracefully when columns are missing", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  res <- run_exogeneity_tests(data.frame(effect = 1:3, se = rep(1, 3)), default_exogeneity_options())
+
+  expect_true(!is.null(res$skipped))
+  expect_true(grepl("study_id", res$skipped$reason))
+})
+
+test_that("run_exogeneity_tests aborts when a required package is absent", {
+  local_options(artma.verbose = 1)
+  df <- make_exogeneity_df(n = 30)
+
+  local_pretend_packages_absent("AER")
+  expect_error(run_exogeneity_tests(df, default_exogeneity_options()), regexp = "AER")
+})
+
+test_that("run_exogeneity_tests aborts when ivmodel is absent", {
+  skip_if_not_installed("AER")
+  local_options(artma.verbose = 1)
+  df <- make_exogeneity_df(n = 30)
+
+  local_pretend_packages_absent("ivmodel")
+  expect_error(run_exogeneity_tests(df, default_exogeneity_options()), regexp = "ivmodel")
+})

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -1,0 +1,258 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_true,
+    test_that
+  ],
+  withr[local_options],
+  artma / econometric / p_hacking[
+    compute_pvalues,
+    maive_p_from_coef,
+    prepare_maive_data,
+    run_single_caliper,
+    run_binomial,
+    run_fisher,
+    run_caliper_tests,
+    run_p_hacking_tests
+  ]
+)
+
+# compute_pvalues -----------------------------------------------------------
+
+test_that("compute_pvalues returns two-sided normal p-values", {
+  # t = effect / se; p = 2 * pnorm(-|t|)
+  effect <- c(0, 1.96, qnorm(0.995), -1.96)
+  se <- c(1, 1, 1, 1)
+
+  pvals <- compute_pvalues(effect, se)
+
+  expect_equal(pvals[1], 1, tolerance = 1e-12)
+  expect_equal(pvals[2], 0.0499957902964409, tolerance = 1e-12)
+  expect_equal(pvals[3], 0.01, tolerance = 1e-12)
+  # Symmetric in the sign of the effect
+  expect_equal(pvals[2], pvals[4], tolerance = 1e-12)
+})
+
+test_that("compute_pvalues errors on mismatched lengths", {
+  expect_error(compute_pvalues(c(1, 2), c(1)))
+})
+
+# maive_p_from_coef ---------------------------------------------------------
+
+test_that("maive_p_from_coef matches the two-sided normal p-value", {
+  expect_equal(maive_p_from_coef(1.96, 1), 0.0499957902964409, tolerance = 1e-12)
+  expect_equal(maive_p_from_coef(0, 2), 1, tolerance = 1e-12)
+})
+
+test_that("maive_p_from_coef returns NA for degenerate inputs", {
+  expect_true(is.na(maive_p_from_coef(1, 0)))
+  expect_true(is.na(maive_p_from_coef(1, -1)))
+  expect_true(is.na(maive_p_from_coef(Inf, 1)))
+  expect_true(is.na(maive_p_from_coef(1, NA_real_)))
+})
+
+# prepare_maive_data --------------------------------------------------------
+
+test_that("prepare_maive_data renames columns to the MAIVE contract", {
+  df <- data.frame(
+    effect = c(0.1, 0.2, 0.3),
+    se = c(0.05, 0.06, 0.07),
+    n_obs = c(100, 200, 300),
+    study_id = c(1, 1, 2)
+  )
+
+  out <- prepare_maive_data(df)
+
+  expect_equal(colnames(out), c("bs", "sebs", "Ns", "studyid"))
+  expect_equal(out$bs, df$effect)
+  expect_equal(out$sebs, df$se)
+  expect_equal(out$Ns, df$n_obs)
+  expect_equal(out$studyid, df$study_id)
+})
+
+test_that("prepare_maive_data omits studyid when study_id is absent", {
+  df <- data.frame(effect = 1, se = 0.1, n_obs = 10)
+  out <- prepare_maive_data(df)
+  expect_equal(colnames(out), c("bs", "sebs", "Ns"))
+})
+
+test_that("prepare_maive_data errors when required columns are missing", {
+  expect_error(prepare_maive_data(data.frame(effect = 1, se = 0.1)))
+})
+
+# run_single_caliper --------------------------------------------------------
+
+test_that("run_single_caliper counts observations on each side of the threshold", {
+  # Interval around 1.96 with width 0.05 is (1.91, 2.01).
+  #   in-interval: 1.92, 1.93 (below), 1.97, 1.99 (above)
+  #   excluded:    0.50, 3.00
+  t_stats <- c(1.92, 1.93, 1.97, 1.99, 0.50, 3.00)
+  study_id <- seq_along(t_stats)
+
+  res <- run_single_caliper(t_stats, study_id, threshold = 1.96, width = 0.05)
+
+  expect_equal(res$n_above, 2)
+  expect_equal(res$n_below, 2)
+  expect_true(is.finite(res$estimate))
+  expect_true(is.finite(res$std_error))
+})
+
+test_that("run_single_caliper returns NA estimate when the interval is empty", {
+  t_stats <- c(0.1, 0.2, 0.3)
+  res <- run_single_caliper(t_stats, seq_along(t_stats), threshold = 1.96, width = 0.05)
+
+  expect_true(is.na(res$estimate))
+  expect_equal(res$n_above, 0)
+  expect_equal(res$n_below, 0)
+})
+
+# run_caliper_tests ---------------------------------------------------------
+
+test_that("run_caliper_tests produces one cell per threshold-width pair", {
+  local_options(artma.verbose = 1)
+  set.seed(101)
+  t_stats <- c(rnorm(50, 1.96, 0.1), rnorm(50, 0, 1))
+  study_id <- rep(seq_len(20), length.out = length(t_stats))
+
+  results <- run_caliper_tests(
+    t_stats = t_stats,
+    study_id = study_id,
+    thresholds = c(1.96, 2.58),
+    widths = c(0.05, 0.1),
+    show_progress = FALSE
+  )
+
+  expect_equal(length(results), 4L)
+  thresholds_seen <- vapply(results, function(x) x$threshold, numeric(1))
+  widths_seen <- vapply(results, function(x) x$width, numeric(1))
+  expect_equal(sort(unique(thresholds_seen)), c(1.96, 2.58))
+  expect_equal(sort(unique(widths_seen)), c(0.05, 0.1))
+  expect_true(all(vapply(results, function(x) x$n_above >= 0, logical(1))))
+})
+
+# Elliott wrappers ----------------------------------------------------------
+
+test_that("run_binomial matches the upper-tail binomial p-value", {
+  # p-values inside [0, 0.05]; midpoint is 0.025.
+  #   above midpoint: 0.03, 0.04  -> kk = 2, nn = 4
+  #   p = 1 - pbinom(kk - 1, nn, 0.5) = 1 - pbinom(1, 4, 0.5) = 0.6875
+  pvalues <- c(0.01, 0.02, 0.03, 0.04)
+  expect_equal(run_binomial(pvalues, 0, 0.05, type = "c"), 0.6875, tolerance = 1e-12)
+})
+
+test_that("run_binomial validates its interval and type", {
+  expect_error(run_binomial(c(0.01, 0.02), 0.05, 0.05))
+  expect_error(run_binomial(c(0.01, 0.02), 0, 0.05, type = "x"))
+})
+
+test_that("run_fisher matches the chi-squared tail probability", {
+  # stat = -2 * sum(log(1 - (p - p_min) / (p_max - p_min))); df = 2 * n
+  pvalues <- c(0.01, 0.02)
+  expect_equal(run_fisher(pvalues, 0, 0.05), 0.832305204038496, tolerance = 1e-12)
+})
+
+test_that("run_fisher flags clustering just below the threshold", {
+  # p-values bunched near the upper bound (just-significant) are the p-hacking
+  # signature and must yield a smaller p-value than p-values spread near zero.
+  near_threshold <- c(0.048, 0.049, 0.0495, 0.0499)
+  near_zero <- c(0.001, 0.002, 0.003, 0.004)
+
+  p_suspicious <- run_fisher(near_threshold, 0, 0.05)
+  p_clean <- run_fisher(near_zero, 0, 0.05)
+
+  expect_true(p_suspicious < p_clean)
+  expect_true(p_suspicious < 0.05)
+})
+
+# run_p_hacking_tests integration -------------------------------------------
+
+base_p_hacking_options <- function(...) {
+  defaults <- list(
+    include_caliper = TRUE,
+    caliper_thresholds = c(1.96, 2.58),
+    caliper_widths = c(0.05, 0.1),
+    caliper_display_ratios = TRUE,
+    include_elliott = FALSE,
+    lcm_iterations = 50L,
+    lcm_grid_points = 50L,
+    include_discontinuity = FALSE,
+    discontinuity_bandwidth = 0.05,
+    include_cox_shi = FALSE,
+    cox_shi_bins = 20L,
+    cox_shi_order = 2L,
+    cox_shi_bounds = 1L,
+    include_maive = FALSE,
+    maive_method = 3L,
+    maive_weight = 0L,
+    maive_instrument = 1L,
+    maive_studylevel = 2L,
+    maive_se = 1L,
+    maive_ar = 0L,
+    maive_first_stage = 0L,
+    add_significance_marks = TRUE,
+    round_to = 3L
+  )
+  utils::modifyList(defaults, list(...))
+}
+
+make_p_hacking_df <- function() {
+  # 6 observations with hand-known two-sided p-values via t = effect / se.
+  #   t = 2.576 -> p = 0.010 (significant at 0.05)
+  #   t = 2.100 -> p ~ 0.036 (significant at 0.05)
+  #   t = 1.960 -> p = 0.050 (significant at 0.05, boundary inclusive)
+  #   t = 1.500 -> p ~ 0.134
+  #   t = 1.000 -> p ~ 0.317
+  #   t = 0.500 -> p ~ 0.617
+  t_stats <- c(2.576, 2.100, 1.960, 1.500, 1.000, 0.500)
+  data.frame(
+    effect = t_stats,
+    se = rep(1, length(t_stats)),
+    study_id = c(1, 1, 2, 2, 3, 3),
+    n_obs = c(100, 120, 140, 160, 180, 200)
+  )
+}
+
+test_that("run_p_hacking_tests reports p-value counts and a caliper table", {
+  local_options(artma.verbose = 1)
+  df <- make_p_hacking_df()
+
+  result <- run_p_hacking_tests(df, base_p_hacking_options())
+
+  expect_equal(result$n_pvalues, nrow(df))
+  # p <= 0.05 for the first three rows (p = 0.010, 0.036, 0.050).
+  expect_equal(result$n_significant_005, 3L)
+  # p <= 0.10 adds none of the remaining rows (next is p ~ 0.134).
+  expect_equal(result$n_significant_010, 3L)
+  expect_true(is.data.frame(result$caliper))
+  expect_true(nrow(result$caliper) > 0)
+})
+
+test_that("run_p_hacking_tests skips gracefully when required columns are missing", {
+  local_options(artma.verbose = 1)
+  df <- data.frame(effect = c(0.1, 0.2, 0.3))
+
+  result <- run_p_hacking_tests(df, base_p_hacking_options())
+
+  expect_true(!is.null(result$skipped))
+  expect_true(grepl("se", result$skipped$reason))
+})
+
+test_that("run_p_hacking_tests runs the Elliott suite when requested", {
+  local_options(
+    artma.verbose = 1,
+    artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
+  )
+  set.seed(202)
+  df <- make_p_hacking_df()
+
+  result <- run_p_hacking_tests(
+    df,
+    base_p_hacking_options(include_caliper = FALSE, include_elliott = TRUE)
+  )
+
+  expect_true(is.data.frame(result$elliott))
+  expect_true("Binomial [0, 0.05]" %in% result$elliott$Test)
+  expect_true("Fisher [0, 0.05]" %in% result$elliott$Test)
+})


### PR DESCRIPTION
## Summary

Priority 1 of #172: numeric-correctness tests for the two estimator subsystems that had zero direct coverage. Every assertion pins a hand-computed value or a recoverable DGP parameter, not a snapshot of current output.

Part of #172.

### p-hacking (`inst/artma/econometric/p_hacking.R`)

New `tests/testthat/test-econometric-p-hacking.R`:
- `compute_pvalues` against known two-sided normal p-values (t = 1.96 gives 0.0500, t = 2.576 gives 0.010, sign-symmetric).
- `maive_p_from_coef` value and the NA guards (se <= 0, non-finite inputs).
- `prepare_maive_data` column renaming to the MAIVE contract, the optional `studyid`, and the missing-column error.
- `run_single_caliper` above/below counts around a threshold and the empty-interval NA branch.
- `run_binomial` against the exact upper-tail binomial p-value (0.6875) and its interval/type guards.
- `run_fisher` against the exact chi-squared tail probability (0.8323) plus the directional check that p-values clustered just below the threshold score lower than p-values near zero.
- `run_p_hacking_tests` integration: exact significant-count reporting, the missing-column skip, and the Elliott suite path.

To test the numeric helpers directly, they are added to the module's `box::export` list (consistent with `exogeneity.R`, which already exports its internals).

### Exogeneity (`inst/artma/econometric/exogeneity.R`)

New `tests/testthat/test-econometric-exogeneity.R`:
- `run_iv_regression` recovers the intercept (effect beyond bias) and slope (publication bias) from a controlled DGP with a valid sample-size instrument, and reports a strong Anderson-Rubin F.
- automatic instrument selection lands on `1/sqrt(n_obs)`; instruments without `n_obs` are rejected.
- `find_best_instrument` returns one of its candidates.
- `run_puniform_star` NA branch (too few significant studies) and the finite-estimate path.
- `run_exogeneity_tests` assembles the IV and p-uniform results, skips on missing columns, and aborts when a Suggests package (`AER`, `ivmodel`) is absent.

The absent-package path is exercised with a new `tests/testthat/helper-mocking.R` (`local_pretend_packages_absent`), which swaps the `base` `requireNamespace` binding and restores it on frame exit, since the guards resolve `requireNamespace` from `base` inside locked box namespaces.

## Test plan

- [x] `make test` (0 failures, 1205 passed)
- [x] `LC_ALL=en_US.UTF-8` lint of changed files (0 lints)
- [x] `make check` (0 errors; the lone WARNING is an Apple-clang header warning during Rcpp compile and the NOTE is `.git` from the worktree, both environmental)
