### PR TITLE
build: move dev-only packages from Suggests to Config/Needs fields

### DIFF
--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::remotes, any::devtools
+          needs: release
 
       - name: Check for R CMD check
         id: rcmdCheck
@@ -203,7 +203,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::remotes, any::devtools
+          needs: release
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/submit-to-cran.yaml
+++ b/.github/workflows/submit-to-cran.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::curl, any::httr
+          needs: release
 
       - name: Fetch and download release assets
         id: assets

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -27,7 +27,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          needs: check
+          needs: e2e
 
       - name: Run E2E tests
         run: make test-e2e

--- a/.lintr.R
+++ b/.lintr.R
@@ -22,7 +22,7 @@ linters <- c(
     lintr::linters_with_defaults(
         # https://lintr.r-lib.org/reference/index.html#individual-linters
         #
-        # All default box linters
+        # All default lintr linters (resolved from the lintr namespace)
         defaults = default_linters,
         # Set indentation to 2 spaces
         indentation_linter = custom_linters_env$indentation_guard_clause_linter(indent = 2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: artma
 Title: Automatic Replication Tools for Meta-Analysis
 Version: 0.3.3
-Authors@R: 
+Authors@R:
     person("Petr", "Čala", , "61505008@fsv.cuni.cz", role = c("aut", "cre"))
 Author: Petr Čala [aut, cre]
 Maintainer: Petr Čala <61505008@fsv.cuni.cz>
@@ -37,38 +37,36 @@ Suggests:
     AER (>= 1.2-10),
     bayesm (>= 3.1-5),
     BMS (>= 0.3.4),
-    box.linters (>= 0.10.6),
     car (>= 3.1-0),
     clubSandwich (>= 0.5.10),
     corrplot (>= 0.92),
-    covr (>= 3.6.4),
-    devtools (>= 2.4.5),
     fdrtool (>= 1.2.17),
     fs (>= 1.6.6),
     haven (>= 2.5.0),
     ivmodel (>= 1.9.0),
     jsonlite (>= 1.8.0),
     knitr (>= 1.50),
-    languageserver (>= 0.3.16),
     lintr (>= 3.2.0),
     MAIVE (>= 0.1.10),
     mathjaxr (>= 1.8-0),
     mice (>= 3.16.0),
     NlcOptim (>= 0.6),
-    optparse (>= 1.7.5),
-    pkgbuild (>= 1.4.8),
     plm (>= 2.6-3),
     quadprog (>= 1.5-8),
     rddensity (>= 2.5),
     readxl (>= 1.4.0),
-    remotes (>= 2.5.0),
     rex (>= 1.2.1),
     rmarkdown (>= 2.30),
     roxygen2 (>= 7.3.3),
     testthat (>= 3.2.3),
     writexl (>= 1.4.0)
-VignetteBuilder: 
+VignetteBuilder:
     knitr
+Config/Needs/coverage: covr, xml2
+Config/Needs/dev: box.linters, devtools, languageserver, remotes
+Config/Needs/e2e: remotes
+Config/Needs/lint: devtools, remotes
+Config/Needs/release: devtools, optparse, pkgbuild, remotes
 Config/testthat/edition: 3
 Config/testthat/parallel: TRUE
 Config/testthat/start-first: github-actions, release


### PR DESCRIPTION
## What

Moves development-only packages out of `Suggests` into `Config/Needs/*` fields so they are no longer installed by R CMD check jobs, by `setup-r-dependencies` Suggests resolution, or by `dependencies = TRUE` installs.

## Package moves

| Package | New home | Why |
|---|---|---|
| covr | `Config/Needs/coverage` (with xml2) | Only used by `make coverage` and the Test Coverage workflow, which already passes `needs: coverage`. The hardcoded `extra-packages: any::covr, any::xml2` is now redundant and removed. |
| languageserver | `Config/Needs/dev` | IDE tooling; zero references anywhere in the repo. |
| box.linters | `Config/Needs/dev` | Not actually used. `.lintr.R` evaluates bare `default_linters` in an environment chained to the lintr namespace, so it resolves to `lintr::default_linters`; the "default box linters" comment was stale and is fixed in this PR. Kept as a dev convenience for IDE-based box linting. |
| devtools | `Config/Needs/dev`, `lint`, `release` | Needed by `make` targets, the Lint workflow (`devtools::load_all()`), build-and-tag (`devtools::check/document`), and `scripts/R/release.R` (`devtools::as.package`, used by the CRAN submit path). |
| remotes | `Config/Needs/dev`, `e2e`, `lint`, `release` | `tests/E2E/test-installation.R` calls `remotes::install_local()` (E2E workflow now passes `needs: e2e`), and the lint job needs it installed so `namespace_linter` can resolve that call. Previously installed explicitly in build-and-tag. |
| optparse | `Config/Needs/release` | Only used by `scripts/R/get_release_notes.R` and `generate_cran_comments.R`, both invoked from build-and-tag. |
| pkgbuild | `Config/Needs/release` | Only used by `scripts/R/release.R` (`build_pkg`), invoked from build-and-tag and submit-to-cran. Also a transitive Import of devtools. |

## Stayed in Suggests, and why

- lintr: exercised directly by unit tests (`tests/testthat/test-indentation_guard_clause_linter.R`, `test-dir_create_linter.R`, guarded by `skip_if_not_installed`). Moving it would silently skip those tests under R CMD check.
- Runtime method soft-dependencies (AER, BMS, bayesm, ivmodel, quadprog, MAIVE, etc.): gated via the `suggests` argument of `register_runtime_method()`; none of the moved packages appear there.
- Vignette and test infrastructure (knitr, rmarkdown, testthat, roxygen2) and data IO extras (haven, readxl, writexl, jsonlite, fs, ...): unchanged.

## Workflow changes

- `test-coverage.yaml`: dropped `extra-packages: any::covr, any::xml2`; `needs: coverage` now resolves to the new field.
- `test-e2e.yaml`: `needs: check` changed to `needs: e2e` (remotes).
- `build-and-tag.yaml`: both jobs use `needs: release` instead of `extra-packages: any::remotes, any::devtools`.
- `submit-to-cran.yaml`: added `needs: release` so the custom `submit_cran()` path keeps devtools after the Suggests move.
- `lint.yaml` and the R CMD check workflows are untouched; `needs: lint` now resolves to `Config/Needs/lint`, and the check jobs need nothing beyond Imports + remaining Suggests.

## Expected effect

- Every R CMD check matrix job (3 PR jobs, 5 extended jobs) stops installing languageserver, devtools, optparse, remotes, box.linters, covr, and pkgbuild plus their dependency trees (languageserver alone pulls styler, xml2, and friends; devtools pulls the whole r-lib dev stack). That shrinks each job's install step and its dependency cache.
- End users are unaffected: CRAN-style installs use Imports only, and `dependencies = TRUE` installs now skip dev tooling too. No runtime method, options flow, or test depends on a moved package.
- The unstated-dependencies check cannot flag the E2E `remotes::` usage: it only scans top-level `tests/*.R` and known unit-test subdirs, never `tests/E2E`.

## Verification

- `make test` under `LC_ALL=en_US.UTF-8`: 0 failures, 1416 passing (includes the check-manifest drift test; the manifest only tracks Imports, so no regeneration was needed).
- `lintr::lint_package()` with `devtools::load_all()`: `.lintr.R` and `scripts/linters.R` resolve fine without box.linters in play; remaining lints are identical to master (pre-existing indentation style hits).
- All edited workflow files parse as valid YAML.
