### PR TITLE
build: require R >= 4.4.0 for base %||%

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ License: GPL-3
 URL: https://github.com/PetrCala/artma
 BugReports: https://github.com/PetrCala/artma/issues
 Depends:
-    R (>= 4.0.0)
+    R (>= 4.4.0)
 Imports:
     box (>= 1.2.0),
     cli (>= 3.6.5),

--- a/inst/artma/data/column_recognition.R
+++ b/inst/artma/data/column_recognition.R
@@ -687,10 +687,6 @@ check_mapping_completeness <- function(mapping) {
 }
 
 
-# Helper for NULL coalescing
-`%||%` <- function(x, y) if (is.null(x)) y else x # nolint
-
-
 box::export(
   MATCH_THRESHOLDS,
   get_column_patterns,


### PR DESCRIPTION
## Summary

`%||%` is used in 24 files across `R/` and `inst/artma` without any import or definition (except one local copy), so every use resolves to base R's `%||%`, which only exists since R 4.4.0. DESCRIPTION claimed `R (>= 4.0.0)`, so on R 4.0-4.3 these code paths would fail with "could not find function".

Since the whole package already depends on base `%||%` in practice, this bumps the declared dependency to `R (>= 4.4.0)` rather than threading rlang imports through 23 box modules. Also removes the now-redundant local definition in `inst/artma/data/column_recognition.R` (it was defined there but never used or exported).

CI's matrix tests `release` and `oldrel-1`, both >= 4.4, so no workflow changes needed.

## Testing

- `make test`: 1401 pass, 0 fail
- `lintr::lint` on the edited file: clean