### PR TITLE
test: cover calc estimators, output export, and visualization subsystems

### DIFF
--- a/tests/testthat/test-calc-endo-kink.R
+++ b/tests/testthat/test-calc-endo-kink.R
@@ -1,0 +1,86 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_named,
+    expect_true,
+    test_that
+  ],
+  artma / calc / methods / endo_kink[
+    prepare_endokink_columns,
+    fit_auxiliary_lm,
+    compute_cutoff,
+    run_endogenous_kink
+  ]
+)
+
+# prepare_endokink_columns --------------------------------------------------
+
+test_that("prepare_endokink_columns derives the regression columns exactly", {
+  data <- data.frame(effect = c(0.2, 0.4, 0.6), se = c(0.1, 0.2, 0.4))
+  out <- prepare_endokink_columns(data)
+
+  expect_named(out, c("bs", "sebs", "ones", "sebs2", "wis", "bs_sebs", "ones_sebs", "bswis"))
+  expect_equal(out$bs, c(0.2, 0.4, 0.6))
+  expect_equal(out$sebs, c(0.1, 0.2, 0.4))
+  expect_equal(out$sebs2, c(0.01, 0.04, 0.16))
+  expect_equal(out$wis, 1 / c(0.01, 0.04, 0.16))
+  expect_equal(out$bs_sebs, c(2.0, 2.0, 1.5))
+  expect_equal(out$ones_sebs, c(10.0, 5.0, 2.5))
+  expect_equal(out$bswis, c(0.2, 0.4, 0.6) / c(0.01, 0.04, 0.16))
+})
+
+# compute_cutoff ------------------------------------------------------------
+
+test_that("compute_cutoff matches its closed form above the kink", {
+  # estimate > 1.96 * sd -> (est - 1.96 sd)(est + 1.96 sd) / (2 * 1.96 * est)
+  expected <- (0.5 - 1.96 * 0.1) * (0.5 + 1.96 * 0.1) / (2 * 1.96 * 0.5)
+  expect_equal(compute_cutoff(0.5, 0.1), expected)
+})
+
+test_that("compute_cutoff is zero when the estimate is within the band", {
+  expect_equal(compute_cutoff(0.1, 0.5), 0)
+})
+
+# fit_auxiliary_lm ----------------------------------------------------------
+
+test_that("fit_auxiliary_lm returns the requested coefficient of a fitted lm", {
+  data <- prepare_endokink_columns(
+    data.frame(effect = c(0.2, 0.4, 0.6, 0.1, 0.5), se = c(0.1, 0.2, 0.4, 0.15, 0.3))
+  )
+  fit <- fit_auxiliary_lm(bs_sebs ~ 0 + ones_sebs + ones, data, "ones_sebs")
+
+  reference <- summary(stats::lm(bs_sebs ~ 0 + ones_sebs + ones, data = data))$coefficients
+  expect_equal(fit$estimate, unname(reference["ones_sebs", "Estimate"]))
+  expect_equal(fit$std_error, unname(reference["ones_sebs", "Std. Error"]))
+  expect_true(inherits(fit$model, "lm"))
+})
+
+# run_endogenous_kink -------------------------------------------------------
+
+test_that("run_endogenous_kink recovers a homogeneous true effect", {
+  set.seed(5)
+  n <- 40
+  se <- runif(n, 0.05, 0.5)
+  # No publication bias: effect centred on mu = 0.3 with sampling noise ~ se.
+  effect <- 0.3 + rnorm(n, 0, se)
+
+  out <- run_endogenous_kink(data.frame(effect, se), verbose = FALSE)
+
+  expect_length(out, 4L)
+  # First element is the mean-effect estimate.
+  expect_equal(unname(out[1]), 0.3, tolerance = 0.1)
+  expect_true(is.finite(out[2]))
+})
+
+test_that("run_endogenous_kink is deterministic for identical input", {
+  set.seed(5)
+  n <- 40
+  se <- runif(n, 0.05, 0.5)
+  effect <- 0.3 + rnorm(n, 0, se)
+  df <- data.frame(effect, se)
+
+  first <- run_endogenous_kink(df, verbose = FALSE)
+  second <- run_endogenous_kink(df, verbose = FALSE)
+  expect_equal(first, second)
+})

