### PR TITLE
ci: fail lint job on man/NAMESPACE docs drift

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::lintr, local::.
+          # roxygen2 is pinned to the RoxygenNote version in DESCRIPTION so the
+          # docs-drift check below regenerates the exact same output as a
+          # contributor running `make document` locally with that version.
+          # Bump this alongside RoxygenNote if it ever changes.
+          extra-packages: any::lintr, roxygen2@7.3.3, local::.
           needs: lint
 
       - name: Lint
@@ -36,3 +40,15 @@ jobs:
           devtools::load_all()
           lintr::lint_package()
         shell: Rscript {0}
+
+      - name: Check generated docs are up to date
+        env:
+          LC_ALL: en_US.UTF-8
+          LANG: en_US.UTF-8
+        run: |
+          Rscript scripts/R/generate_check_manifest.R
+          Rscript -e "devtools::document()"
+          if ! git diff --exit-code -- man NAMESPACE R/generated_check_manifest.R; then
+            echo "::error::man/, NAMESPACE, or R/generated_check_manifest.R are out of date. Run 'make document' locally and commit the result. This job pins roxygen2 to the RoxygenNote version in DESCRIPTION, so a clean local diff with the same roxygen2 version means this is real drift, not version skew."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- PR 235 dropped `devtools::document()` from the R CMD check matrix jobs, since man/ and NAMESPACE are committed and regenerating them per-job only masked uncommitted drift. That left roxygen-generated docs unguarded: nothing in CI now catches a contributor (or agent) editing roxygen comments or box::use imports without running make document.
- Adds a "Check generated docs are up to date" step to the lint workflow (the cheapest always-on PR job): it runs the same commands as make document (generate_check_manifest.R, then devtools::document()) and fails the job on any diff to man/, NAMESPACE, or R/generated_check_manifest.R, with a hint pointing the author at make document.
- Sets LC_ALL/LANG to en_US.UTF-8 for that step. The runner's default locale is already UTF-8, but CLAUDE.md flags C-locale corruption of UTF-8 in generated man/*.Rd as a known failure mode, so it's set explicitly rather than relied upon.

## Roxygen2 version skew
Rd output can differ across roxygen2 versions, and DESCRIPTION pins `RoxygenNote: 7.3.3`. Installing an unpinned `any::roxygen2` in the job would install whatever is newest on CRAN and risk spurious diffs purely from version drift (confirmed locally: with roxygen2 8.0.0 installed, `devtools::document()` rewrote `RoxygenNote:` into `Config/roxygen2/version:` and added a redundant Authors block to `artma-package.Rd`, neither a real doc change).

Rather than just documenting the risk, the workflow pins the install itself: `extra-packages: any::lintr, roxygen2@7.3.3, local::.` matches the RoxygenNote value, so CI regenerates with the same roxygen2 version a contributor running `make document` locally would use (assuming they also have 7.3.3). This needs bumping alongside RoxygenNote if that version ever changes; the step comment calls this out. The failure hint also notes it so a spurious-looking failure gets diagnosed correctly.

## Verification
Ran the exact commands from the new step locally against current master (forcing `box.path` to the worktree's `inst/`, since `~/.Rprofile` pins it to the main checkout): `generate_check_manifest.R` produced no diff, and `devtools::document()` diff was confined to the roxygen2 8.0.0 vs 7.3.3 skew symptoms described above, which were discarded. No real pre-existing drift, so no regenerated files needed to be committed alongside the workflow change.

## Test plan
- [ ] CI run on this PR passes the new "Check generated docs are up to date" step
- [ ] Manually verify the step fails with a clear message if man/NAMESPACE drift is introduced in a follow-up test branch