### PR TITLE
fix: draw mock standard errors from a strictly positive range

### DIFF
--- a/inst/artma/data/mock.R
+++ b/inst/artma/data/mock.R
@@ -117,7 +117,7 @@ create_mock_df <- function(
     list(
       study_names = study_names,
       effect = generate_random_vector(from = -1, to = 1, length.out = nrow),
-      se = generate_random_vector(from = -1, to = 1, length.out = nrow),
+      se = generate_random_vector(from = 0.01, to = 1, length.out = nrow),
       n_obs = generate_random_vector(from = 10, to = 1000, length.out = nrow, integer = TRUE)
     )
   })


### PR DESCRIPTION
## Summary

`create_mock_df()` drew the `se` column from `generate_random_vector(from = -1, to = 1, ...)`, producing negative standard errors. Negative SEs are invalid: they yield negative precision (`1/se`), garbage t-stats (`effect/se`), and make the MAIVE estimator abort with "Standard errors ('sebs') must be positive".

The fix changes the draw to a strictly positive range: `from = 0.01, to = 1`.

Because `stats::runif(n, min, max)` consumes `n` uniforms regardless of the bounds, shifting only the `se` bounds does not move the RNG stream for the later `n_obs` draw. Only `se` and its derived columns (`precision`, `t_stat`) change; `study_names`, `effect`, and `n_obs` stay byte-identical.

## Verification

- Mock `se` now ranges within (0.01, 1); no negative values, precision and t-stats finite and positive.
- Ran `p_hacking_tests` with MAIVE enabled on mock data: the MAIVE sub-table populates without the "Standard errors must be positive" abort. Confirmed the old negative-SE data still triggers that abort, so the fix addresses the reported error directly.
- `make test` green (FAIL 0 | PASS 1404). No fixed-seed value assertions needed updating; the suite computes expectations dynamically.
- `make check` clean (0 errors; only a pre-existing install warning and `.git` hidden-dir note, both present on master and unrelated).

Fixes #209