--- a/tests/testthat/test-calc-maive.R
+++ b/tests/testthat/test-calc-maive.R
@@ -1,0 +1,42 @@
+box::use(
+  testthat[
+    expect_error,
+    expect_true,
+    skip_if_not_installed,
+    test_that
+  ],
+  artma / calc / methods / maive[maive]
+)
+
+make_maive_data <- function(seed = 9, n = 40) {
+  set.seed(seed)
+  data.frame(
+    bs = rnorm(n, 0.3, 0.1),
+    sebs = runif(n, 0.05, 0.4),
+    Ns = sample(50:400, n, replace = TRUE)
+  )
+}
+
+test_that("maive dispatches to the MAIVE package and returns its contract", {
+  skip_if_not_installed("MAIVE")
+  dat <- make_maive_data()
+
+  # Numeric method/weight args are coerced to integer before dispatch.
+  res <- maive(dat, method = 1, weight = 0, instrument = 1, studylevel = 0, SE = 1, AR = 0)
+
+  expect_true(is.list(res))
+  expect_true(all(c("beta", "SE", "F-test") %in% names(res)))
+  expect_true(is.numeric(res$beta) && is.finite(res$beta))
+  expect_true(is.numeric(res$SE) && is.finite(res$SE))
+})
+
+test_that("maive aborts when required columns are missing", {
+  skip_if_not_installed("MAIVE")
+  expect_error(maive(data.frame(bs = 1:3, sebs = rep(0.1, 3)), SE = 1L), regexp = "Ns")
+})
+
+test_that("maive aborts when the MAIVE package is absent", {
+  dat <- make_maive_data(n = 20)
+  local_pretend_packages_absent("MAIVE")
+  expect_error(maive(dat, SE = 1L), regexp = "MAIVE")
+})

--- a/tests/testthat/test-calc-selection-model.R
+++ b/tests/testthat/test-calc-selection-model.R
@@ -1,0 +1,101 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_true,
+    test_that
+  ],
+  artma / calc / methods / selection_model[
+    compute_tpowers,
+    variation_variance_loglikelihood,
+    clustered_covariance_estimate,
+    estimates_table,
+    metastudies_estimation
+  ]
+)
+
+# compute_tpowers -----------------------------------------------------------
+
+test_that("compute_tpowers builds symmetric significance indicators", {
+  tp <- compute_tpowers(c(0.5, 1.5, 2.5), cutoffs = 1.96, symmetric = TRUE)
+  # column 1: |t| < 1.96; column 2: |t| >= 1.96
+  expect_equal(tp[, 1], c(1, 1, 0))
+  expect_equal(tp[, 2], c(0, 0, 1))
+})
+
+test_that("compute_tpowers keeps the sign when asymmetric", {
+  tp <- compute_tpowers(c(-2.5, 0.5, 2.5), cutoffs = 1.96, symmetric = FALSE)
+  # column 1: t < 1.96 (true for -2.5 and 0.5); column 2: t >= 1.96
+  expect_equal(tp[, 1], c(1, 1, 0))
+  expect_equal(tp[, 2], c(0, 0, 1))
+})
+
+test_that("compute_tpowers partitions multiple cutoffs into adjacent bins", {
+  tp <- compute_tpowers(c(0.5, 1.2, 2.0), cutoffs = c(1, 1.64), symmetric = TRUE)
+  # bins: [0,1), [1,1.64), [1.64, Inf)
+  expect_equal(tp[, 1], c(1, 0, 0))
+  expect_equal(tp[, 2], c(0, 1, 0))
+  expect_equal(tp[, 3], c(0, 0, 1))
+  # Each row is a partition (exactly one bin).
+  expect_equal(rowSums(tp), c(1, 1, 1))
+})
+
+# variation_variance_loglikelihood ------------------------------------------
+
+test_that("variation_variance_loglikelihood aggregates the per-observation logs", {
+  set.seed(1)
+  x <- rnorm(8, 0.3, 0.1)
+  sigma <- rep(0.1, 8)
+  tp <- compute_tpowers(x / sigma, cutoffs = 1.96, symmetric = TRUE)
+
+  ll <- variation_variance_loglikelihood(0.3, 0.05, c(1, 1), 1.96, TRUE, x, sigma, tp)
+
+  expect_length(ll$logL, 8L)
+  expect_true(is.finite(ll$LLH))
+  # LLH is the negated sum of the individual log-likelihoods.
+  expect_equal(ll$LLH, -sum(ll$logL))
+})
+
+# clustered_covariance_estimate ---------------------------------------------
+
+test_that("clustered_covariance_estimate returns a symmetric p-by-p matrix", {
+  set.seed(3)
+  scores <- matrix(rnorm(30), ncol = 3)
+  clusters <- rep(seq_len(5), each = 2)
+
+  cov <- clustered_covariance_estimate(scores, clusters)
+
+  expect_equal(dim(cov), c(3L, 3L))
+  expect_equal(cov, t(cov))
+})
+
+# estimates_table -----------------------------------------------------------
+
+test_that("estimates_table lays out estimates and standard errors", {
+  psi <- c(0.3, 0.1, 0.8)
+  se <- c(0.05, 0.02, 0.1)
+
+  tab <- estimates_table(psi, se, cutoffs = 1.96, symmetric = TRUE, model = "normal")
+
+  expect_equal(rownames(tab), c("estimate", "standard error"))
+  expect_equal(unname(tab["estimate", ]), psi)
+  expect_equal(unname(tab["standard error", ]), se)
+  # mu and tau are the first two column labels.
+  expect_equal(colnames(tab)[1], intToUtf8(956))
+  expect_equal(colnames(tab)[2], intToUtf8(964))
+})
+
+# metastudies_estimation ----------------------------------------------------
+
+test_that("metastudies_estimation recovers a homogeneous true effect", {
+  set.seed(5)
+  n <- 40
+  se <- runif(n, 0.05, 0.5)
+  effect <- 0.3 + rnorm(n, 0, se)
+
+  fit <- metastudies_estimation(effect, se, cutoffs = 1.96, symmetric = TRUE, model = "normal")
+
+  # Psihat = c(mu, tau, publication weight); mu is the mean effect.
+  expect_equal(fit$Psihat[1], 0.3, tolerance = 0.1)
+  expect_length(fit$SE, length(fit$Psihat))
+  expect_true(all(fit$Psihat[-1] >= 0))
+})

