### PR TITLE
feat: support user-defined data subset conditions

### DIFF
--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -193,6 +193,71 @@ enforce_correct_values <- function(df) {
   df
 }
 
+#' @title Apply user-defined subset conditions
+#' @description Filter the data frame down to rows matching every user-defined
+#'   condition in `artma.data.subset_conditions`. Each condition is an R
+#'   expression (e.g. `"country == 'USA'"`, `"year >= 2000"`) evaluated against
+#'   the data frame; conditions are combined with logical AND. Rows for which a
+#'   condition evaluates to `NA` are dropped, matching base `subset()` semantics.
+#' @param df *\[data.frame\]* The data frame to subset
+#' @return *\[data.frame\]* The data frame restricted to rows matching every condition
+#' @keywords internal
+apply_subset_conditions <- function(df) {
+  box::use(
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / core / validation[assert]
+  )
+
+  conditions <- getOption("artma.data.subset_conditions", default = NA_character_)
+  conditions <- conditions[!is.na(conditions)]
+
+  if (length(conditions) == 0) {
+    return(df)
+  }
+
+  if (get_verbosity() >= 3) {
+    cli::cli_inform("Applying {length(conditions)} user-defined subset condition{?s}...")
+  }
+
+  n_before <- nrow(df)
+
+  for (condition in conditions) {
+    parsed <- tryCatch(str2lang(condition), error = function(err) NULL)
+    assert(!is.null(parsed), sprintf("Invalid subset condition: %s", condition))
+
+    keep <- tryCatch(
+      eval(parsed, envir = df, enclos = parent.frame()),
+      error = function(err) {
+        cli::cli_abort(c(
+          "x" = "Failed to evaluate subset condition {.val {condition}}.",
+          "i" = conditionMessage(err)
+        ))
+      }
+    )
+
+    assert(
+      is.logical(keep) && length(keep) == nrow(df),
+      sprintf(
+        "Subset condition '%s' must evaluate to a logical vector matching the number of rows",
+        condition
+      )
+    )
+
+    df <- df[!is.na(keep) & keep, , drop = FALSE]
+  }
+
+  if (get_verbosity() >= 3) {
+    n_removed <- n_before - nrow(df)
+    if (n_removed > 0) {
+      cli::cli_alert_success(
+        "Removed {n_removed} row{?s} via user-defined subset conditions ({nrow(df)} remaining)."
+      )
+    }
+  }
+
+  df
+}
+
 #' @title Winsorize data
 #' @description Winsorize effect and standard error columns at specified quantiles.
 #' @param df *\[data.frame\]* The data frame to winsorize
@@ -266,7 +331,8 @@ clean_data <- function(df) {
 
 #' @title Preprocess data
 #' @description Preprocess a standardized data frame: removes empty rows, handles
-#'   missing values, enforces data types, winsorizes, and validates values.
+#'   missing values, enforces data types, applies user-defined subset conditions,
+#'   winsorizes, and validates values.
 #'   Column presence validation is handled upstream by the schema reconciliation
 #'   step; this function assumes the dataframe columns already match the config.
 #'   It is pure: the missing-value strategy is resolved beforehand by
@@ -281,8 +347,15 @@ preprocess_data <- function(df) {
     clean_data() |>
     handle_missing_values() |>
     enforce_data_types() |>
+    apply_subset_conditions() |>
     winsorize_data() |>
     enforce_correct_values()
 }
 
-box::export(clean_data, enforce_data_types, preprocess_data, resolve_na_handling)
+box::export(
+  clean_data,
+  enforce_data_types,
+  apply_subset_conditions,
+  preprocess_data,
+  resolve_na_handling
+)

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -750,6 +750,18 @@ data:
         {cli::symbol$bullet} {.strong 0.10}: Winsorize at 10% level
       Higher values provide stronger outlier protection but may distort the data more.
 
+  subset_conditions:
+    type: "character"
+    default: .na
+    allow_na: true
+    help: |
+      Optional user-defined filter conditions applied to the data frame before analysis.
+      Each element is an R expression evaluated against the data, e.g.:
+        {cli::symbol$bullet} {.emph country == 'USA'}
+        {cli::symbol$bullet} {.emph year >= 2000}
+      All conditions must hold for a row to be kept (conditions are combined with AND).
+      Leave unset (NA) to skip subsetting.
+
 
 output:
   dir:

--- a/tests/testthat/test-data-preprocess.R
+++ b/tests/testthat/test-data-preprocess.R
@@ -78,3 +78,88 @@ test_that("enforce_data_types skips entries without type information", {
   expect_true(is.numeric(result$x))
   expect_equal(result$y, df$y)
 })
+
+# -- apply_subset_conditions ---------------------------------------------------
+
+test_that("apply_subset_conditions returns the data frame unchanged when unset", {
+  box::use(artma / data / preprocess[apply_subset_conditions])
+
+  withr::local_options(list(
+    "artma.data.subset_conditions" = NA_character_,
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(country = c("USA", "UK"), year = c(1999, 2001))
+  expect_equal(apply_subset_conditions(df), df)
+})
+
+test_that("apply_subset_conditions filters rows matching a single condition", {
+  box::use(artma / data / preprocess[apply_subset_conditions])
+
+  withr::local_options(list(
+    "artma.data.subset_conditions" = "year >= 2000",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(country = c("USA", "UK", "USA"), year = c(1999, 2001, 2005))
+  result <- apply_subset_conditions(df)
+
+  expect_equal(result$year, c(2001, 2005))
+})
+
+test_that("apply_subset_conditions combines multiple conditions with AND", {
+  box::use(artma / data / preprocess[apply_subset_conditions])
+
+  withr::local_options(list(
+    "artma.data.subset_conditions" = c("year >= 2000", "country == 'USA'"),
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(
+    country = c("USA", "UK", "USA"),
+    year = c(1999, 2001, 2005)
+  )
+  result <- apply_subset_conditions(df)
+
+  expect_equal(nrow(result), 1)
+  expect_equal(result$year, 2005)
+})
+
+test_that("apply_subset_conditions drops rows where the condition evaluates to NA", {
+  box::use(artma / data / preprocess[apply_subset_conditions])
+
+  withr::local_options(list(
+    "artma.data.subset_conditions" = "year >= 2000",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(country = c("USA", "UK"), year = c(NA, 2001))
+  result <- apply_subset_conditions(df)
+
+  expect_equal(nrow(result), 1)
+  expect_equal(result$country, "UK")
+})
+
+test_that("apply_subset_conditions errors on an unparseable condition", {
+  box::use(artma / data / preprocess[apply_subset_conditions])
+
+  withr::local_options(list(
+    "artma.data.subset_conditions" = "year >=",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(year = c(1999, 2001))
+  expect_error(apply_subset_conditions(df), "Invalid subset condition")
+})
+
+test_that("apply_subset_conditions errors when a condition targets a missing column", {
+  box::use(artma / data / preprocess[apply_subset_conditions])
+
+  withr::local_options(list(
+    "artma.data.subset_conditions" = "region == 'EU'",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(country = c("USA", "UK"), year = c(1999, 2001))
+  expect_error(apply_subset_conditions(df), "Failed to evaluate subset condition")
+})


### PR DESCRIPTION
Adds `artma.data.subset_conditions`, an optional character vector of R filter expressions (e.g. `country == 'USA'`, `year >= 2000`) evaluated against the data frame during preprocessing, right after type enforcement and before winsorization. Conditions are combined with logical AND, matching the thesis's `applyDataSubsetConditions`.

Closes #220