### PR TITLE
ci: speed up the PR gate by restructuring the R CMD check matrix

### DIFF
--- a/.github/workflows/R-CMD-check-extended.yaml
+++ b/.github/workflows/R-CMD-check-extended.yaml
@@ -1,0 +1,60 @@
+# Full R CMD check across the complete matrix, including R-devel and
+# oldrel, with vignettes. Runs after merges to master instead of on
+# PRs: R-devel has no binary packages and its version string embeds a
+# unique build id, so its dependency cache can never be restored and
+# every run compiles the whole dependency tree from source (5+ min).
+# Running the release configs here also saves their dependency caches
+# on master, where every PR branch can restore them. The weekly run
+# keeps those caches from being evicted during quiet periods and
+# catches breakage against a moving R-devel.
+name: R CMD Check (extended)
+
+on:
+  push:
+    branches: master
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: macos-latest, r: "release" }
+          - { os: windows-latest, r: "release" }
+          - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
+          - { os: ubuntu-latest, r: "release" }
+          - { os: ubuntu-latest, r: "oldrel-1" }
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,10 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# PR gate: release R on the three major platforms, without vignettes.
+# The full matrix (plus R-devel and oldrel, with vignettes) runs after
+# merges in R-CMD-check-extended.yaml, which also saves the dependency
+# caches on master so every PR branch can restore them.
 name: R CMD Check
 
 on:
@@ -7,6 +12,10 @@ on:
     types: [opened, synchronize]
 
 permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   R-CMD-check:
@@ -20,9 +29,7 @@ jobs:
         config:
           - { os: macos-latest, r: "release" }
           - { os: windows-latest, r: "release" }
-          - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
           - { os: ubuntu-latest, r: "release" }
-          - { os: ubuntu-latest, r: "oldrel-1" }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +43,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -44,10 +50,8 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Document the package
-        run: Rscript -e "devtools::document()"
-
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+          args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -8,6 +8,10 @@ on:
   push:
     branches: master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The R CMD Check run on PRs takes ~8 minutes wall clock (e.g. [this run](https://github.com/PetrCala/artma/actions/runs/29816677815)). Almost all of it is the `ubuntu-latest (devel)` job:

- R-devel has no prebuilt binaries, so all ~150 dependencies compile from source every run (5m38s in the linked run).
- Its dependency cache can never restore: the cache key embeds the R-devel version string, which contains a unique build id (`R version 4.7.0 (ge:17; iid:2fdf6c18-...)`), so the key changes with every devel snapshot.

A second issue: caches saved by PR runs are only visible to the same branch, and the check workflow never ran on master, so nothing primed a master-scoped cache that fresh PRs could restore. That is why the windows and oldrel-1 jobs also missed their caches (1m24s and 3m36s of installs).

## What

- **R-CMD-check.yaml** (PR gate) now runs release R on ubuntu, macos, and windows only, with `--ignore-vignettes` / `--no-build-vignettes`, and cancels superseded runs via `concurrency`.
- **R-CMD-check-extended.yaml** (new) runs the full five-config matrix, vignettes included, on push to master, weekly (Mon 04:00 UTC), and on dispatch. Post-merge coverage of devel/oldrel is unchanged; running the release configs on master also saves their dependency caches where every PR branch can restore them, and the weekly run keeps those caches from being evicted.
- The `devtools::document()` step is dropped from CI: `man/` and `NAMESPACE` are committed and `make document` is part of the pre-commit checklist, so regenerating docs in all matrix jobs only masked uncommitted drift and cost 7-24s per job.
- **lint.yaml** and **test-coverage.yaml** get `concurrency` cancellation for superseded PR runs (master pushes are never cancelled).

## Expected effect

PR wall clock drops from ~8m to roughly 3-3.5m (gated by windows), and closer to 2.5-3m once master-primed caches are warm. If a ~2m gate is wanted later, dropping windows or macos from the PR matrix is the next lever; the extended workflow still covers them post-merge.