--- a/tests/testthat/test-calc-stem.R
+++ b/tests/testthat/test-calc-stem.R
@@ -1,0 +1,88 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_true,
+    test_that
+  ],
+  artma / calc / methods / stem[
+    weighted_mean,
+    variance_b,
+    variance_0,
+    compute_submatrix_sums,
+    stem
+  ]
+)
+
+# weighted_mean -------------------------------------------------------------
+
+test_that("weighted_mean is the running inverse-variance weighted mean", {
+  # Equal weights (se = 1, sigma = 0): cumulative arithmetic mean.
+  expect_equal(weighted_mean(c(1, 2, 3), c(1, 1, 1), 0), c(1, 1.5, 2))
+})
+
+test_that("weighted_mean honours unequal precisions", {
+  beta <- c(1, 3)
+  se <- c(1, 2)
+  sigma <- 0
+  weights <- 1 / se^2
+  expected <- c(beta[1], sum(beta * weights) / sum(weights))
+  expect_equal(weighted_mean(beta, se, sigma), expected)
+})
+
+# variance_b ----------------------------------------------------------------
+
+test_that("variance_b is the reciprocal cumulative precision", {
+  expect_equal(variance_b(c(1, 1, 1), 0), 1 / cumsum(c(1, 1, 1)))
+  expect_equal(variance_b(c(1, 1, 1), 0), c(1, 0.5, 1 / 3))
+})
+
+# variance_0 ----------------------------------------------------------------
+
+test_that("variance_0 returns zero when dispersion matches sampling error", {
+  # sum(w * (beta - mean)^2) = q - 1 degrees of freedom cancels the numerator.
+  expect_equal(variance_0(3, c(1, 2, 3), c(1, 1, 1), 2), 0)
+})
+
+test_that("variance_0 matches its closed form with excess dispersion", {
+  beta <- c(0, 2, 4)
+  se <- c(1, 1, 1)
+  mean_val <- 2
+  # weights = 1; numerator = sum((beta-mean)^2) - (n-1) = 8 - 2 = 6
+  # denominator = sum(w) - sum(w^2)/sum(w) = 3 - 1 = 2 -> 3
+  expect_equal(variance_0(3, beta, se, mean_val), 3)
+})
+
+# compute_submatrix_sums ----------------------------------------------------
+
+test_that("compute_submatrix_sums returns leading principal block sums", {
+  m <- matrix(1:9, nrow = 3)
+  # top-left 1x1 = 1; 2x2 = 1+2+4+5 = 12; 3x3 = sum(1:9) = 45
+  expect_equal(compute_submatrix_sums(m), c(1, 12, 45))
+})
+
+# stem ----------------------------------------------------------------------
+
+test_that("stem recovers a homogeneous true effect", {
+  set.seed(5)
+  n <- 40
+  se <- runif(n, 0.05, 0.5)
+  effect <- 0.3 + rnorm(n, 0, se)
+
+  out <- stem(effect, se, c(1e-4, 100))
+
+  expect_true(is.matrix(out$estimates))
+  expect_equal(unname(out$estimates[1, "estimate"]), 0.3, tolerance = 0.1)
+  expect_true(out$estimates[1, "se"] > 0)
+  # The stem uses a subset of at least the three most precise studies.
+  expect_true(out$estimates[1, "n_stem"] >= 3)
+  expect_true(out$estimates[1, "n_stem"] <= n)
+})
+
+test_that("stem is deterministic for identical input", {
+  set.seed(5)
+  n <- 40
+  se <- runif(n, 0.05, 0.5)
+  effect <- 0.3 + rnorm(n, 0, se)
+
+  expect_equal(stem(effect, se, c(1e-4, 100)), stem(effect, se, c(1e-4, 100)))
+})

