### PR TITLE
ci: file an issue on extended/e2e CI failure, gate polish

### DIFF
--- a/.github/workflows/R-CMD-check-extended.yaml
+++ b/.github/workflows/R-CMD-check-extended.yaml
@@ -18,6 +18,14 @@ on:
 
 permissions: read-all
 
+# Grouped by workflow name only, not ref: push, schedule, and dispatch
+# runs of this workflow all target master anyway, and only the newest
+# run (repo tip) needs to validate and refresh the dependency caches,
+# so a merge burst collapses to one run instead of queuing several.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -58,3 +66,41 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+
+  # Runs once per run regardless of how many matrix legs failed, since
+  # nobody watches master CI and a failure here (e.g. against a moving
+  # R-devel) would otherwise go unnoticed until the next PR.
+  notify-on-failure:
+    needs: R-CMD-check
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: File or update a CI failure issue
+        run: |
+          set -euo pipefail
+          MARKER="ci: extended check failing"
+          REPO="${{ github.repository }}"
+          RUN_URL="${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}"
+          FAILED_CONFIGS=$(gh run view "${{ github.run_id }}" --repo "$REPO" --json jobs \
+            --jq '[.jobs[] | select(.conclusion=="failure") | .name] | join(", ")')
+
+          {
+            echo "Extended R CMD check failed."
+            echo ""
+            echo "Run: $RUN_URL"
+            echo "Failing configs: ${FAILED_CONFIGS:-unknown}"
+          } > /tmp/issue-body.md
+
+          EXISTING=$(gh issue list --repo "$REPO" --state open --search "\"$MARKER\" in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body-file /tmp/issue-body.md
+          else
+            gh issue create --repo "$REPO" --title "$MARKER" --body-file /tmp/issue-body.md
+          fi

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      _R_CHECK_CRAN_INCOMING_: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   test-e2e:
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -28,3 +27,37 @@ jobs:
 
       - name: Run E2E tests
         run: make test-e2e
+
+  # Runs once per run; nightly E2E failures otherwise go unnoticed since
+  # nobody watches the schedule tab.
+  notify-on-failure:
+    needs: test-e2e
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: File or update a CI failure issue
+        run: |
+          set -euo pipefail
+          MARKER="ci: e2e test failing"
+          REPO="${{ github.repository }}"
+          RUN_URL="${{ github.server_url }}/${REPO}/actions/runs/${{ github.run_id }}"
+
+          {
+            echo "E2E test run failed."
+            echo ""
+            echo "Run: $RUN_URL"
+          } > /tmp/issue-body.md
+
+          EXISTING=$(gh issue list --repo "$REPO" --state open --search "\"$MARKER\" in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body-file /tmp/issue-body.md
+          else
+            gh issue create --repo "$REPO" --title "$MARKER" --body-file /tmp/issue-body.md
+          fi


### PR DESCRIPTION
## Summary
- Add a `notify-on-failure` job to `R-CMD-check-extended.yaml` and `test-e2e.yaml` that files a GitHub issue (or comments on an existing open one, matched by title) when the run fails, since nobody watches master CI or the nightly schedule tab.
- Remove `continue-on-error: true` from the E2E job: the last 6 scheduled/push runs (2026-07-16 to 2026-07-21) were all green, so the flag was only masking a run's true status, not absorbing real flakiness.
- Add `_R_CHECK_CRAN_INCOMING_: false` to the PR-gate job env in `R-CMD-check.yaml`, skipping the CRAN incoming feasibility network call that `--as-cran` otherwise performs on every PR run (a flake source and ~10-30s of runtime). `R-CMD-check-extended.yaml` is left untouched so the post-merge run still exercises full CRAN-like behavior.
- Add a `concurrency` block to `R-CMD-check-extended.yaml` grouped by workflow name only (not ref), so a burst of merges within a minute collapses to one run instead of queuing several redundant full-matrix runs; only the newest run (repo tip) matters for validation and for saving the master dependency caches PRs restore.

## Notes on token permissions
Both notify jobs run as a separate job (`needs: <main job>`, `if: failure()`) rather than a per-matrix-leg step, so the issue is filed/commented on once per run regardless of how many matrix legs failed. Each notify job sets its own job-level `permissions: { issues: write, actions: read }` since job-level permissions fully replace the workflow-level `permissions: read-all` / `contents: read` rather than adding to them, and the job needs `actions: read` to call `gh run view` for the list of failing matrix configs.

## Test plan
- [x] `Rscript -e "yaml::read_yaml(...)"` on all three edited workflow files parses cleanly.
- [x] `gh run list --workflow "E2E Test" --limit 20` reviewed to confirm consistent green history before dropping `continue-on-error`.
- [ ] First real failure of either workflow to confirm the issue-filing step behaves as expected (can't be exercised in CI without an actual failure).