### PR TITLE
test: cover interactive modules, method wrappers, and injectable autonomy gate

### DIFF
--- a/inst/artma/libs/core/autonomy.R
+++ b/inst/artma/libs/core/autonomy.R
@@ -89,9 +89,13 @@ is_autonomy_level_set <- function() {
 #'   user is not prompted. The user is prompted only when the current level is
 #'   strictly less autonomous than `required_level`, ordered
 #'   "ask_more" < "balanced" < "autonomous". Defaults to "autonomous".
+#' @param is_interactive *\[logical\]* Whether the session is interactive. Defaults
+#'   to `interactive()`. Injectable so both branches of the hard gate can be
+#'   exercised in headless tests; production callers should leave it at the
+#'   default.
 #' @return *\[logical\]* TRUE if the user should be prompted, FALSE otherwise.
 #' @export
-should_prompt_user <- function(required_level = "autonomous") {
+should_prompt_user <- function(required_level = "autonomous", is_interactive = interactive()) {
   box::use(
     artma / const[CONST],
     artma / libs / core / validation[validate]
@@ -104,7 +108,7 @@ should_prompt_user <- function(required_level = "autonomous") {
   )
 
   # interactive() is the hard gate: never prompt outside interactive sessions
-  if (!interactive()) {
+  if (!is_interactive) {
     return(FALSE)
   }
 

--- a/tests/testthat/test-autonomy.R
+++ b/tests/testthat/test-autonomy.R
@@ -67,7 +67,7 @@ test_that("is_autonomy_level_set works correctly", {
   expect_true(is_autonomy_level_set())
 })
 
-test_that("should_prompt_user respects autonomy level ordering", {
+test_that("should_prompt_user respects autonomy level ordering (interactive branch)", {
   box::use(artma / libs / core / autonomy[
     should_prompt_user,
     set_autonomy_level
@@ -75,12 +75,7 @@ test_that("should_prompt_user respects autonomy level ordering", {
 
   withr::local_options(list(artma.autonomy.level = NULL))
 
-  # This test only works in interactive mode; in non-interactive mode,
-  # should_prompt_user always returns FALSE regardless of the level.
-  if (!interactive()) {
-    skip("Test requires interactive mode")
-  }
-
+  # The interactive branch is exercised headlessly by injecting is_interactive.
   levels <- c("ask_more", "balanced", "autonomous")
   ordinal <- stats::setNames(seq_along(levels), levels)
 
@@ -88,7 +83,7 @@ test_that("should_prompt_user respects autonomy level ordering", {
     set_autonomy_level(current_level)
 
     for (required_level in levels) {
-      should_prompt <- should_prompt_user(required_level)
+      should_prompt <- should_prompt_user(required_level, is_interactive = TRUE)
       expected <- ordinal[[current_level]] < ordinal[[required_level]]
       expect_equal(should_prompt, expected,
         info = paste0(
@@ -100,15 +95,29 @@ test_that("should_prompt_user respects autonomy level ordering", {
   }
 })
 
-test_that("should_prompt_user returns TRUE when level not set (interactive mode)", {
+test_that("should_prompt_user returns TRUE when level not set (interactive branch)", {
   box::use(artma / libs / core / autonomy[should_prompt_user])
 
   withr::local_options(list(artma.autonomy.level = NULL))
 
-  if (interactive()) {
-    expect_true(should_prompt_user(required_level = "ask_more"))
-    expect_true(should_prompt_user(required_level = "autonomous"))
-  }
+  expect_true(should_prompt_user(required_level = "ask_more", is_interactive = TRUE))
+  expect_true(should_prompt_user(required_level = "autonomous", is_interactive = TRUE))
+})
+
+test_that("should_prompt_user hard-gates on the non-interactive branch", {
+  box::use(artma / libs / core / autonomy[should_prompt_user, set_autonomy_level])
+
+  withr::local_options(list(artma.autonomy.level = NULL))
+
+  # Even at the most prompt-eager level, an injected non-interactive session
+  # never prompts.
+  set_autonomy_level("ask_more")
+  expect_false(should_prompt_user(required_level = "autonomous", is_interactive = FALSE))
+  expect_false(should_prompt_user(required_level = "ask_more", is_interactive = FALSE))
+
+  # Unset level would prompt interactively, but not when non-interactive.
+  options(artma.autonomy.level = NULL)
+  expect_false(should_prompt_user(required_level = "autonomous", is_interactive = FALSE))
 })
 
 test_that("should_prompt_user returns FALSE in non-interactive mode regardless of level", {

--- a/tests/testthat/test-effect-summary-stats-integration.R
+++ b/tests/testthat/test-effect-summary-stats-integration.R
@@ -182,6 +182,97 @@ test_that("effect_summary_stats processes configured variables correctly", {
 })
 
 
+# Value-level assertions ------------------------------------------------------
+
+test_that("effect_summary_stats computes the All Data row exactly", {
+  box::use(
+    artma / methods / effect_summary_stats[effect_summary_stats]
+  )
+
+  # Fixed dataset with hand-computable summary statistics.
+  #   mean   = 0.32   median = 0.30   min = 0.10   max = 0.50
+  #   sd     = 0.164 (rounded)        obs = 5
+  #   z_0.95 = qnorm(0.975) = 1.959964
+  #   se     = round(sd, 3) / sqrt(5); ci = mean +/- z * se -> [0.176, 0.464]
+  #   weighted mean with w = 1 / study_size^2 -> 0.165
+  df <- data.frame(
+    effect = c(0.10, 0.24, 0.30, 0.46, 0.50),
+    study_size = c(10, 20, 30, 40, 50),
+    stringsAsFactors = FALSE
+  )
+
+  local_options(
+    "artma.data.config" = list(
+      effect = list(var_name = "effect", effect_sum_stats = NA, equal = NA, gltl = NA),
+      study_size = list(
+        var_name = "study_size",
+        var_name_verbose = "Study Size",
+        data_type = "int",
+        effect_sum_stats = TRUE,
+        equal = NA,
+        gltl = NA
+      )
+    ),
+    "artma.methods.effect_summary_stats.conf_level" = 0.95,
+    "artma.methods.effect_summary_stats.formal_output" = FALSE,
+    "artma.output.number_of_decimals" = 3,
+    "artma.verbose" = 1
+  )
+
+  result <- effect_summary_stats(df)$tables$summary
+  all_data <- result[result$`Var Name` == "All Data", , drop = FALSE]
+
+  expect_equal(nrow(all_data), 1L)
+  expect_equal(all_data$Mean, 0.32)
+  expect_equal(all_data$Median, 0.30)
+  expect_equal(all_data$Min, 0.10)
+  expect_equal(all_data$Max, 0.50)
+  expect_equal(all_data$SD, 0.164)
+  expect_equal(all_data$Obs, 5L)
+  expect_equal(all_data$`CI lower`, 0.176)
+  expect_equal(all_data$`CI upper`, 0.464)
+  expect_equal(all_data$`Weighted Mean`, 0.165)
+})
+
+test_that("effect_summary_stats confidence interval widens with the confidence level", {
+  box::use(
+    artma / methods / effect_summary_stats[effect_summary_stats]
+  )
+
+  df <- data.frame(
+    effect = c(0.10, 0.24, 0.30, 0.46, 0.50),
+    study_size = c(10, 20, 30, 40, 50),
+    stringsAsFactors = FALSE
+  )
+
+  config <- list(
+    effect = list(var_name = "effect", effect_sum_stats = NA, equal = NA, gltl = NA),
+    study_size = list(
+      var_name = "study_size",
+      var_name_verbose = "Study Size",
+      data_type = "int",
+      effect_sum_stats = TRUE,
+      equal = NA,
+      gltl = NA
+    )
+  )
+
+  run_at <- function(conf_level) {
+    local_options(
+      "artma.data.config" = config,
+      "artma.methods.effect_summary_stats.conf_level" = conf_level,
+      "artma.output.number_of_decimals" = 3,
+      "artma.verbose" = 1
+    )
+    res <- effect_summary_stats(df)$tables$summary
+    row <- res[res$`Var Name` == "All Data", , drop = FALSE]
+    row$`CI upper` - row$`CI lower`
+  }
+
+  expect_true(run_at(0.99) > run_at(0.95))
+  expect_true(run_at(0.95) > run_at(0.80))
+})
+
 # Config update integration ---------------------------------------------------
 
 test_that("update_config_with_selections integrates with effect_summary_stats", {

--- a/tests/testthat/test-interactive.R
+++ b/tests/testthat/test-interactive.R
@@ -1,0 +1,96 @@
+box::use(
+  testthat[
+    expect_error,
+    expect_false,
+    expect_true,
+    test_that
+  ],
+  withr[local_options, local_tempdir],
+  artma / interactive / ask[ask_for_overwrite_permission],
+  artma / interactive / save_preference[
+    prompt_save_preference,
+    prompt_save_variable_selection
+  ],
+  artma / interactive / welcome[is_first_time_user, mark_welcome_as_shown]
+)
+
+# ask_for_overwrite_permission ----------------------------------------------
+
+test_that("ask_for_overwrite_permission allows writing a non-existent file", {
+  local_options(artma.verbose = 1)
+  expect_true(ask_for_overwrite_permission(tempfile()))
+})
+
+test_that("ask_for_overwrite_permission honours an explicit should_overwrite", {
+  local_options(artma.verbose = 1)
+  path <- tempfile()
+  writeLines("x", path)
+
+  expect_true(ask_for_overwrite_permission(path, should_overwrite = TRUE))
+  expect_error(ask_for_overwrite_permission(path, should_overwrite = FALSE))
+})
+
+test_that("ask_for_overwrite_permission aborts rather than prompting when non-interactive", {
+  local_options(artma.verbose = 1)
+  path <- tempfile()
+  writeLines("x", path)
+
+  # The test runner is non-interactive, so the interactive prompt path aborts.
+  expect_error(ask_for_overwrite_permission(path))
+})
+
+# prompt_save_preference ----------------------------------------------------
+
+test_that("prompt_save_preference does not save in non-interactive mode", {
+  local_options(artma.verbose = 1)
+  expect_false(prompt_save_preference("data.example", 1, description = "example"))
+})
+
+test_that("prompt_save_preference validates its arguments", {
+  local_options(artma.verbose = 1)
+  expect_error(prompt_save_preference(123, 1))
+  expect_error(prompt_save_preference("data.example", 1, respect_autonomy = "no"))
+})
+
+# prompt_save_variable_selection --------------------------------------------
+
+test_that("prompt_save_variable_selection short-circuits on empty input", {
+  local_options(artma.verbose = 1)
+  expect_false(prompt_save_variable_selection(character(0)))
+})
+
+test_that("prompt_save_variable_selection does not save in non-interactive mode", {
+  local_options(artma.verbose = 1)
+  expect_false(prompt_save_variable_selection(c("effect", "se")))
+})
+
+test_that("prompt_save_variable_selection validates its arguments", {
+  local_options(artma.verbose = 1)
+  expect_error(prompt_save_variable_selection(123))
+})
+
+# welcome -------------------------------------------------------------------
+
+test_that("is_first_time_user returns FALSE once the session flag is set", {
+  local_options(artma.welcome.shown = TRUE)
+  expect_false(is_first_time_user(local_tempdir()))
+})
+
+test_that("is_first_time_user is TRUE for a fresh options directory", {
+  local_options(artma.welcome.shown = NULL)
+  expect_true(is_first_time_user(local_tempdir()))
+})
+
+test_that("mark_welcome_as_shown creates a flag file and is then not first-time", {
+  local_options(artma.welcome.shown = NULL)
+  dir <- local_tempdir()
+
+  mark_welcome_as_shown(dir)
+
+  expect_true(file.exists(file.path(dir, ".welcome_shown")))
+  expect_true(isTRUE(getOption("artma.welcome.shown")))
+
+  # A fresh session (option cleared) still sees the persistent flag file.
+  local_options(artma.welcome.shown = NULL)
+  expect_false(is_first_time_user(dir))
+})

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -1,0 +1,83 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_true,
+    skip_if_not_installed,
+    test_that
+  ],
+  withr[local_options],
+  artma / methods / p_hacking_tests[p_hacking_tests],
+  artma / methods / exogeneity_tests[exogeneity_tests]
+)
+
+# p_hacking_tests wrapper ---------------------------------------------------
+
+test_that("p_hacking_tests returns the standard contract with a caliper table", {
+  local_options(
+    artma.verbose = 1,
+    # Keep the run fast and dependency-light: caliper only.
+    artma.methods.p_hacking_tests.include_elliott = FALSE,
+    artma.methods.p_hacking_tests.include_discontinuity = FALSE,
+    artma.methods.p_hacking_tests.include_cox_shi = FALSE,
+    artma.methods.p_hacking_tests.include_maive = FALSE
+  )
+  set.seed(1)
+  n <- 60
+  df <- data.frame(
+    effect = rnorm(n, 0.3, 0.1),
+    se = runif(n, 0.05, 0.3),
+    study_id = rep(seq_len(15), length.out = n)
+  )
+  df$t_stat <- df$effect / df$se
+
+  result <- p_hacking_tests(df)
+
+  expect_true(is.list(result))
+  expect_true(is.data.frame(result$tables$caliper))
+  expect_true(nrow(result$tables$caliper) > 0)
+})
+
+test_that("p_hacking_tests aborts when a required column is missing", {
+  local_options(artma.verbose = 1)
+  # Missing t_stat and study_id.
+  expect_error(p_hacking_tests(data.frame(effect = 1:3, se = rep(1, 3))))
+})
+
+# exogeneity_tests wrapper --------------------------------------------------
+
+make_exogeneity_df <- function(seed = 2024, n = 200) {
+  set.seed(seed)
+  n_obs <- sample(30:600, n, replace = TRUE)
+  se <- 2 / sqrt(n_obs) + abs(rnorm(n, 0, 0.01))
+  effect <- 0.5 + 1.0 * se + rnorm(n, 0, 0.05)
+  data.frame(
+    effect = effect,
+    se = se,
+    study_id = rep(seq_len(40), length.out = n),
+    n_obs = n_obs,
+    study_size = n_obs
+  )
+}
+
+test_that("exogeneity_tests returns the standard contract with IV results", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  result <- exogeneity_tests(make_exogeneity_df())
+
+  expect_true(is.list(result))
+  expect_true(is.data.frame(result$tables$summary))
+  expect_equal(nrow(result$tables$summary), 6L)
+  # The IV model lives in the meta slot and recovers the true effect (mu = 0.5).
+  iv_coef <- result$meta$iv$coefficients
+  effect_est <- iv_coef$estimate[iv_coef$term == "effect"]
+  expect_equal(effect_est, 0.5, tolerance = 0.05)
+})
+
+test_that("exogeneity_tests aborts when a required column is missing", {
+  local_options(artma.verbose = 1)
+  df <- make_exogeneity_df(n = 30)
+  expect_error(exogeneity_tests(df[, c("effect", "se")]))
+})


### PR DESCRIPTION
## Summary

Final part of #172. Adds direct tests for the remaining zero-coverage subsystems, strengthens the assertion-light effect-summary tests with value-level assertions, and makes the autonomy hard gate injectable so both branches run headless.

Closes #172.

### Injectable autonomy gate (priority 5)

`should_prompt_user()` in `inst/artma/libs/core/autonomy.R` now takes `is_interactive = interactive()`. The default keeps production behaviour identical (all existing callers pass only `required_level`), but tests can drive both branches of the hard gate without a live session. The "requires interactive mode" skip in `test-autonomy.R` is removed and replaced with headless coverage of the interactive branch (level ordering, unset-level prompt) and the non-interactive branch (never prompts).

### Value-level assertions for effect summary stats (priority 4)

`test-effect-summary-stats-integration.R` gains a fixed-dataset test that pins the exact All Data row (mean 0.32, median 0.30, min/max, sd 0.164, obs 5, 95% CI [0.176, 0.464], weighted mean 0.165) and a monotonicity test that the CI widens with the confidence level.

### Method wrappers (`inst/artma/methods/`)

`test-methods-p-hacking-exogeneity.R`: `p_hacking_tests` returns the standard contract with a caliper table (elliott/discontinuity/cox-shi/maive disabled via options for speed) and aborts on missing columns; `exogeneity_tests` returns the contract, recovers the true effect through its meta IV model, and aborts on missing columns.

### Interactive modules (`inst/artma/interactive/`)

`test-interactive.R`: `ask_for_overwrite_permission` (non-existent file, explicit overwrite yes/no, non-interactive abort), `prompt_save_preference` / `prompt_save_variable_selection` (non-interactive no-save, empty-input short-circuit, argument validation), and `welcome` (`is_first_time_user` session-flag and fresh-dir behaviour, `mark_welcome_as_shown` flag-file creation and persistence).

## Coverage

Every subsystem in the issue's zero-coverage list now has a direct test file that imports and executes its code: `econometric/{p_hacking,exogeneity}.R` and `methods/{p_hacking_tests,exogeneity_tests}.R`, `calc/methods/{maive,endo_kink,stem,selection_model}.R`, `visualization/{colors,theme,export,options}.R`, `output/export.R`, and `interactive/{ask,save_preference,welcome}.R` (the first three groups landed in #203 and #205). CI's codecov `inst` component measures `inst/artma/` line coverage for these files.

## Test plan

- [x] `make test` (0 failures, 1360 passed, autonomy skip removed)
- [x] `LC_ALL=en_US.UTF-8` lint of changed files (0 lints)
- [x] `LC_ALL=en_US.UTF-8 make check` (0 errors; the lone WARNING is an Apple-clang header warning during Rcpp compile and the NOTE is `.git` from the worktree, both environmental)