--- a/tests/testthat/test-output-export.R
+++ b/tests/testthat/test-output-export.R
@@ -1,0 +1,140 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_true,
+    test_that
+  ],
+  withr[local_options, local_tempdir],
+  artma / output / export[
+    resolve_output_dir,
+    resolve_graphics_dir,
+    ensure_output_dirs,
+    export_results
+  ]
+)
+
+# resolve_output_dir --------------------------------------------------------
+
+test_that("resolve_output_dir falls back to a session temp dir when auto", {
+  local_options(artma.output.dir = "auto")
+  expect_equal(resolve_output_dir(), file.path(tempdir(), "artma-results"))
+})
+
+test_that("resolve_output_dir returns an explicit path unchanged", {
+  local_options(artma.output.dir = "/some/explicit/path")
+  expect_equal(resolve_output_dir(), "/some/explicit/path")
+})
+
+# resolve_graphics_dir ------------------------------------------------------
+
+test_that("resolve_graphics_dir joins the export subdirectory", {
+  local_options(artma.visualization.export_path = "graphics")
+  expect_equal(resolve_graphics_dir("/base"), file.path("/base", "graphics"))
+})
+
+# ensure_output_dirs --------------------------------------------------------
+
+test_that("ensure_output_dirs creates the tables and graphics subdirectories", {
+  dir <- local_tempdir()
+  local_options(
+    artma.output.dir = dir,
+    artma.visualization.export_path = "graphics"
+  )
+
+  ensure_output_dirs(dir)
+
+  expect_true(dir.exists(file.path(dir, "tables")))
+  expect_true(dir.exists(file.path(dir, "graphics")))
+})
+
+# export_results ------------------------------------------------------------
+
+setup_output_dir <- function() {
+  dir <- local_tempdir(.local_envir = parent.frame())
+  local_options(
+    artma.output.dir = dir,
+    artma.visualization.export_path = "graphics",
+    artma.verbose = 1,
+    .local_envir = parent.frame()
+  )
+  ensure_output_dirs(dir)
+  dir
+}
+
+test_that("export_results writes a single summary table as <method>.csv", {
+  dir <- setup_output_dir()
+  df <- data.frame(term = c("a", "b"), estimate = c(1.5, 2.5))
+
+  export_results(list(bma = list(tables = list(summary = df))), dir)
+
+  path <- file.path(dir, "tables", "bma.csv")
+  expect_true(file.exists(path))
+  written <- utils::read.csv(path, stringsAsFactors = FALSE)
+  expect_equal(written$term, df$term)
+  expect_equal(written$estimate, df$estimate)
+})
+
+test_that("export_results names sub-tables as <method>_<key>.csv", {
+  dir <- setup_output_dir()
+  caliper <- data.frame(x = 1)
+  elliott <- data.frame(y = 2)
+  maive <- data.frame(z = 3)
+
+  export_results(
+    list(p_hacking_tests = list(tables = list(caliper = caliper, elliott = elliott, maive = maive))),
+    dir
+  )
+
+  expect_true(file.exists(file.path(dir, "tables", "p_hacking_tests_caliper.csv")))
+  expect_true(file.exists(file.path(dir, "tables", "p_hacking_tests_elliott.csv")))
+  expect_true(file.exists(file.path(dir, "tables", "p_hacking_tests_maive.csv")))
+})
+
+test_that("export_results treats generic and method-name keys as <method>.csv", {
+  dir <- setup_output_dir()
+
+  export_results(
+    list(
+      m1 = list(tables = list(coefficients = data.frame(a = 1))),
+      m2 = list(tables = list(m2 = data.frame(b = 2)))
+    ),
+    dir
+  )
+
+  expect_true(file.exists(file.path(dir, "tables", "m1.csv")))
+  expect_true(file.exists(file.path(dir, "tables", "m2.csv")))
+})
+
+test_that("export_results ignores plots and meta and skips NULL results", {
+  dir <- setup_output_dir()
+
+  export_results(
+    list(
+      with_plot = list(
+        tables = list(summary = data.frame(a = 1)),
+        plots = list(p = "not a table"),
+        meta = list(model = 1:10)
+      ),
+      empty = NULL
+    ),
+    dir
+  )
+
+  files <- list.files(file.path(dir, "tables"))
+  expect_true("with_plot.csv" %in% files)
+  # No files leak out of the plots/meta slots.
+  expect_equal(length(files), 1L)
+})
+
+test_that("export_results skips non-data-frame entries in the tables slot", {
+  dir <- setup_output_dir()
+
+  export_results(
+    list(m = list(tables = list(summary = data.frame(a = 1), junk = 1:5))),
+    dir
+  )
+
+  expect_true(file.exists(file.path(dir, "tables", "m.csv")))
+  expect_false(file.exists(file.path(dir, "tables", "m_junk.csv")))
+})

