### PR TITLE
Add local git hooks for style, lint, and commit-msg checks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# commit-msg hook: validates Conventional Commits formatting, matching the
+# repo's Commit Lint CI check where possible.
+#
+# Installed via `make hooks` (git config core.hooksPath .githooks).
+
+set -u
+
+COMMIT_MSG_FILE="$1"
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+fallback_check() {
+  local header
+  header=$(head -n1 "$COMMIT_MSG_FILE")
+
+  local types="build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test"
+  local pattern="^(${types})(\([a-zA-Z0-9_./-]+\))?!?: .+"
+
+  if ! echo "$header" | grep -Eq "$pattern"; then
+    echo "" >&2
+    echo "error: commit message does not follow Conventional Commits format." >&2
+    echo "  expected: type(scope)!: subject" >&2
+    echo "  types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test" >&2
+    echo "  example: feat(cache): add memoise-backed CLI cache" >&2
+    return 1
+  fi
+
+  local len=${#header}
+  if [ "$len" -gt 100 ]; then
+    echo "warning: commit message header is $len characters; repo convention keeps it under 100, on a single line." >&2
+  fi
+
+  return 0
+}
+
+if command -v npx >/dev/null 2>&1; then
+  timeout 15 npx --yes -p commitlint@latest -p @commitlint/config-conventional \
+    -c 'commitlint --version' >/dev/null 2>&1
+  PROBE_STATUS=$?
+
+  if [ "$PROBE_STATUS" -eq 0 ]; then
+    COMMITLINT_OUTPUT=$(cd "$REPO_ROOT" && timeout 15 npx --yes -p commitlint@latest -p @commitlint/config-conventional \
+      -c "commitlint --config \"$REPO_ROOT/commitlint.config.js\" --edit \"$COMMIT_MSG_FILE\"" 2>&1)
+    COMMITLINT_STATUS=$?
+
+    if [ "$COMMITLINT_STATUS" -ne 0 ]; then
+      echo "" >&2
+      echo "error: commitlint rejected the commit message:" >&2
+      echo "$COMMITLINT_OUTPUT" >&2
+      exit 1
+    fi
+
+    exit 0
+  fi
+
+  echo "warning: commitlint via npx was unavailable (no network or resolution failure); falling back to a regex check." >&2
+fi
+
+fallback_check || exit 1
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Pre-commit hook: styles and lints staged .R files only.
+#
+# Installed via `make hooks` (git config core.hooksPath .githooks). See
+# CLAUDE.md's Pre-commit Checklist for the manual equivalent of this check.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+HOOK_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+STAGED_FILES=()
+while IFS= read -r line; do
+  [ -n "$line" ] && STAGED_FILES+=("$line")
+done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.R')
+
+if [ "${#STAGED_FILES[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+if ! command -v Rscript >/dev/null 2>&1; then
+  echo "warning: Rscript not found on PATH, skipping pre-commit style/lint checks" >&2
+  exit 0
+fi
+
+# Never touch a file that has unstaged changes on top of what is staged: we
+# cannot safely auto-style/re-add it without pulling unstaged edits into the
+# commit, so ask the user to fully stage (or stash) it instead.
+PARTIAL_FILES=()
+FULL_FILES=()
+for f in "${STAGED_FILES[@]}"; do
+  if [ -n "$(git diff --name-only -- "$f")" ]; then
+    PARTIAL_FILES+=("$f")
+  else
+    FULL_FILES+=("$f")
+  fi
+done
+
+if [ "${#PARTIAL_FILES[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "error: the following staged .R files also have unstaged changes:" >&2
+  printf '  %s\n' "${PARTIAL_FILES[@]}" >&2
+  echo "Stage the rest of the changes (or stash them separately) and re-commit;" >&2
+  echo "the pre-commit hook cannot safely auto-style a partially staged file." >&2
+  exit 1
+fi
+
+if [ "${#FULL_FILES[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+OUTPUT=$(cd "$REPO_ROOT" && Rscript "$HOOK_DIR/pre-commit-lint.R" "$REPO_ROOT" "${FULL_FILES[@]}" 2>&1)
+STATUS=$?
+
+if [ "$STATUS" -eq 2 ]; then
+  echo "warning: pre-commit style/lint check hit an internal error, skipping:" >&2
+  echo "$OUTPUT" >&2
+  exit 0
+fi
+
+STYLED_FILES=$(printf '%s\n' "$OUTPUT" | awk '/::STYLED::/{f=1;next} /::END_STYLED::/{f=0} f')
+if [ -n "$STYLED_FILES" ]; then
+  while IFS= read -r sf; do
+    [ -n "$sf" ] && (cd "$REPO_ROOT" && git add -- "$sf")
+  done <<<"$STYLED_FILES"
+  echo "note: styler reformatted and re-staged the following file(s):" >&2
+  printf '%s\n' "$STYLED_FILES" | sed 's/^/  /' >&2
+fi
+
+if [ "$STATUS" -eq 1 ]; then
+  echo "" >&2
+  echo "error: lintr found issues in staged .R files; commit blocked." >&2
+  printf '%s\n' "$OUTPUT" | grep -v '^::' >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit-lint.R
+++ b/.githooks/pre-commit-lint.R
@@ -1,0 +1,64 @@
+#!/usr/bin/env Rscript
+
+# Styles and lints staged .R files for the pre-commit hook.
+#
+# Usage: Rscript pre-commit-lint.R <repo_root> <file1> [file2 ...]
+#
+# Exit codes:
+#   0 - clean (files may have been auto-styled; see ::STYLED:: markers)
+#   1 - lintr found issues; the commit should be blocked
+#   2 - internal error (missing packages, unexpected failure); the caller
+#       should warn and let the commit through rather than block on this
+
+args <- commandArgs(trailingOnly = TRUE)
+
+if (length(args) < 2) {
+  quit(status = 0, save = "no")
+}
+
+repo_root <- args[[1]]
+files <- args[-1]
+
+result <- tryCatch(
+  {
+    if (!requireNamespace("styler", quietly = TRUE) || !requireNamespace("lintr", quietly = TRUE)) {
+      stop("styler and/or lintr package not installed", call. = FALSE)
+    }
+
+    options(box.path = file.path(repo_root, "inst"))
+
+    styled_files <- character(0)
+    for (f in files) {
+      before <- readLines(f, warn = FALSE)
+      invisible(utils::capture.output(styler::style_file(f)))
+      after <- readLines(f, warn = FALSE)
+      if (!identical(before, after)) {
+        styled_files <- c(styled_files, f)
+      }
+    }
+
+    if (length(styled_files) > 0) {
+      cat("::STYLED::\n")
+      cat(paste(styled_files, collapse = "\n"), "\n", sep = "")
+      cat("::END_STYLED::\n")
+    }
+
+    lint_failures <- FALSE
+    for (f in files) {
+      lints <- lintr::lint(f)
+      if (length(lints) > 0) {
+        lint_failures <- TRUE
+        cat("::LINT_FAIL::", f, "\n", sep = "")
+        print(lints)
+      }
+    }
+
+    if (lint_failures) 1L else 0L
+  },
+  error = function(e) {
+    cat("::INTERNAL_ERROR::", conditionMessage(e), "\n", sep = "")
+    2L
+  }
+)
+
+quit(status = result, save = "no")

--- a/.lintr.R
+++ b/.lintr.R
@@ -7,70 +7,71 @@ custom_linters_env <- new.env()
 # The custom linters live under scripts/ so that the installed package does
 # not carry lintr as a runtime dependency.
 source(
-    local({
-        path <- getwd()
-        while (!file.exists(file.path(path, "DESCRIPTION")) && dirname(path) != path) {
-            path <- dirname(path)
-        }
-        file.path(path, "scripts", "linters.R")
-    }),
-    local = custom_linters_env,
-    chdir = TRUE
+  local({
+    path <- getwd()
+    while (!file.exists(file.path(path, "DESCRIPTION")) && dirname(path) != path) {
+      path <- dirname(path)
+    }
+    file.path(path, "scripts", "linters.R")
+  }),
+  local = custom_linters_env,
+  chdir = TRUE
 )
 
 linters <- c(
-    lintr::linters_with_defaults(
-        # https://lintr.r-lib.org/reference/index.html#individual-linters
-        #
-        # All default lintr linters (resolved from the lintr namespace)
-        defaults = default_linters,
-        # Set indentation to 2 spaces
-        indentation_linter = custom_linters_env$indentation_guard_clause_linter(indent = 2),
-        # Check that all commas are followed by spaces, but do not have spaces before them.
-        commas_linter = lintr::commas_linter(allow_trailing = FALSE),
-        # Check that all comments are preceded by a space
-        object_name_linter = lintr::object_name_linter(
-            styles = c("snake_case", "SNAKE_CASE", "dotted.case")
-        ),
-        object_length_linter = lintr::object_length_linter(length = 40),
-        # Disable the default lintr object usage - incompatible with box module system
-        object_usage_linter = NULL,
-        # No line length limit enforced
-        line_length_linter = lintr::line_length_linter(NULL),
-        # Disable commented code linter
-        commented_code_linter = NULL,
-        # Turn off linting for several functions otherwise flagged as undesirable
-        undesirable_function_linter = lintr::undesirable_function_linter(
-            fun = lintr::modify_defaults(
-                "defaults" = lintr::default_undesirable_functions,
-                "options" = NULL, # Remove down the line
-                "ifelse" = "use 'res <- if (x) expr1 else expr2'",
-                # Console print methods
-                "print" = "use cli::cli_inform()",
-                "cat" = "use cli::cli_inform()",
-                # Base messaging
-                "message" = "use cli::cli_inform()",
-                "warning" = "use cli::cli_warn()",
-                "stop" = "use cli::cli_abort()",
-                # rlang messaging
-                "inform" = "use cli::cli_inform()",
-                "warn" = "use cli::cli_warn()",
-                "abort" = "use cli::cli_abort()"
-            )
-        ),
-        # Check for missing packages and symbols in namespace calls
-        namespace_linter = lintr::namespace_linter()
+  lintr::linters_with_defaults(
+    # https://lintr.r-lib.org/reference/index.html#individual-linters
+    #
+    # All default lintr linters (resolved from the lintr namespace)
+    defaults = default_linters,
+    # Set indentation to 2 spaces
+    indentation_linter = custom_linters_env$indentation_guard_clause_linter(indent = 2),
+    # Check that all commas are followed by spaces, but do not have spaces before them.
+    commas_linter = lintr::commas_linter(allow_trailing = FALSE),
+    # Check that all comments are preceded by a space
+    object_name_linter = lintr::object_name_linter(
+      styles = c("snake_case", "SNAKE_CASE", "dotted.case")
     ),
-    # Custom linters
-    # Disable the usage of 'dir.create' in favor of 'fs::dir_create'
-    dir_create_linter = custom_linters_env$dir_create_linter(),
-    # Flag literal '<U+XXXX>' escape text left behind by C-locale rewrites
-    unicode_escape_linter = custom_linters_env$unicode_escape_linter()
+    object_length_linter = lintr::object_length_linter(length = 40),
+    # Disable the default lintr object usage - incompatible with box module system
+    object_usage_linter = NULL,
+    # No line length limit enforced
+    line_length_linter = lintr::line_length_linter(NULL),
+    # Disable commented code linter
+    commented_code_linter = NULL,
+    # Turn off linting for several functions otherwise flagged as undesirable
+    undesirable_function_linter = lintr::undesirable_function_linter(
+      fun = lintr::modify_defaults(
+        "defaults" = lintr::default_undesirable_functions,
+        "options" = NULL, # Remove down the line
+        "ifelse" = "use 'res <- if (x) expr1 else expr2'",
+        # Console print methods
+        "print" = "use cli::cli_inform()",
+        "cat" = "use cli::cli_inform()",
+        # Base messaging
+        "message" = "use cli::cli_inform()",
+        "warning" = "use cli::cli_warn()",
+        "stop" = "use cli::cli_abort()",
+        # rlang messaging
+        "inform" = "use cli::cli_inform()",
+        "warn" = "use cli::cli_warn()",
+        "abort" = "use cli::cli_abort()"
+      )
+    ),
+    # Check for missing packages and symbols in namespace calls
+    namespace_linter = lintr::namespace_linter()
+  ),
+  # Custom linters
+  # Disable the usage of 'dir.create' in favor of 'fs::dir_create'
+  dir_create_linter = custom_linters_env$dir_create_linter(),
+  # Flag literal '<U+XXXX>' escape text left behind by C-locale rewrites
+  unicode_escape_linter = custom_linters_env$unicode_escape_linter()
 )
 
 exclusions <- list(
-    "local/",
-    "scripts/"
+  "local/",
+  "scripts/",
+  ".githooks/"
 )
 
 # Clean up imported linters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,8 @@ The level is stored in the options file under `autonomy.level` and loaded with t
 
 ## Pre-commit Checklist
 
+Run `make hooks` once per clone; it installs git hooks (`.githooks/`) that then style, lint, and validate commit messages automatically on every commit.
+
 1. `styler::style_pkg()` (or style the changed files).
 2. If you changed `box::use()` imports in `R/*.R` or added an Imports package used only in `inst/artma`: `make document` (see Generated Check Manifest).
 3. `make lint` and `make test`.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #   make build      - Build package tarball
 #   make clean      - Clean build artifacts
 
-.PHONY: help install test test-file test-filter test-e2e check check-fast lint document generate-check-manifest build clean coverage coverage-report style desc-normalize all dev quick setup vignettes preview-vignette fix-options clear-cache stats
+.PHONY: help install test test-file test-filter test-e2e check check-fast lint document generate-check-manifest build clean coverage coverage-report style desc-normalize all dev quick setup hooks vignettes preview-vignette fix-options clear-cache stats
 
 # Default target
 help:
@@ -17,6 +17,7 @@ help:
 	@echo "  make install          Install package locally"
 	@echo "  make deps             Install package dependencies"
 	@echo "  make setup            Setup the development environment"
+	@echo "  make hooks            Install local git hooks (style/lint/commit-msg checks)"
 	@echo "  make test             Run test suite"
 	@echo "  make test-file        Run specific test file (FILE=test-name.R)"
 	@echo "  make test-filter      Run tests matching pattern (FILTER=pattern)"
@@ -48,9 +49,16 @@ deps:
 	@Rscript -e "devtools::install_deps(dependencies = TRUE, upgrade = 'never')"
 
 # Setup development environment
-setup:
+setup: hooks
 	@echo "Setting up development environment..."
 	@bash scripts/setup.sh
+
+# Install local git hooks (style/lint staged .R files, validate commit messages)
+hooks:
+	@echo "Installing git hooks..."
+	@git config core.hooksPath .githooks
+	@chmod +x .githooks/pre-commit .githooks/commit-msg .githooks/pre-commit-lint.R
+	@echo "Done. Hooks now run automatically on commit (see .githooks/)."
 
 # Install package locally
 install: deps


### PR DESCRIPTION
## Summary
- Add version-controlled git hooks under `.githooks/` (pre-commit, commit-msg) wired via `make hooks`, called from `make setup`
- pre-commit styles and lints only staged .R files (skips fast when none staged; aborts instead of touching partially staged files)
- commit-msg validates Conventional Commits via `npx commitlint` (matching CI's config), falling back to a regex check if npx/network is unavailable
- Hook-internal errors (missing R packages, tooling unavailable) warn and let the commit through; actual lint/style/commit-msg findings block
- Exclude `.githooks/` from lintr scanning in `.lintr.R`, matching the existing `scripts/` exclusion
- Document `make hooks` in the Pre-commit Checklist and Makefile help text

## Test plan
- [x] Staged a scratch .R file with real lint violations (`print()`, explicit `return()`); pre-commit hook auto-fixed pure style issues and re-staged them, then blocked the commit on the remaining lint findings
- [x] Attempted a commit with a non-conventional message; commit-msg hook rejected it via npx commitlint
- [x] Verified the regex fallback path (npx hidden from PATH): rejects a bad header, accepts plain/scoped/breaking-change conventional headers
- [x] Made a normal clean commit with a conventional message; both hooks passed
- [x] `make lint` (pre-existing unrelated findings in untouched test files) and `make test` (1421 passed, 0 failed)