### PR TITLE
fix: recompute user-supplied precision after winsorization

### DIFF
--- a/inst/artma/data/compute.R
+++ b/inst/artma/data/compute.R
@@ -206,9 +206,24 @@ add_precision_column <- function(df) {
     artma / libs / core / utils[get_verbosity]
   )
 
+  winsorization_level <- getOption("artma.data.winsorization_level", default = 0)
+  winsorization_active <- !is.null(winsorization_level) &&
+    !is.na(winsorization_level) && winsorization_level != 0
+
   if ("precision" %in% colnames(df)) {
-    # Validate existing precision column
-    if (any(is.na(df$precision))) {
+    if (!is.numeric(df$precision)) {
+      cli::cli_abort("The column {.val precision} must be numeric.")
+    }
+
+    if (winsorization_active) {
+      # se (and thus precision) was winsorized upstream; recompute precision
+      # from the winsorized se/reg_dof so it stays consistent with
+      # effect/se/t_stat instead of keeping stale pre-winsorization values.
+      if (get_verbosity() >= 3) {
+        cli::cli_alert_info("Recalculating {.field precision} from winsorized data.")
+      }
+      df$precision <- calc$precision(se = df$se, reg_dof = df$reg_dof)
+    } else if (any(is.na(df$precision))) {
       n_missing <- sum(is.na(df$precision))
       if (get_verbosity() >= 2) {
         cli::cli_alert_warning(c(
@@ -220,10 +235,6 @@ add_precision_column <- function(df) {
       missing_idx <- which(is.na(df$precision))
       calculated_precision <- calc$precision(se = df$se, reg_dof = df$reg_dof)
       df$precision[missing_idx] <- calculated_precision[missing_idx]
-    }
-
-    if (!is.numeric(df$precision)) {
-      cli::cli_abort("The column {.val precision} must be numeric.")
     }
   } else {
     # Calculate precision based on option

--- a/tests/testthat/test-data-compute.R
+++ b/tests/testthat/test-data-compute.R
@@ -75,6 +75,43 @@ test_that("compute_optional_columns overwrites conflicting existing study_label"
 })
 
 
+test_that("compute_optional_columns recomputes a user-supplied precision column when winsorization is active", {
+  df <- data.frame(
+    study_id = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)"),
+    effect = c(0.2, 0.5, 0.1),
+    se = c(0.1, 0.2, 0.1),
+    n_obs = c(120, 150, 120),
+    precision = c(999, 999, 999),
+    stringsAsFactors = FALSE
+  )
+
+  withr::local_options(list("artma.data.winsorization_level" = 0.01))
+  local_compute_options()
+
+  result <- compute_optional_columns(df)
+
+  expect_equal(result$precision, 1 / result$se)
+})
+
+
+test_that("compute_optional_columns keeps a user-supplied precision column when winsorization is disabled", {
+  df <- data.frame(
+    study_id = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)"),
+    effect = c(0.2, 0.5, 0.1),
+    se = c(0.1, 0.2, 0.1),
+    n_obs = c(120, 150, 120),
+    precision = c(999, 999, 999),
+    stringsAsFactors = FALSE
+  )
+
+  local_compute_options()
+
+  result <- compute_optional_columns(df)
+
+  expect_equal(result$precision, c(999, 999, 999))
+})
+
+
 test_that("get_reserved_colnames covers every column compute_optional_columns can add", {
   df <- sample_study_df()
   local_compute_options()


### PR DESCRIPTION
t_stat already gets recomputed from the winsorized effect/se after winsorization runs, but a user-supplied precision column (a recognized source column) was left untouched. This recomputes precision from se/reg_dof whenever winsorization_level is active, keeping it consistent with effect/se/t_stat, matching the thesis behavior. The pre-winsorization funnel_plot copy from the same audit is left as a follow-up.

Closes #221