--- a/tests/testthat/test-visualization.R
+++ b/tests/testthat/test-visualization.R
@@ -1,0 +1,149 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_true,
+    test_that
+  ],
+  withr[local_options, local_tempdir],
+  artma / visualization / colors[
+    VALID_THEMES,
+    validate_theme,
+    get_colors,
+    get_background,
+    get_vline_color
+  ],
+  artma / visualization / theme[get_theme],
+  artma / visualization / export[
+    ensure_export_dir,
+    build_export_filename,
+    save_plot
+  ],
+  artma / visualization / options[
+    get_visualization_options,
+    set_visualization_option,
+    get_valid_themes
+  ]
+)
+
+# colors --------------------------------------------------------------------
+
+test_that("validate_theme accepts known themes and rejects unknown ones", {
+  expect_true(validate_theme("blue"))
+  expect_error(validate_theme("chartreuse"))
+  expect_error(validate_theme(c("blue", "red")))
+})
+
+test_that("get_colors returns the exact box_plot palette", {
+  expect_equal(
+    get_colors("blue", "box_plot"),
+    list(outlier = "#005CAB", fill = "#e6f3ff", border = "#0d4ed1")
+  )
+})
+
+test_that("get_colors returns a single hex for the funnel palette", {
+  expect_equal(get_colors("red", "funnel_plot"), "#FF0000")
+})
+
+test_that("get_colors resolves submethods", {
+  expect_equal(get_colors("blue", "t_stat_histogram", "density"), "#013091")
+})
+
+test_that("get_colors aborts on unknown method or submethod", {
+  expect_error(get_colors("blue", "no_such_method"))
+  expect_error(get_colors("blue", "t_stat_histogram", "no_such_submethod"))
+})
+
+test_that("get_background and get_vline_color return theme hex codes", {
+  expect_equal(get_background("yellow"), "#FFFFD1")
+  expect_equal(get_vline_color("blue"), "#D10D0D")
+})
+
+test_that("VALID_THEMES lists the five supported themes", {
+  expect_equal(VALID_THEMES, c("blue", "yellow", "green", "red", "purple"))
+})
+
+# theme ---------------------------------------------------------------------
+
+test_that("get_theme returns a ggplot2 theme object", {
+  th <- get_theme("green")
+  expect_true(inherits(th, "theme"))
+  expect_true(inherits(th, "gg"))
+})
+
+test_that("get_theme rejects invalid themes", {
+  expect_error(get_theme("mauve"))
+})
+
+# export --------------------------------------------------------------------
+
+test_that("build_export_filename follows the documented naming scheme", {
+  expect_equal(build_export_filename("box_plot", "country"), "box_plot_country.png")
+  expect_equal(build_export_filename("box_plot", "country", index = 2), "box_plot_country_2.png")
+  expect_equal(build_export_filename("funnel", "year", extension = "pdf"), "funnel_year.pdf")
+})
+
+test_that("ensure_export_dir creates the directory", {
+  base <- local_tempdir()
+  target <- file.path(base, "nested", "graphics")
+  expect_false(dir.exists(target))
+  ensure_export_dir(target)
+  expect_true(dir.exists(target))
+})
+
+test_that("save_plot writes a ggplot to disk and returns the path", {
+  local_options(artma.verbose = 1)
+  dir <- local_tempdir()
+  path <- file.path(dir, "plot.png")
+  plot <- ggplot2::ggplot(mtcars, ggplot2::aes(x = mpg, y = hp)) + ggplot2::geom_point()
+
+  returned <- save_plot(plot, path, width = 200, height = 200)
+
+  expect_equal(returned, path)
+  expect_true(file.exists(path))
+  expect_true(file.info(path)$size > 0)
+})
+
+test_that("save_plot rejects non-ggplot input", {
+  dir <- local_tempdir()
+  expect_error(save_plot("not a plot", file.path(dir, "x.png")))
+})
+
+# options -------------------------------------------------------------------
+
+test_that("get_visualization_options returns defaults", {
+  local_options(
+    artma.visualization.theme = NULL,
+    artma.visualization.export_graphics = NULL,
+    artma.visualization.export_path = NULL,
+    artma.visualization.graph_scale = NULL,
+    artma.output.save_results = FALSE
+  )
+
+  vis <- get_visualization_options()
+  expect_equal(vis$theme, "blue")
+  expect_true(vis$export_graphics)
+  expect_equal(vis$export_path, "graphics")
+  expect_equal(vis$graph_scale, 2)
+})
+
+test_that("set_visualization_option updates a theme and reports the previous value", {
+  local_options(
+    artma.visualization.theme = "blue",
+    artma.output.save_results = FALSE
+  )
+
+  previous <- set_visualization_option(theme = "red")
+  expect_equal(previous$theme, "blue")
+  expect_equal(getOption("artma.visualization.theme"), "red")
+})
+
+test_that("set_visualization_option rejects an invalid theme", {
+  local_options(artma.output.save_results = FALSE)
+  expect_error(set_visualization_option(theme = "octarine"))
+})
+
+test_that("get_valid_themes returns the theme vector", {
+  expect_equal(get_valid_themes(), c("blue", "yellow", "green", "red", "purple"))
+})


