### PR TITLE
feat: add BMA prior-comparison plot for multiple parameter sets

### DIFF
--- a/inst/artma/econometric/bma.R
+++ b/inst/artma/econometric/bma.R
@@ -586,6 +586,121 @@ extract_bma_results <- function(bma_model, bma_data, input_var_list, print_resul
 }
 
 
+#' Build human-readable labels distinguishing multiple BMA parameter sets
+#'
+#' @description
+#' Given the per-model parameter lists returned by `handle_bma_params()`, build a
+#' label for each model listing only the parameters that actually differ between
+#' them (e.g. "g=UIP, mprior=uniform"). Falls back to "Model N" if every parameter
+#' set is identical.
+#'
+#' @param bma_params_list *\[list\]* A list of per-model parameter lists, as returned
+#' by `handle_bma_params()`.
+#'
+#' @return *\[character\]* A vector of labels, one per entry in `bma_params_list`.
+#'
+#' @export
+build_bma_model_labels <- function(bma_params_list) {
+  box::use(
+    artma / libs / core / validation[validate]
+  )
+
+  validate(is.list(bma_params_list), length(bma_params_list) >= 1)
+
+  if (length(bma_params_list) == 1) {
+    return("Model 1")
+  }
+
+  param_names <- names(bma_params_list[[1]])
+  varying_params <- Filter(function(param_name) {
+    values <- vapply(bma_params_list, function(params) as.character(params[[param_name]]), character(1))
+    length(unique(values)) > 1
+  }, param_names)
+
+  if (!length(varying_params)) {
+    return(paste0("Model ", seq_along(bma_params_list)))
+  }
+
+  vapply(bma_params_list, function(params) {
+    paste(
+      vapply(varying_params, function(param_name) {
+        paste0(param_name, "=", params[[param_name]])
+      }, character(1)),
+      collapse = ", "
+    )
+  }, character(1))
+}
+
+
+#' Render a BMA prior-comparison plot across multiple parameter sets
+#'
+#' @description
+#' When more than one BMA parameter set is run (e.g. to compare priors), overlay
+#' their posterior statistics with `BMS::plotComp` so the effect of different
+#' configurations can be compared visually.
+#'
+#' @param bma_models *\[list\]* A named list of two or more fitted `bma` model objects
+#' to compare. The names are used as the plot legend labels.
+#' @param comp *\[character\]* The statistic to compare: "PIP", "Post Mean", "Post SD",
+#' "Std Mean", or "Std SD". Defaults to "PIP".
+#' @param export_graphics *\[logical\]* If TRUE, export the comparison plot to a file. Defaults to TRUE.
+#' @param export_path *\[character\]* Path to the export folder. Defaults to "graphics".
+#' @param graph_scale *\[numeric\]* Scale the plot by this number. Defaults to 1.
+#' @param print_plot *\[logical\]* If TRUE, also render the plot to the current graphics device. Defaults to FALSE.
+#'
+#' @return NULL (invisibly). Called for its plotting side effect.
+#'
+#' @export
+render_bma_comparison_plot <- function(bma_models, comp = "PIP", export_graphics = TRUE,
+                                       export_path = "graphics", graph_scale = 1,
+                                       print_plot = FALSE) {
+  box::use(
+    artma / libs / core / validation[validate],
+    artma / visualization / export[ensure_export_dir]
+  )
+
+  validate(
+    is.list(bma_models),
+    length(bma_models) >= 2,
+    all(vapply(bma_models, inherits, logical(1), what = "bma")),
+    is.character(comp),
+    is.logical(export_graphics),
+    is.character(export_path),
+    is.numeric(graph_scale),
+    is.logical(print_plot)
+  )
+
+  safe_render <- function() {
+    tryCatch(
+      do.call(BMS::plotComp, c(bma_models, list(comp = comp))),
+      error = function(e) {
+        cli::cli_warn("Could not render the BMA comparison plot: {conditionMessage(e)}")
+      }
+    )
+  }
+
+  if (print_plot) {
+    safe_render()
+  }
+
+  if (export_graphics) {
+    ensure_export_dir(export_path)
+    comparison_path <- file.path(export_path, "bma_comparison.png")
+    if (file.exists(comparison_path)) {
+      file.remove(comparison_path)
+    }
+    grDevices::png(comparison_path,
+      width = 800 * graph_scale, height = 600 * graph_scale, units = "px",
+      res = 90 * graph_scale
+    )
+    safe_render()
+    grDevices::dev.off()
+  }
+
+  invisible(NULL)
+}
+
+
 box::export(
   handle_bma_params,
   get_bma_formula,
@@ -593,5 +708,7 @@ box::export(
   get_bma_data,
   run_bma,
   rename_bma_model,
-  extract_bma_results
+  extract_bma_results,
+  build_bma_model_labels,
+  render_bma_comparison_plot
 )

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -11,7 +11,10 @@ bma <- function(df) {
     artma / econometric / bma[
       handle_bma_params,
       run_bma,
-      extract_bma_results
+      extract_bma_results,
+      rename_bma_model,
+      build_bma_model_labels,
+      render_bma_comparison_plot
     ],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
@@ -159,6 +162,24 @@ bma <- function(df) {
       data = bma_data,
       params = bma_params[[i]],
       var_list = bma_var_list
+    )
+  }
+
+  if (length(results) > 1) {
+    comparison_labels <- build_bma_model_labels(bma_params)
+    comparison_models <- stats::setNames(
+      lapply(seq_along(results), function(i) {
+        rename_bma_model(results[[i]]$model, results[[i]]$var_list)
+      }),
+      comparison_labels
+    )
+
+    render_bma_comparison_plot(
+      comparison_models,
+      export_graphics = export_graphics,
+      export_path = export_path,
+      graph_scale = graph_scale,
+      print_plot = print_results == "all" && get_verbosity() >= 3
     )
   }
 
@@ -336,7 +357,7 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
 
   # Check for rank deficiency and multicollinearity, and remove aliased variables
   if (ncol(bma_data) > 2) {
-    max_iterations <- 50  # Prevent infinite loop
+    max_iterations <- 50 # Prevent infinite loop
     iteration <- 0
 
     repeat {

--- a/tests/testthat/test-bma.R
+++ b/tests/testthat/test-bma.R
@@ -6,9 +6,10 @@ box::use(
     expect_named,
     expect_true,
     expect_type,
+    skip_if_not_installed,
     test_that
   ],
-  withr[local_options]
+  withr[local_options, local_tempdir]
 )
 
 box::use(
@@ -160,4 +161,133 @@ test_that("run_bma executes without errors", {
 
   expect_true(inherits(result, "bma"))
   expect_true(!is.null(result$topmod))
+})
+
+test_that("build_bma_model_labels labels only the varying parameters", {
+  box::use(artma / econometric / bma[build_bma_model_labels])
+
+  params_list <- list(
+    list(burn = 100L, iter = 500L, g = "UIP", mprior = "uniform"),
+    list(burn = 100L, iter = 500L, g = "BRIC", mprior = "uniform")
+  )
+
+  labels <- build_bma_model_labels(params_list)
+
+  expect_equal(labels, c("g=UIP", "g=BRIC"))
+})
+
+test_that("build_bma_model_labels falls back to generic names when nothing varies", {
+  box::use(artma / econometric / bma[build_bma_model_labels])
+
+  params_list <- list(
+    list(burn = 100L, g = "UIP"),
+    list(burn = 100L, g = "UIP")
+  )
+
+  labels <- build_bma_model_labels(params_list)
+
+  expect_equal(labels, c("Model 1", "Model 2"))
+})
+
+test_that("build_bma_model_labels returns a single label for one model", {
+  box::use(artma / econometric / bma[build_bma_model_labels])
+
+  labels <- build_bma_model_labels(list(list(burn = 100L, g = "UIP")))
+
+  expect_equal(labels, "Model 1")
+})
+
+test_that("render_bma_comparison_plot exports a comparison png for multiple models", {
+  skip_if_not_installed("BMS")
+  box::use(
+    artma / econometric / bma[run_bma, render_bma_comparison_plot]
+  )
+
+  df <- make_demo_bma_data()
+  bma_data <- df[c("effect", "se", "moderator1", "moderator2")]
+
+  params <- list(burn = 100L, iter = 500L, nmodel = 10L, g = "UIP", mprior = "uniform", mcmc = "bd")
+
+  local_options("artma.verbose" = 1)
+
+  model_1 <- run_bma(bma_data, params)
+  model_2 <- run_bma(bma_data, utils::modifyList(params, list(mprior = "random")))
+
+  export_dir <- local_tempdir()
+
+  render_bma_comparison_plot(
+    list(`mprior=uniform` = model_1, `mprior=random` = model_2),
+    export_graphics = TRUE,
+    export_path = export_dir
+  )
+
+  expect_true(file.exists(file.path(export_dir, "bma_comparison.png")))
+})
+
+test_that("bma exports a comparison plot when multiple parameter sets are run", {
+  skip_if_not_installed("BMS")
+
+  df <- make_demo_bma_data()
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE),
+    moderator1 = list(var_name = "moderator1", var_name_verbose = "Mod1", bma = TRUE),
+    moderator2 = list(var_name = "moderator2", var_name_verbose = "Mod2", bma = TRUE)
+  )
+
+  export_dir <- local_tempdir()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.output.save_results = FALSE,
+    artma.visualization.export_graphics = TRUE,
+    artma.visualization.export_path = export_dir,
+    artma.methods.bma.burn = 100L,
+    artma.methods.bma.iter = 500L,
+    artma.methods.bma.nmodel = 10L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = c("uniform", "random"),
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  result <- bma(df)
+
+  expect_length(result$meta$all, 2)
+  expect_true(file.exists(file.path(export_dir, "bma_comparison.png")))
+})
+
+test_that("bma does not export a comparison plot for a single parameter set", {
+  skip_if_not_installed("BMS")
+
+  df <- make_demo_bma_data()
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE),
+    moderator1 = list(var_name = "moderator1", var_name_verbose = "Mod1", bma = TRUE),
+    moderator2 = list(var_name = "moderator2", var_name_verbose = "Mod2", bma = TRUE)
+  )
+
+  export_dir <- local_tempdir()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.output.save_results = FALSE,
+    artma.visualization.export_graphics = TRUE,
+    artma.visualization.export_path = export_dir,
+    artma.methods.bma.burn = 100L,
+    artma.methods.bma.iter = 500L,
+    artma.methods.bma.nmodel = 10L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  result <- bma(df)
+
+  expect_length(result$meta$all, 1)
+  expect_false(file.exists(file.path(export_dir, "bma_comparison.png")))
 })


### PR DESCRIPTION
The `bma` method supports multiple prior configurations via `meta$all`, but never rendered a visual comparison. When more than one parameter set is run, this exports a `BMS::plotComp` comparison plot (default statistic: PIP) labeled by the parameters that differ between the runs.

Closes #218