### PR TITLE
ci: delete closed-PR Actions caches automatically

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -1,0 +1,35 @@
+# Deletes the Actions caches saved under a PR's ref once that PR closes.
+# Those caches (r-lib/actions/setup-r-dependencies across the R CMD Check
+# matrix, Lint Check, and Test Coverage) are useless the moment the PR
+# closes but otherwise linger until GitHub's LRU eviction reclaims them,
+# crowding out the caches saved under refs/heads/master that every new
+# PR restores from (see R-CMD-check-extended.yaml).
+name: Cache Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to clean up caches for"
+        required: true
+        type: number
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  delete-pr-caches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches for closed PR ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          gh cache delete --all --succeed-on-no-caches \
+            --repo "$REPO" \
+            --ref "refs/pull/${PR_NUMBER}/merge"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cache-cleanup.yaml`, which deletes all Actions caches saved under a PR's ref (`refs/pull/N/merge`) when that PR closes. Triggered on `pull_request: types: [closed]` and `workflow_dispatch` (manual runs, taking a `pr_number` input). Runs `gh cache delete --all --succeed-on-no-caches --ref refs/pull/N/merge`, which does not fail when no caches remain.
- One-off prune of the existing backlog: deleted caches for the 10 closed/merged PRs that still had caches (211, 212, 213, 230, 231, 232, 233, 234, 235, 236). Left `refs/heads/master` and the currently open PR 237 untouched.
  - Before: 64 caches, 11.38 GB
  - After: 15 caches, 2.66 GB
  - Reclaimed: about 8.72 GB

## Steady state

With the cleanup workflow in place, ongoing usage should settle around:

- `refs/heads/master`: currently 10 caches totaling about 1.74 GB (R CMD Check matrix, Lint Check, Test Coverage), refreshed by R-CMD-check-extended.yaml on every master push.
- Each open PR: roughly 500 MB to 1.2 GB depending on which workflows have run, averaging near 870 MB.

At 5 open PRs that is about 1.74 GB + 5 x 0.87 GB = 6.1 GB, comfortably under the 10 GB cap. At 8 open PRs it is about 1.74 GB + 8 x 0.87 GB = 8.7 GB, which is close enough to the limit that a busy week (more PRs, or PRs that trigger the full matrix more than once) could push past 10 GB and put the master caches at risk of LRU eviction again. Worth revisiting if the team regularly runs more than about 8 PRs open at once, for example by also pruning stale caches on the master ref older than N days, or narrowing the matrix caches saved per PR.

## Test plan

- [x] Verified the workflow YAML parses with `Rscript -e "yaml::read_yaml(...)"`.
- [x] Confirmed `gh cache delete --all --ref ...` syntax against the current gh CLI (v2.93.0) `--help` output.
- [ ] First real trigger will be the next PR that closes against this branch merging.