### PR TITLE
ci: streamline the release build pipeline

### DIFF
--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -57,13 +57,21 @@ jobs:
           echo "SKIP_VERSION_BUMP=$skip_version_bump" >> "$GITHUB_OUTPUT"
         shell: bash
 
-  preBuild:
+  # Single job covering what preBuild and build used to do separately, so the
+  # checkout / pandoc / R / dependency setup runs once instead of twice.
+  #
+  # Step order is load-bearing: the bumpVersion and updateNews composite
+  # actions re-run actions/checkout, which wipes the workspace (clean: true is
+  # the default). Everything that has to survive into the artifacts is
+  # therefore produced after those two composites.
+  build:
     runs-on: ubuntu-latest
     needs: [labelChecks]
     if: ${{ needs.labelChecks.outputs.READY_TO_BUILD == 'true' && github.event.pull_request.merged == true }}
     outputs:
       NEW_VERSION: ${{ steps.getNewVersion.outputs.NEW_VERSION }}
-      ARTIFACTS: ${{ steps.getPrebuildArtifacts.outputs.ARTIFACTS }}
+      PREBUILD_ARTIFACTS: ${{ steps.getPrebuildArtifacts.outputs.ARTIFACTS }}
+      BUILD_ARTIFACTS: ${{ steps.getBuildArtifacts.outputs.ARTIFACTS }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -85,22 +93,37 @@ jobs:
         with:
           needs: release
 
-      - name: Check for R CMD check
+      # Structural check only. Correctness is already gated elsewhere: every PR
+      # must pass R CMD check on three platforms before it can merge
+      # (R-CMD-check.yaml), and every push to master runs the full five-config
+      # matrix with vignettes (R-CMD-check-extended.yaml), which is the matrix
+      # cran-comments.md reports on. Re-running tests, examples and vignettes
+      # here bought nothing but wall time.
+      #
+      # What those runs do NOT cover is the release-specific view of the merge
+      # commit: --as-cran metadata, package structure and documentation. That is
+      # what this step keeps, and it is what CHECK_STATUS now attests to.
+      #
+      # It runs before the version bump on purpose: a failure has to leave
+      # master unmutated, exactly as it did when the full check ran first.
+      - name: Structural R CMD check (--as-cran)
         id: rcmdCheck
         run: |
           Rscript -e '
-            results <- devtools::check(args = c("--as-cran", "--no-manual", "--no-build-vignettes"))
+            results <- devtools::check(
+              document = FALSE,
+              vignettes = FALSE,
+              args = c(
+                "--as-cran", "--no-manual", "--no-build-vignettes",
+                "--no-tests", "--no-examples", "--no-vignettes"
+              ),
+              build_args = c("--no-build-vignettes"),
+              error_on = "warning"
+            )
             status <- ifelse(length(results$errors) == 0 && length(results$warnings) == 0, "success", "failure")
             cat("CHECK_STATUS=", status, "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep="")
           '
         continue-on-error: false
-
-      # - name: Check reverse dependencies
-      #   id: rcmdCheckReverse
-      #   run: |
-      #     # The library must be added and loaded first
-      #     Rscript -e 'revdepcheck::revdep_check(num_workers = 4)'
-      #   continue-on-error: false
 
       - name: Get current versions
         id: getCurrentVersions
@@ -136,7 +159,30 @@ jobs:
             NEW_VERSION="${{ steps.getCurrentVersions.outputs.OLD_VERSION }}"
           fi
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "BUILD_ARTIFACT=artma_${NEW_VERSION}.tar.gz" >> $GITHUB_OUTPUT
 
+      # build_pkg() calls devtools::document() itself (scripts/R/release.R), so
+      # the separate documentation step that used to live here was a no-op.
+      - name: Build the .tar.gz
+        run: |
+          pkg_version <- devtools::as.package('.')$version
+          if (pkg_version != Sys.getenv("NEW_VERSION")) {
+            # This means the version was not bumped
+            cli::cli_abort("Version mismatch: {pkg_version} != {Sys.getenv('NEW_VERSION')}")
+          }
+          source("./scripts/R/release.R")
+          build_pkg(
+            pkg = ".",
+            path = "./${{ steps.getNewVersion.outputs.BUILD_ARTIFACT }}"
+          )
+        env:
+          NEW_VERSION: ${{ steps.getNewVersion.outputs.NEW_VERSION }}
+        shell: Rscript {0}
+
+      # cran-comments.md, release-notes.md and metadata.json are all
+      # .Rbuildignore'd, and they are generated after the tarball is built so
+      # the shipped tarball is byte-for-byte what it was when these lived in a
+      # separate job.
       - name: Create release notes
         run: |
           Rscript ./scripts/R/get_release_notes.R \
@@ -159,7 +205,7 @@ jobs:
             --arg CRAN_VERSION "${{ steps.getCurrentVersions.outputs.CRAN_VERSION }}" \
             --arg NEW_VERSION "${{ steps.getNewVersion.outputs.NEW_VERSION }}" \
             --arg TAG_NAME "v${{ steps.getNewVersion.outputs.NEW_VERSION }}" \
-            --arg BUILD_ARTIFACT "artma_${{ steps.getNewVersion.outputs.NEW_VERSION }}.tar.gz" \
+            --arg BUILD_ARTIFACT "${{ steps.getNewVersion.outputs.BUILD_ARTIFACT }}" \
             --arg SKIP_CRAN "${{ needs.labelChecks.outputs.SKIP_CRAN }}" \
             '{$OLD_VERSION, $CRAN_VERSION, $NEW_VERSION, $TAG_NAME, $BUILD_ARTIFACT, $SKIP_CRAN}' > metadata.json
 
@@ -179,70 +225,12 @@ jobs:
           name: prebuild-artifacts
           path: ${{ steps.getPrebuildArtifacts.outputs.ARTIFACTS }}
 
-  build:
-    runs-on: ubuntu-latest
-    needs: [labelChecks, preBuild]
-    outputs:
-      ARTIFACTS: ${{ steps.getBuildArtifacts.outputs.ARTIFACTS }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          ref: master
-          # The ARTMA_BOT_COMMIT_TOKEN is a personal access token tied to ArtmaBot
-          # This is a workaround to allow pushes to a protected branch
-          token: ${{ secrets.ARTMA_BOT_COMMIT_TOKEN }}
-
-      - name: Set up pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          needs: release
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: prebuild-artifacts
-
-      - name: Set job metadata
-        id: setJobMetadata
-        run: |
-          while IFS="=" read -r key value; do
-            echo "$key=$value" >> $GITHUB_OUTPUT
-          done < <(jq -r 'to_entries[] | "\(.key)=\(.value)"' metadata.json)
-
-      - name: Build documentation
-        run: |
-          Rscript -e 'devtools::document()'
-
-      - name: Build the .tar.gz
-        run: |
-          pkg_version <- devtools::as.package('.')$version
-          if (pkg_version != Sys.getenv("NEW_VERSION")) {
-            # This means the version was not bumped
-            cli::cli_abort("Version mismatch: {pkg_version} != {Sys.getenv('NEW_VERSION')}")
-          }
-          source("./scripts/R/release.R")
-          build_pkg(
-            pkg = ".",
-            path = "./${{ steps.setJobMetadata.outputs.BUILD_ARTIFACT }}"
-          )
-        env:
-          NEW_VERSION: ${{ needs.preBuild.outputs.NEW_VERSION }}
-        shell: Rscript {0}
-
       - name: Get build artifacts
         id: getBuildArtifacts
         run: |
           {
             echo 'ARTIFACTS<<EOF'
-            echo ${{ steps.setJobMetadata.outputs.BUILD_ARTIFACT }}
+            echo ${{ steps.getNewVersion.outputs.BUILD_ARTIFACT }}
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
@@ -255,7 +243,7 @@ jobs:
 
   postBuild:
     runs-on: ubuntu-latest
-    needs: [preBuild, build]
+    needs: [build]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -275,7 +263,7 @@ jobs:
           ./.github/scripts/checkArtifacts.sh 'prebuild-artifacts.txt'
 
           # Rename the build artifact to include .gz extension as expected
-          mv build-artifacts/* "${{ needs.build.outputs.ARTIFACTS }}"
+          mv build-artifacts/* "${{ needs.build.outputs.BUILD_ARTIFACTS }}"
           ./.github/scripts/checkArtifacts.sh 'build-artifacts.txt'
 
       - name: Unpack the metadata
@@ -296,8 +284,8 @@ jobs:
         with:
           tag_name: ${{ steps.unpackMetadata.outputs.TAG_NAME }}
           files: |
-            ${{ needs.preBuild.outputs.ARTIFACTS }}
-            ${{ needs.build.outputs.ARTIFACTS }}
+            ${{ needs.build.outputs.PREBUILD_ARTIFACTS }}
+            ${{ needs.build.outputs.BUILD_ARTIFACTS }}
           body_path: ./release-notes.md
           draft: false
           prerelease: false


### PR DESCRIPTION
## What

Collapses the release pipeline in `.github/workflows/build-and-tag.yaml` from three R-provisioning jobs to one, and cuts the redundant part of the release-time `R CMD check`. No change to the tag, release-asset, or CRAN-submission contract.

## The three changes

### 1. `preBuild` + `build` merged into a single `build` job

Both jobs did the same checkout, pandoc setup, R setup, and full `setup-r-dependencies` install (~3 min each) purely to hand four files and a tarball between them via artifacts. They are now one job with one setup.

Step order is load-bearing and preserved. The `bumpVersion` and `updateNews` composite actions each re-run `actions/checkout`, which wipes the workspace (`clean: true` is the default). So every file that has to survive into the artifacts is still produced *after* those composites. That is also why the tarball is now built before `cran-comments.md` / `release-notes.md` / `metadata.json` are generated: those three are `.Rbuildignore`d and were never present in the old `build` job's workspace, so building first keeps the shipped tarball identical to what it was before. Comments in the file record both constraints.

### 2. Release `R CMD check` reduced to a structural `--as-cran` check

Kept, not dropped, but with `--no-tests --no-examples --no-vignettes` and `document = FALSE`.

Reasoning:

* Correctness is already gated twice. Since #235 every PR must pass `R CMD check` on three platforms before it can merge, and every push to master runs the five-config matrix with vignettes in `R-CMD-check-extended.yaml`. Re-running tests, examples and vignettes on the merge commit bought wall time and nothing else.
* `generate_cran_comments.R` does not need a fresh full verdict. Its `write_cmd_check_results()` already hardcodes the five-config matrix list under "R CMD check passed on:", i.e. the text has always been reporting the *extended matrix*, not the release-time check. `CHECK_STATUS` only selects between the "0 errors / 0 warnings / 0 notes" line and a failure line.
* In practice `CHECK_STATUS` could never be `failure` anyway: `devtools::check()` defaults to `error_on = "warning"` non-interactively, so any warning aborted the step before the status was written. I made that explicit rather than changing it.
* What the three gating runs do *not* cover is the release-specific view of the merge commit as CRAN sees it: `--as-cran` metadata, package structure, documentation. That is exactly what the trimmed check retains, so `CHECK_STATUS` still attests to something real.
* It still runs *before* the version bump, so a failure leaves master unmutated, same as before.

### 3. `devtools::document()` step dropped from the build

`build_pkg()` in `scripts/R/release.R` already calls `devtools::document()` before `pkgbuild::build()`. The workflow step was a duplicate no-op on top of a committed `man/` and `NAMESPACE`.

## Wall time

Revised after measuring the trimmed check locally (16.3 s on an M-series Mac with dependencies warm). Budgeting ~1 min for it on a runner:

| | Before | After |
|---|---|---|
| `labelChecks` | ~10 s | ~10 s |
| `preBuild` | ~25 min (3 min setup + 15 to 20 min full check + ~4.5 min composites) | merged |
| `build` | ~5 min (3 min setup + document + build) | merged |
| combined build job | | ~10 to 12 min (3 min setup + ~1 min structural check + ~4.5 min composites + ~1.5 min build) |
| `postBuild` | ~1 min | ~1 min |
| **total** | **~31 min** | **~11 min** |

The composite actions still do their own checkout and R setup; that is untouched here deliberately, since they push to a protected branch as ArtmaBot and are the riskiest part of the pipeline.

## Compatibility

Unchanged: artifact names (`prebuild-artifacts`, `build-artifacts`), the contents of `.github/scripts/prebuild-artifacts.txt` and `build-artifacts.txt`, the `metadata.json` key set and values, `release-notes.md`, the tag name, and the release asset list. `postBuild` still needs no R setup.

`submit-to-cran.yaml` reads `SKIP_CRAN` and `BUILD_ARTIFACT` out of `metadata.json`; both are produced identically (`BUILD_ARTIFACT` is now computed once in `getNewVersion` instead of being re-interpolated in two places, same string).

Only rename: the old `preBuild.outputs.ARTIFACTS` / `build.outputs.ARTIFACTS` pair became `build.outputs.PREBUILD_ARTIFACTS` / `build.outputs.BUILD_ARTIFACTS`, and `postBuild.needs` is now `[build]`. Both references in `postBuild` were updated.

## Verification

### Static

* `actionlint` (1.7.12) is clean: 0 non-shellcheck findings, and the 7 shellcheck style/info notes are byte-identical to the ones the original file already produced.
* YAML parses; job graph is `labelChecks` to `build` to `postBuild`.
* Scripted audit of every `${{ steps.*.outputs.* }}` and `${{ needs.*.outputs.* }}` in the file: every step id exists in its own job, every `needs.X` is declared in that job's `needs:`, and every referenced job output is declared. All resolve.
* PR gates green (R CMD check on three platforms, lint, commitlint, coverage). Note these do not execute this workflow at all, since it only fires on a merged PR into master.

### Simulated release run

`act` needs Docker, which is not available here, so instead the job was replayed step by step against a fresh clone of this branch in a scratch dir, in the exact order the workflow defines, using the real scripts (`bump_version.R`, `git-chglog`, `build_pkg()`, `get_release_notes.R`, `generate_cran_comments.R`, `checkArtifacts.sh`) on a simulated 0.3.3 to 0.3.4 patch release:

* Trimmed `--as-cran` check: **0 errors, 0 warnings, 0 notes** in **16.3 s**. (One WARNING appeared locally, `-Wfixed-enum-extension` unknown to clang in Homebrew R's headers. That is a macOS toolchain artifact, not a package problem, and the three-platform PR check is green.)
* `bump_version.R patch` bumped `DESCRIPTION` and the options template 0.3.3 to 0.3.4.
* `git-chglog --next-tag v0.3.4` wrote the `<a name="v0.3.4">` anchor, and `get_release_notes.R` then extracted 54 lines from it. This is the data dependency between the two composites and the release notes, and it holds.
* The version guard passed and `build_pkg()` produced `artma_0.3.4.tar.gz` (331 KB) at exactly the `BUILD_ARTIFACT` path the metadata records.
* Tarball contents confirm the reordering is safe: `NEWS.md` is in, and `cran-comments.md` / `metadata.json` / `release-notes.md` are absent, matching what the old two-job split produced.
* `cran-comments.md` and `metadata.json` generated; `checkArtifacts.sh` passed for **both** `prebuild-artifacts.txt` and `build-artifacts.txt`; and re-reading `metadata.json` with the `jq` expression `submit-to-cran.yaml` uses returns all six keys intact.

### Still not covered

* That `actions/checkout` inside the `bumpVersion` and `updateNews` composites leaves the workspace in the state the later build step expects **when they run in the same job** rather than in a job that ends right after them. The simulation reproduced the file-level effects but not the checkout-wipe itself. This is the one behavioral assumption only a live run can confirm.
* The real push to the protected branch, the tag push, and the release-asset upload (all need ArtmaBot credentials).

If the composite-checkout assumption is wrong, the failure mode is a missing-artifact abort in `checkArtifacts.sh` before the tag is pushed, which is recoverable. Recommend labeling the next routine release as the live test rather than forcing one.