### PR DESCRIPTION
## Summary

Priorities 2 and 3 of #172: direct test files for the calc estimators and the output/visualization subsystems, all previously at zero coverage. Every numeric assertion pins a hand-computed value, a closed-form result, or a recoverable DGP parameter.

Part of #172.

### Calc methods (`inst/artma/calc/methods/`)

- `test-calc-endo-kink.R`: exact derived regression columns, the `compute_cutoff` closed form (both branches), `fit_auxiliary_lm` against a directly fitted `lm`, and homogeneous-effect recovery plus determinism for `run_endogenous_kink`.
- `test-calc-stem.R`: exact `weighted_mean`, `variance_b`, `variance_0` (zero-dispersion and excess-dispersion cases), `compute_submatrix_sums` leading-block sums, and homogeneous-effect recovery plus determinism for `stem`.
- `test-calc-selection-model.R`: exact `compute_tpowers` bins (symmetric, asymmetric, multi-cutoff partition), the `variation_variance_loglikelihood` `LLH == -sum(logL)` identity, `clustered_covariance_estimate` symmetry, `estimates_table` layout, and homogeneous-effect recovery for `metastudies_estimation`.
- `test-calc-maive.R`: `maive` dispatch to the MAIVE package (present via `skip_if_not_installed`), the missing-column abort, and the absent-package abort (via `local_pretend_packages_absent`).

### Output export (`inst/artma/output/export.R`)

`test-output-export.R`: `resolve_output_dir` (auto and explicit), `resolve_graphics_dir`, `ensure_output_dirs`, and the generic `export_results` walk of the standard contract: `<method>.csv` for summary / generic / method-name keys, `<method>_<key>.csv` for sub-tables, plots and meta ignored, NULL results and non-data-frame entries skipped, with CSV content round-tripped.

### Visualization (`inst/artma/visualization/`)

`test-visualization.R`: exact palettes from `colors.R` (`get_colors`, `get_background`, `get_vline_color`, `validate_theme`, `VALID_THEMES`), `get_theme` returning a valid ggplot2 theme, the `export.R` filename scheme / directory creation / `save_plot` round-trip to disk, and the `options.R` getters and setters.

## Test plan

- [x] `make test` (0 failures, 1310 passed)
- [x] `LC_ALL=en_US.UTF-8` lint of new files (0 lints)
- [x] `LC_ALL=en_US.UTF-8 make check` (0 errors; the lone WARNING is an Apple-clang header warning during Rcpp compile and the NOTE is `.git` from the worktree, both environmental)
