### PR TITLE
Add BPE economic significance, graphs, factor summary; explicit no-recommendation

### DIFF
--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -100,12 +100,20 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   autonomy_level <- resolve_effective_autonomy_level(get_autonomy_level())
   current_overrides <- get_existing_bpe_overrides(predictors, config)
   recommended_overrides <- get_bpe_recommendations(predictors, config)
+  # A recommendation of NA is ambiguous between "we recommend the mean" and "we
+  # have no idea": has_recommendation makes the latter an explicit, reportable
+  # outcome instead of silently blending into the mean fallback.
+  has_recommendation <- stats::setNames(
+    vapply(predictors, function(var_name) !is_bpe_override_na(recommended_overrides[[var_name]]), logical(1)),
+    predictors
+  )
 
   override_resolution <- resolve_bpe_overrides(
     predictor_names = predictors,
     autonomy_level = autonomy_level,
     current_overrides = current_overrides,
-    recommended_overrides = recommended_overrides
+    recommended_overrides = recommended_overrides,
+    has_recommendation = has_recommendation
   )
   resolved_overrides <- override_resolution$overrides
 
@@ -191,6 +199,14 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       function(var_name) format_bpe_override(resolved_overrides[[var_name]]),
       character(1)
     ),
+    recommended = vapply(
+      predictors,
+      function(var_name) {
+        format_bpe_recommendation(recommended_overrides[[var_name]], has_recommendation[[var_name]])
+      },
+      character(1)
+    ),
+    has_recommendation = as.logical(has_recommendation[predictors]),
     author_value = round_if_finite(as.numeric(author_values[predictors]), round_to),
     stringsAsFactors = FALSE
   )
@@ -379,7 +395,8 @@ resolve_effective_autonomy_level <- function(level) {
   level %||% CONST$AUTONOMY$DEFAULT
 }
 
-resolve_bpe_overrides <- function(predictor_names, autonomy_level, current_overrides, recommended_overrides) {
+resolve_bpe_overrides <- function(predictor_names, autonomy_level, current_overrides, recommended_overrides,
+                                  has_recommendation) {
   box::use(
     artma / const[CONST],
     artma / libs / core / validation[validate]
@@ -391,7 +408,8 @@ resolve_bpe_overrides <- function(predictor_names, autonomy_level, current_overr
     length(autonomy_level) == 1,
     autonomy_level %in% CONST$AUTONOMY$LEVELS,
     is.list(current_overrides),
-    is.list(recommended_overrides)
+    is.list(recommended_overrides),
+    is.logical(has_recommendation)
   )
 
   if (autonomy_level == "autonomous") {
@@ -420,6 +438,7 @@ resolve_bpe_overrides <- function(predictor_names, autonomy_level, current_overr
     predictor_names = predictor_names,
     current_overrides = current_overrides,
     recommended_overrides = recommended_overrides,
+    has_recommendation = has_recommendation,
     show_recommendations = TRUE
   )
 
@@ -446,14 +465,14 @@ prompt_use_bpe_recommendations <- function() {
 }
 
 prompt_manual_bpe_overrides <- function(predictor_names, current_overrides, recommended_overrides,
-                                        show_recommendations) {
+                                        has_recommendation, show_recommendations) {
   box::use(artma / libs / core / utils[get_verbosity])
 
   overrides <- current_overrides
 
   choice_labels <- vapply(predictor_names, function(var_name) {
     current_label <- format_bpe_override(overrides[[var_name]])
-    rec_label <- format_bpe_override(recommended_overrides[[var_name]])
+    rec_label <- format_bpe_recommendation(recommended_overrides[[var_name]], has_recommendation[[var_name]])
     if (show_recommendations) {
       sprintf("%s (current: %s, recommended: %s)", var_name, current_label, rec_label)
     } else {
@@ -484,6 +503,7 @@ prompt_manual_bpe_overrides <- function(predictor_names, current_overrides, reco
       var_name = var_name,
       current_value = overrides[[var_name]],
       recommended_value = recommended_overrides[[var_name]],
+      has_recommendation = isTRUE(has_recommendation[[var_name]]),
       show_recommendations = show_recommendations
     )
   }
@@ -491,8 +511,9 @@ prompt_manual_bpe_overrides <- function(predictor_names, current_overrides, reco
   overrides
 }
 
-prompt_single_bpe_override <- function(var_name, current_value, recommended_value, show_recommendations) {
-  default_value <- if (show_recommendations && !is_bpe_override_na(recommended_value)) {
+prompt_single_bpe_override <- function(var_name, current_value, recommended_value, has_recommendation,
+                                       show_recommendations) {
+  default_value <- if (show_recommendations && has_recommendation) {
     recommended_value
   } else {
     current_value
@@ -500,7 +521,7 @@ prompt_single_bpe_override <- function(var_name, current_value, recommended_valu
 
   default_label <- format_bpe_override(default_value)
   recommendation_note <- if (show_recommendations) {
-    sprintf(" (recommended: %s)", format_bpe_override(recommended_value))
+    sprintf(" (recommended: %s)", format_bpe_recommendation(recommended_value, has_recommendation))
   } else {
     ""
   }
@@ -1442,6 +1463,20 @@ format_bpe_override <- function(value) {
   as.character(value)
 }
 
+#' @title Format a BPE Recommendation for Display
+#' @description
+#' Distinguishes "no recommendation" (nothing matched, so the mean fallback
+#' is not a genuine recommendation) from an actual recommended value, which
+#' `format_bpe_override()` alone cannot express since both currently share
+#' the same NA representation.
+#' @keywords internal
+format_bpe_recommendation <- function(value, has_recommendation) {
+  if (!isTRUE(has_recommendation)) {
+    return("no recommendation")
+  }
+  format_bpe_override(value)
+}
+
 is_bpe_override_na <- function(value) {
   is.null(value) || length(value) == 0 || (length(value) == 1 && is.na(value))
 }
@@ -1502,4 +1537,4 @@ run <- register_runtime_method(
   suggests = "BMS"
 )
 
-box::export(best_practice_estimate, run)
+box::export(best_practice_estimate, run, infer_bpe_recommendation, format_bpe_recommendation)

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -30,6 +30,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   run_bma_if_missing <- opt$run_bma_if_missing %||% TRUE
   include_economic_significance <- opt$include_economic_significance %||% TRUE
   economic_significance_pip_threshold <- as.numeric(opt$economic_significance_pip_threshold %||% NA_real_)
+  include_factor_summary <- opt$include_factor_summary %||% TRUE
   round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
 
   validate(
@@ -47,6 +48,8 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     length(include_economic_significance) == 1,
     is.numeric(economic_significance_pip_threshold),
     length(economic_significance_pip_threshold) == 1,
+    is.logical(include_factor_summary),
+    length(include_factor_summary) == 1,
     is.numeric(round_to),
     length(round_to) == 1
   )
@@ -211,6 +214,20 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       config = config,
       round_to = round_to,
       pip_threshold = economic_significance_pip_threshold
+    )
+  }
+
+  if (include_factor_summary) {
+    tables$summary_by_factor <- compute_bpe_factor_summary(
+      predictors = predictors,
+      config = config,
+      bma_data = bma_data,
+      coef_post_mean = coef_post_mean,
+      include_intercept = include_intercept,
+      vcov_matrix = vcov_matrix,
+      z_value = z_value,
+      overrides = resolved_overrides,
+      round_to = round_to
     )
   }
 
@@ -859,6 +876,90 @@ compute_bpe_economic_significance <- function(predictors, bma_data, coef_post_me
     out[[col]] <- round_if_finite(out[[col]], round_to)
   }
 
+  rownames(out) <- NULL
+  out
+}
+
+#' @title Best-Practice Estimate Grouped by Factor Levels
+#' @description
+#' For every predictor flagged via `bpe_sum_stats`/`bpe_equal`/`bpe_gltl` in
+#' the data config, splits the BMA observations into factor-level groups
+#' (mirroring `effect_summary_stats`) and computes the best-practice estimate
+#' for each group, holding every other predictor at its configured/resolved
+#' override.
+#' @keywords internal
+compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_mean, include_intercept,
+                                       vcov_matrix, z_value, overrides, round_to) {
+  empty <- data.frame(
+    scope = character(0),
+    study_id = character(0),
+    study_label = character(0),
+    estimate = numeric(0),
+    standard_error = numeric(0),
+    ci_lower = numeric(0),
+    ci_upper = numeric(0),
+    n_obs = integer(0),
+    stringsAsFactors = FALSE
+  )
+
+  rows <- list()
+
+  for (var_name in predictors) {
+    config_key <- find_config_key_for_var(var_name, config)
+    if (is.null(config_key)) {
+      next
+    }
+
+    var_cfg <- config[[config_key]]
+    if (!is_bpe_factor_var(var_cfg)) {
+      next
+    }
+
+    var_label <- var_cfg$var_name_verbose %||% var_name
+    groups <- resolve_bpe_factor_groups(
+      var_label = var_label,
+      equal_val = var_cfg$bpe_equal,
+      gltl_val = var_cfg$bpe_gltl,
+      var_values = bma_data[[var_name]],
+      round_to = round_to
+    )
+
+    for (group in groups) {
+      if (!length(group$row_idx)) {
+        next
+      }
+
+      group_values <- compute_context_values(
+        bma_data = bma_data,
+        row_idx = group$row_idx,
+        predictors = predictors,
+        overrides = overrides
+      )
+
+      row <- build_bpe_row(
+        scope = "factor",
+        study_id = NA_character_,
+        study_label = group$label,
+        predictor_values = group_values,
+        coef_post_mean = coef_post_mean,
+        include_intercept = include_intercept,
+        vcov_matrix = vcov_matrix,
+        z_value = z_value
+      )
+      row$n_obs <- length(group$row_idx)
+      rows[[length(rows) + 1]] <- row
+    }
+  }
+
+  if (!length(rows)) {
+    return(empty)
+  }
+
+  out <- do.call(rbind, rows)
+  out$estimate <- round_if_finite(out$estimate, round_to)
+  out$standard_error <- round_if_finite(out$standard_error, round_to)
+  out$ci_lower <- round_if_finite(out$ci_lower, round_to)
+  out$ci_upper <- round_if_finite(out$ci_upper, round_to)
   rownames(out) <- NULL
   out
 }

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -10,7 +10,9 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
-    artma / options / index[get_option_group]
+    artma / options / index[get_option_group],
+    artma / visualization / options[get_visualization_options],
+    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
   )
 
   validate(is.data.frame(df))
@@ -117,7 +119,6 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   vcov_matrix <- resolve_bpe_vcov(ols_model = ols_model, cluster_ids = context$study_id)
   z_value <- stats::qnorm((1 + conf_level) / 2)
 
-  rows <- list()
   author_values <- compute_context_values(
     bma_data = bma_data,
     row_idx = seq_len(nrow(bma_data)),
@@ -125,12 +126,40 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     overrides = resolved_overrides
   )
 
-  if (include_author_row) {
-    rows[[length(rows) + 1]] <- build_bpe_row(
-      scope = "author",
-      study_id = NA_character_,
-      study_label = "Author",
-      predictor_values = author_values,
+  # Computed unconditionally (regardless of include_author_row/include_study_rows)
+  # because plots reuse the author reference point and per-study estimates.
+  author_row <- build_bpe_row(
+    scope = "author",
+    study_id = NA_character_,
+    study_label = "Author",
+    predictor_values = author_values,
+    coef_post_mean = coef_post_mean,
+    include_intercept = include_intercept,
+    vcov_matrix = vcov_matrix,
+    z_value = z_value
+  )
+
+  study_rows <- list()
+  unique_ids <- unique(context$study_id)
+  for (study_id in unique_ids) {
+    row_idx <- which(context$study_id == study_id)
+    if (!length(row_idx)) {
+      next
+    }
+
+    study_values <- compute_context_values(
+      bma_data = bma_data,
+      row_idx = row_idx,
+      predictors = predictors,
+      overrides = resolved_overrides
+    )
+
+    study_label <- context$study_label[match(study_id, context$study_id)]
+    study_rows[[length(study_rows) + 1]] <- build_bpe_row(
+      scope = "study",
+      study_id = as.character(study_id),
+      study_label = as.character(study_label),
+      predictor_values = study_values,
       coef_post_mean = coef_post_mean,
       include_intercept = include_intercept,
       vcov_matrix = vcov_matrix,
@@ -138,33 +167,12 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     )
   }
 
+  rows <- list()
+  if (include_author_row) {
+    rows[[length(rows) + 1]] <- author_row
+  }
   if (include_study_rows) {
-    unique_ids <- unique(context$study_id)
-    for (study_id in unique_ids) {
-      row_idx <- which(context$study_id == study_id)
-      if (!length(row_idx)) {
-        next
-      }
-
-      study_values <- compute_context_values(
-        bma_data = bma_data,
-        row_idx = row_idx,
-        predictors = predictors,
-        overrides = resolved_overrides
-      )
-
-      study_label <- context$study_label[match(study_id, context$study_id)]
-      rows[[length(rows) + 1]] <- build_bpe_row(
-        scope = "study",
-        study_id = as.character(study_id),
-        study_label = as.character(study_label),
-        predictor_values = study_values,
-        coef_post_mean = coef_post_mean,
-        include_intercept = include_intercept,
-        vcov_matrix = vcov_matrix,
-        z_value = z_value
-      )
-    }
+    rows <- c(rows, study_rows)
   }
 
   summary <- do.call(rbind, rows)
@@ -194,21 +202,32 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   tables <- list(summary = summary)
 
   if (include_economic_significance) {
-    bpe_reference_estimate <- compute_bpe_point_estimate(
-      predictor_values = author_values,
-      coef_post_mean = coef_post_mean,
-      include_intercept = include_intercept
-    )
     tables$economic_significance <- compute_bpe_economic_significance(
       predictors = predictors,
       bma_data = bma_data,
       coef_post_mean = coef_post_mean,
-      bpe_reference_estimate = bpe_reference_estimate,
+      bpe_reference_estimate = author_row$estimate,
       pip_values = pip_values,
       config = config,
       round_to = round_to,
       pip_threshold = economic_significance_pip_threshold
     )
+  }
+
+  vis <- get_visualization_options()
+  plots <- build_bpe_plots(
+    study_rows = study_rows,
+    author_estimate = author_row$estimate,
+    predictors = predictors,
+    config = config,
+    bma_data = bma_data,
+    context = context,
+    round_to = round_to,
+    theme_name = vis$theme
+  )
+
+  if (isTRUE(vis$export_graphics) && length(plots)) {
+    export_bpe_plots(plots = plots, export_path = vis$export_path, graph_scale = vis$graph_scale)
   }
 
   if (get_verbosity() >= 3) {
@@ -222,6 +241,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
 
   invisible(new_method_result(
     tables = tables,
+    plots = plots,
     meta = list(
       formula = formula,
       overrides = override_table,
@@ -841,6 +861,347 @@ compute_bpe_economic_significance <- function(predictors, bma_data, coef_post_me
 
   rownames(out) <- NULL
   out
+}
+
+#' @title Build Best-Practice Estimate Plots
+#' @description
+#' Builds the sorted "miracle" scatter plot of per-study best-practice
+#' estimates (with the author's own estimate highlighted) and, for every
+#' variable flagged for BPE grouping in the data config, a per-factor density
+#' plot of the per-study estimates split by factor level.
+#' @keywords internal
+build_bpe_plots <- function(study_rows, author_estimate, predictors, config, bma_data,
+                            context, round_to, theme_name) {
+  plots <- list()
+
+  study_estimates <- if (length(study_rows)) do.call(rbind, study_rows) else NULL
+
+  min_points_for_scatter <- 4L
+  if (!is.null(study_estimates) && nrow(study_estimates) >= min_points_for_scatter) {
+    plots$bpe_scatter <- create_bpe_scatter_plot(
+      study_estimates = study_estimates,
+      author_estimate = author_estimate,
+      theme_name = theme_name
+    )
+  }
+
+  if (!is.null(study_estimates) && nrow(study_estimates) > 0) {
+    density_plots <- build_bpe_density_plots(
+      predictors = predictors,
+      config = config,
+      bma_data = bma_data,
+      context = context,
+      study_estimates = study_estimates,
+      round_to = round_to,
+      theme_name = theme_name
+    )
+    plots <- c(plots, density_plots)
+  }
+
+  plots
+}
+
+#' @title Create the Sorted BPE Scatter Plot
+#' @description
+#' Studies sorted by their best-practice estimate, a spline smoother through
+#' the sorted points, and a dashed reference line at the author's own
+#' best-practice estimate.
+#' @keywords internal
+create_bpe_scatter_plot <- function(study_estimates, author_estimate, theme_name) {
+  box::use(
+    artma / visualization / colors[get_colors, get_vline_color],
+    artma / visualization / theme[get_theme]
+  )
+
+  has_author_reference <- is.finite(author_estimate)
+
+  plot_df <- study_estimates[order(study_estimates$estimate), , drop = FALSE]
+  plot_df$rank <- seq_len(nrow(plot_df))
+  plot_df$relative_to_author <- "Study"
+  if (has_author_reference) {
+    plot_df$relative_to_author <- "Below author's BPE"
+    plot_df$relative_to_author[
+      is.finite(plot_df$estimate) & plot_df$estimate >= author_estimate
+    ] <- "At or above author's BPE"
+  }
+
+  palette <- get_colors(theme_name, "bpe", submethod = "miracle")
+  vline_color <- get_vline_color(theme_name)
+  plot_theme <- get_theme(theme_name)
+
+  p <- ggplot2::ggplot(
+    data = plot_df,
+    ggplot2::aes(x = .data$rank, y = .data$estimate, color = .data$relative_to_author)
+  ) +
+    ggplot2::geom_errorbar(
+      ggplot2::aes(ymin = .data$ci_lower, ymax = .data$ci_upper),
+      width = 0, alpha = 0.4
+    ) +
+    ggplot2::geom_point(size = 2) +
+    ggplot2::scale_color_brewer(palette = palette, name = "Study vs. author's BPE") +
+    ggplot2::labs(
+      title = NULL,
+      x = "Studies (sorted by best-practice estimate)",
+      y = "Best-practice estimate"
+    ) +
+    plot_theme
+
+  if (has_author_reference) {
+    p <- p + ggplot2::geom_hline(
+      yintercept = author_estimate, linetype = "dashed", color = vline_color, linewidth = 0.85
+    )
+  }
+
+  spline_points <- plot_df[is.finite(plot_df$rank) & is.finite(plot_df$estimate), , drop = FALSE]
+  min_points_for_spline <- 4L
+  if (nrow(spline_points) >= min_points_for_spline) {
+    spline_fit <- tryCatch(
+      stats::smooth.spline(x = spline_points$rank, y = spline_points$estimate),
+      error = function(e) NULL
+    )
+    if (!is.null(spline_fit)) {
+      spline_df <- data.frame(rank = spline_fit$x, estimate = spline_fit$y)
+      p <- p + ggplot2::geom_line(
+        data = spline_df,
+        mapping = ggplot2::aes(x = .data$rank, y = .data$estimate),
+        inherit.aes = FALSE,
+        color = vline_color,
+        linewidth = 1
+      )
+    }
+  }
+
+  p
+}
+
+#' @title Build Per-Factor BPE Density Plots
+#' @description
+#' For every predictor flagged via `bpe_sum_stats`/`bpe_equal`/`bpe_gltl` in
+#' the data config, split studies into groups by that variable's study-level
+#' value and plot the density of their best-practice estimates per group.
+#' @keywords internal
+build_bpe_density_plots <- function(predictors, config, bma_data, context, study_estimates,
+                                    round_to, theme_name) {
+  plots <- list()
+
+  for (var_name in predictors) {
+    config_key <- find_config_key_for_var(var_name, config)
+    if (is.null(config_key)) {
+      next
+    }
+
+    var_cfg <- config[[config_key]]
+    if (!is_bpe_factor_var(var_cfg)) {
+      next
+    }
+
+    var_label <- var_cfg$var_name_verbose %||% var_name
+    study_level_values <- resolve_bpe_study_level_values(bma_data, context, var_name)
+
+    groups <- resolve_bpe_factor_groups(
+      var_label = var_label,
+      equal_val = var_cfg$bpe_equal,
+      gltl_val = var_cfg$bpe_gltl,
+      var_values = study_level_values,
+      round_to = round_to
+    )
+
+    plot_df <- build_bpe_density_plot_data(
+      groups = groups,
+      study_ids = names(study_level_values),
+      study_estimates = study_estimates
+    )
+
+    if (is.null(plot_df) || length(unique(plot_df$group)) < 2) {
+      next
+    }
+
+    plots[[paste0("bpe_density_", var_name)]] <- create_bpe_density_plot(
+      var_label = var_label,
+      group_estimates = plot_df,
+      theme_name = theme_name
+    )
+  }
+
+  plots
+}
+
+#' @title Study-Level Values for a BPE Grouping Variable
+#' @description
+#' Averages a predictor's observation-level values within each study,
+#' returning a named numeric vector keyed by study id.
+#' @keywords internal
+resolve_bpe_study_level_values <- function(bma_data, context, var_name) {
+  study_ids <- unique(context$study_id)
+  values <- vapply(study_ids, function(sid) {
+    row_idx <- which(context$study_id == sid)
+    mean(as.numeric(bma_data[[var_name]][row_idx]), na.rm = TRUE)
+  }, numeric(1))
+  stats::setNames(values, as.character(study_ids))
+}
+
+#' @title Assemble Per-Group Density Plot Data
+#' @description
+#' Maps study-level group membership (indices into `study_ids`) back to each
+#' study's best-practice estimate, producing a long-format data frame with
+#' `estimate` and `group` columns.
+#' @keywords internal
+build_bpe_density_plot_data <- function(groups, study_ids, study_estimates) {
+  if (!length(groups)) {
+    return(NULL)
+  }
+
+  rows <- lapply(groups, function(group) {
+    if (!length(group$row_idx)) {
+      return(NULL)
+    }
+    matched_ids <- study_ids[group$row_idx]
+    estimates <- study_estimates$estimate[as.character(study_estimates$study_id) %in% matched_ids]
+    estimates <- estimates[is.finite(estimates)]
+    if (length(estimates) < 2) {
+      return(NULL)
+    }
+    data.frame(estimate = estimates, group = group$label, stringsAsFactors = FALSE)
+  })
+
+  do.call(rbind, Filter(Negate(is.null), rows))
+}
+
+#' @title Create a Per-Factor BPE Density Plot
+#' @keywords internal
+create_bpe_density_plot <- function(var_label, group_estimates, theme_name) {
+  box::use(
+    artma / visualization / colors[get_colors],
+    artma / visualization / theme[get_theme]
+  )
+
+  palette <- get_colors(theme_name, "bpe", submethod = "density")
+  plot_theme <- get_theme(theme_name)
+
+  ggplot2::ggplot(
+    data = group_estimates,
+    ggplot2::aes(x = .data$estimate, color = .data$group)
+  ) +
+    ggplot2::geom_density(alpha = 0.2, linewidth = 1) +
+    ggplot2::scale_color_brewer(palette = palette, name = var_label) +
+    ggplot2::labs(x = "Best-practice estimate", y = "Density") +
+    plot_theme
+}
+
+#' @title Whether a Config Entry is Flagged for BPE Factor Grouping
+#' @keywords internal
+is_bpe_factor_var <- function(var_cfg) {
+  if (!is.list(var_cfg)) {
+    return(FALSE)
+  }
+
+  flag <- var_cfg$bpe_sum_stats
+  equal <- var_cfg$bpe_equal
+  gltl <- var_cfg$bpe_gltl
+
+  any(c(isTRUE(flag), !is_bpe_override_na(equal), !is_bpe_override_na(gltl)))
+}
+
+#' @title Split a Variable's Values into BPE Factor-Level Groups
+#' @description
+#' Mirrors the equal/gltl split used by `effect_summary_stats`: an exact-match
+#' group when `equal_val` is set, greater/less-than groups when `gltl_val` is
+#' set (accepting "mean"/"median" as well as a literal threshold), and,
+#' absent both, one group per distinct level for variables with a small
+#' number of unique values.
+#' @return *\[list\]* A list of `list(label, row_idx)` entries, where `row_idx`
+#'   indexes into `var_values`.
+#' @keywords internal
+resolve_bpe_factor_groups <- function(var_label, equal_val, gltl_val, var_values, round_to) {
+  groups <- list()
+
+  if (!is_bpe_override_na(equal_val)) {
+    row_idx <- which(!is.na(var_values) & var_values == equal_val)
+    groups[[length(groups) + 1]] <- list(
+      label = paste0(var_label, " = ", format_bpe_group_value(equal_val, round_to)),
+      row_idx = row_idx
+    )
+  }
+
+  if (!is_bpe_override_na(gltl_val)) {
+    threshold <- resolve_bpe_gltl_threshold(gltl_val, var_values)
+    if (!is.na(threshold)) {
+      groups[[length(groups) + 1]] <- list(
+        label = paste0(var_label, " >= ", format_bpe_group_value(threshold, round_to)),
+        row_idx = which(!is.na(var_values) & var_values >= threshold)
+      )
+      groups[[length(groups) + 1]] <- list(
+        label = paste0(var_label, " < ", format_bpe_group_value(threshold, round_to)),
+        row_idx = which(!is.na(var_values) & var_values < threshold)
+      )
+    }
+  }
+
+  if (length(groups)) {
+    return(groups)
+  }
+
+  max_auto_levels <- 12L
+  levels_present <- sort(unique(stats::na.omit(var_values)))
+  if (length(levels_present) < 2 || length(levels_present) > max_auto_levels) {
+    return(list())
+  }
+
+  lapply(levels_present, function(level_value) {
+    list(
+      label = paste0(var_label, " = ", format_bpe_group_value(level_value, round_to)),
+      row_idx = which(!is.na(var_values) & var_values == level_value)
+    )
+  })
+}
+
+#' @title Resolve a gltl Threshold to a Numeric Value
+#' @keywords internal
+resolve_bpe_gltl_threshold <- function(gltl_val, var_values) {
+  if (!is.character(gltl_val)) {
+    return(as.numeric(gltl_val))
+  }
+
+  filtered <- var_values[!is.na(var_values)]
+  switch(gltl_val,
+    mean = if (length(filtered)) mean(filtered) else NA_real_,
+    median = if (length(filtered)) stats::median(filtered) else NA_real_,
+    suppressWarnings(as.numeric(gltl_val))
+  )
+}
+
+#' @title Format a Group Boundary Value for Display
+#' @keywords internal
+format_bpe_group_value <- function(value, round_to) {
+  if (is.numeric(value)) {
+    return(as.character(round(value, round_to)))
+  }
+  as.character(value)
+}
+
+#' @title Export BPE Plots to Files
+#' @keywords internal
+export_bpe_plots <- function(plots, export_path, graph_scale) {
+  box::use(
+    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
+  )
+
+  ensure_export_dir(export_path)
+
+  for (plot_name in names(plots)) {
+    filename <- build_export_filename("best_practice_estimate", plot_name)
+    full_path <- file.path(export_path, filename)
+
+    save_plot(
+      plot = plots[[plot_name]],
+      path = full_path,
+      width = 800,
+      height = 600,
+      scale = graph_scale
+    )
+  }
+
+  invisible(NULL)
 }
 
 compute_context_values <- function(bma_data, row_idx, predictors, overrides) {

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -26,6 +26,8 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   include_author_row <- opt$include_author_row %||% TRUE
   include_study_rows <- opt$include_study_rows %||% TRUE
   run_bma_if_missing <- opt$run_bma_if_missing %||% TRUE
+  include_economic_significance <- opt$include_economic_significance %||% TRUE
+  economic_significance_pip_threshold <- as.numeric(opt$economic_significance_pip_threshold %||% NA_real_)
   round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
 
   validate(
@@ -39,6 +41,10 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     length(include_study_rows) == 1,
     is.logical(run_bma_if_missing),
     length(run_bma_if_missing) == 1,
+    is.logical(include_economic_significance),
+    length(include_economic_significance) == 1,
+    is.numeric(economic_significance_pip_threshold),
+    length(economic_significance_pip_threshold) == 1,
     is.numeric(round_to),
     length(round_to) == 1
   )
@@ -47,6 +53,11 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   assert(
     include_author_row || include_study_rows,
     "At least one of include_author_row or include_study_rows must be TRUE."
+  )
+  assert(
+    is.na(economic_significance_pip_threshold) ||
+      (economic_significance_pip_threshold >= 0 && economic_significance_pip_threshold <= 1),
+    "economic_significance_pip_threshold must be between 0 and 1."
   )
 
   resolved_bma <- resolve_bma_input_for_bpe(
@@ -67,6 +78,8 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   )
   coef_post_mean <- as.numeric(bma_coef_matrix[, "Post Mean"])
   names(coef_post_mean) <- rownames(bma_coef_matrix)
+  pip_values <- as.numeric(bma_coef_matrix[, "PIP"])
+  names(pip_values) <- rownames(bma_coef_matrix)
 
   predictors <- setdiff(names(coef_post_mean), "(Intercept)")
   missing_predictors <- predictors[!predictors %in% colnames(bma_data)]
@@ -178,6 +191,26 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     round_to = round_to
   )
 
+  tables <- list(summary = summary)
+
+  if (include_economic_significance) {
+    bpe_reference_estimate <- compute_bpe_point_estimate(
+      predictor_values = author_values,
+      coef_post_mean = coef_post_mean,
+      include_intercept = include_intercept
+    )
+    tables$economic_significance <- compute_bpe_economic_significance(
+      predictors = predictors,
+      bma_data = bma_data,
+      coef_post_mean = coef_post_mean,
+      bpe_reference_estimate = bpe_reference_estimate,
+      pip_values = pip_values,
+      config = config,
+      round_to = round_to,
+      pip_threshold = economic_significance_pip_threshold
+    )
+  }
+
   if (get_verbosity() >= 3) {
     cli::cli_h3("Best-Practice Estimate")
     cli::cli_alert_info("BMA source: {.val {resolved_bma$source}}")
@@ -188,7 +221,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   }
 
   invisible(new_method_result(
-    tables = list(summary = summary),
+    tables = tables,
     meta = list(
       formula = formula,
       overrides = override_table,
@@ -669,8 +702,7 @@ resolve_bpe_vcov <- function(ols_model, cluster_ids = NULL) {
   )
 }
 
-build_bpe_row <- function(scope, study_id, study_label, predictor_values, coef_post_mean,
-                          include_intercept, vcov_matrix, z_value) {
+compute_bpe_point_estimate <- function(predictor_values, coef_post_mean, include_intercept) {
   intercept <- if (include_intercept && "(Intercept)" %in% names(coef_post_mean)) {
     as.numeric(coef_post_mean["(Intercept)"])
   } else {
@@ -678,7 +710,16 @@ build_bpe_row <- function(scope, study_id, study_label, predictor_values, coef_p
   }
 
   predictor_coefs <- coef_post_mean[names(predictor_values)]
-  estimate <- intercept + sum(predictor_coefs * predictor_values, na.rm = TRUE)
+  intercept + sum(predictor_coefs * predictor_values, na.rm = TRUE)
+}
+
+build_bpe_row <- function(scope, study_id, study_label, predictor_values, coef_post_mean,
+                          include_intercept, vcov_matrix, z_value) {
+  estimate <- compute_bpe_point_estimate(
+    predictor_values = predictor_values,
+    coef_post_mean = coef_post_mean,
+    include_intercept = include_intercept
+  )
   standard_error <- compute_linear_combo_se(
     predictor_values = predictor_values,
     include_intercept = include_intercept,
@@ -734,6 +775,72 @@ compute_linear_combo_se <- function(predictor_values, include_intercept, vcov_ma
   }
 
   sqrt(variance)
+}
+
+#' @title Economic Significance of BMA Variables
+#' @description
+#' For each BMA variable, compute the change in the best-practice estimate
+#' from a 1-SD change and from a min-to-max change in that variable, both as
+#' a level and as a percentage of the reference best-practice estimate.
+#' @keywords internal
+compute_bpe_economic_significance <- function(predictors, bma_data, coef_post_mean,
+                                              bpe_reference_estimate, pip_values, config,
+                                              round_to, pip_threshold) {
+  empty <- data.frame(
+    variable = character(0),
+    var_label = character(0),
+    pip = numeric(0),
+    sd_change = numeric(0),
+    sd_change_pct = numeric(0),
+    range_change = numeric(0),
+    range_change_pct = numeric(0),
+    stringsAsFactors = FALSE
+  )
+
+  if (!length(predictors)) {
+    return(empty)
+  }
+
+  has_reference <- is.finite(bpe_reference_estimate) && bpe_reference_estimate != 0
+
+  rows <- lapply(predictors, function(var_name) {
+    values <- as.numeric(bma_data[[var_name]])
+    values <- values[is.finite(values)]
+    beta <- coef_post_mean[[var_name]]
+
+    sd_change <- if (length(values) > 1) beta * stats::sd(values) else NA_real_
+    range_change <- if (length(values)) beta * (max(values) - min(values)) else NA_real_
+
+    config_key <- find_config_key_for_var(var_name, config)
+    var_label <- var_name
+    if (!is.null(config_key)) {
+      var_label <- config[[config_key]]$var_name_verbose %||% var_name
+    }
+
+    data.frame(
+      variable = var_name,
+      var_label = var_label,
+      pip = as.numeric(pip_values[[var_name]]),
+      sd_change = sd_change,
+      sd_change_pct = if (has_reference) sd_change / bpe_reference_estimate * 100 else NA_real_,
+      range_change = range_change,
+      range_change_pct = if (has_reference) range_change / bpe_reference_estimate * 100 else NA_real_,
+      stringsAsFactors = FALSE
+    )
+  })
+
+  out <- do.call(rbind, rows)
+
+  if (!is.na(pip_threshold)) {
+    out <- out[!is.na(out$pip) & out$pip >= pip_threshold, , drop = FALSE]
+  }
+
+  for (col in c("pip", "sd_change", "sd_change_pct", "range_change", "range_change_pct")) {
+    out[[col]] <- round_if_finite(out[[col]], round_to)
+  }
+
+  rownames(out) <- NULL
+  out
 }
 
 compute_context_values <- function(bma_data, row_idx, predictors, overrides) {

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -481,6 +481,14 @@ methods:
         posterior inclusion probability (PIP) is at least this value.
         Leave unset (NA) to include every BMA variable.
 
+    include_factor_summary:
+      type: "logical"
+      default: true
+      help: |
+        If `TRUE`, include a best-practice estimate summary table grouped by
+        the factor levels of variables flagged with `bpe_sum_stats`,
+        `bpe_equal`, or `bpe_gltl` in the data configuration.
+
   fma:
     round_to:
       type: "integer"

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -464,6 +464,23 @@ methods:
         If `TRUE`, run BMA when best-practice estimation has no BMA result to
         reuse. In interactive mode, you will still be prompted for confirmation.
 
+    include_economic_significance:
+      type: "logical"
+      default: true
+      help: |
+        If `TRUE`, include the economic significance table (effect of a 1-SD
+        and a min-to-max change in each BMA variable, as a level and as a
+        percentage of the best-practice estimate).
+
+    economic_significance_pip_threshold:
+      type: "numeric"
+      allow_na: true
+      default: .na
+      help: |
+        If set, restrict the economic significance table to variables whose
+        posterior inclusion probability (PIP) is at least this value.
+        Leave unset (NA) to include every BMA variable.
+
   fma:
     round_to:
       type: "integer"

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -84,7 +84,7 @@ test_that("best_practice_estimate uses provided BMA result and returns structure
   result <- best_practice_estimate(df, bma_result = bma_result)
 
   expect_named(result, c("tables", "plots", "meta"))
-  expect_named(result$tables, "summary")
+  expect_named(result$tables, c("summary", "economic_significance"), ignore.order = TRUE)
   expect_named(
     result$meta,
     c("formula", "overrides", "bma_formula", "bma_source", "autonomy_level"),
@@ -100,6 +100,42 @@ test_that("best_practice_estimate uses provided BMA result and returns structure
   expect_equal(overrides[["se"]], "0")
   expect_equal(overrides[["citations"]], "max")
   expect_equal(overrides[["first_lag_instrument"]], "0")
+
+  econ_sig <- result$tables$economic_significance
+  expect_true(is.data.frame(econ_sig))
+  expect_named(
+    econ_sig,
+    c("variable", "var_label", "pip", "sd_change", "sd_change_pct", "range_change", "range_change_pct")
+  )
+  expect_equal(sort(econ_sig$variable), sort(c("citations", "first_lag_instrument", "se", "top_journal")))
+})
+
+test_that("best_practice_estimate filters economic significance by PIP threshold", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = make_bpe_demo_config(),
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd",
+    artma.methods.best_practice_estimate.include_study_rows = FALSE,
+    artma.methods.best_practice_estimate.economic_significance_pip_threshold = 0.999
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  econ_sig <- result$tables$economic_significance
+  expect_true(nrow(econ_sig) <= 4L)
+  expect_true(all(econ_sig$pip >= 0.999))
 })
 
 test_that("best_practice_estimate fails early when BMA is missing and auto-run is disabled", {

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -15,7 +15,11 @@ box::use(ggplot2[is_ggplot])
 
 box::use(
   artma / methods / bma[bma],
-  artma / methods / best_practice_estimate[best_practice_estimate]
+  artma / methods / best_practice_estimate[
+    best_practice_estimate,
+    infer_bpe_recommendation,
+    format_bpe_recommendation
+  ]
 )
 
 make_bpe_demo_data <- function() {
@@ -328,4 +332,46 @@ test_that("best_practice_estimate returns an empty factor summary table with no 
   result <- best_practice_estimate(df, bma_result = bma_result)
 
   expect_equal(nrow(result$tables$summary_by_factor), 0L)
+})
+
+test_that("infer_bpe_recommendation returns NA (no recommendation) for unmatched variables", {
+  expect_equal(infer_bpe_recommendation("se"), 0)
+  expect_equal(infer_bpe_recommendation("citations"), "max")
+  expect_true(is.na(infer_bpe_recommendation("gdp_growth_rate_at_purchase")))
+  expect_true(is.na(infer_bpe_recommendation("x1")))
+})
+
+test_that("format_bpe_recommendation reports no recommendation explicitly instead of default(mean)", {
+  expect_equal(format_bpe_recommendation(NA, FALSE), "no recommendation")
+  expect_equal(format_bpe_recommendation(0, TRUE), "0")
+  expect_equal(format_bpe_recommendation(NA, TRUE), "default(mean)")
+})
+
+test_that("best_practice_estimate reports has_recommendation explicitly in the overrides table", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = make_bpe_demo_config(),
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd",
+    artma.methods.best_practice_estimate.include_study_rows = FALSE
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  overrides <- result$meta$overrides
+  expect_true(all(c("recommended", "has_recommendation") %in% colnames(overrides)))
+  # Every demo predictor matches a keyword rule, so all have a genuine recommendation.
+  expect_true(all(overrides$has_recommendation))
+  expect_false(any(overrides$recommended == "no recommendation"))
 })

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -11,6 +11,8 @@ box::use(
   withr[local_options]
 )
 
+box::use(ggplot2[is_ggplot])
+
 box::use(
   artma / methods / bma[bma],
   artma / methods / best_practice_estimate[best_practice_estimate]
@@ -185,4 +187,81 @@ test_that("best_practice_estimate accepts logical BPE overrides from config", {
   expect_equal(overrides[["top_journal"]], "1")
   expect_equal(overrides[["first_lag_instrument"]], "0")
   expect_false(is.na(overrides[["se"]]))
+})
+
+test_that("best_practice_estimate produces a sorted scatter plot highlighting the author's BPE", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = make_bpe_demo_config(),
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  expect_true("bpe_scatter" %in% names(result$plots))
+  expect_true(is_ggplot(result$plots$bpe_scatter))
+})
+
+test_that("best_practice_estimate produces per-factor density plots for bpe_sum_stats variables", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+  config <- make_bpe_demo_config()
+  config$top_journal$bpe_sum_stats <- TRUE
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  expect_true("bpe_density_top_journal" %in% names(result$plots))
+  expect_true(is_ggplot(result$plots$bpe_density_top_journal))
+})
+
+test_that("best_practice_estimate skips plots that would need no flagged BPE grouping variables", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+  config <- make_bpe_demo_config()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  expect_false(any(grepl("^bpe_density_", names(result$plots))))
 })

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -86,7 +86,11 @@ test_that("best_practice_estimate uses provided BMA result and returns structure
   result <- best_practice_estimate(df, bma_result = bma_result)
 
   expect_named(result, c("tables", "plots", "meta"))
-  expect_named(result$tables, c("summary", "economic_significance"), ignore.order = TRUE)
+  expect_named(
+    result$tables,
+    c("summary", "economic_significance", "summary_by_factor"),
+    ignore.order = TRUE
+  )
   expect_named(
     result$meta,
     c("formula", "overrides", "bma_formula", "bma_source", "autonomy_level"),
@@ -264,4 +268,64 @@ test_that("best_practice_estimate skips plots that would need no flagged BPE gro
   result <- best_practice_estimate(df, bma_result = bma_result)
 
   expect_false(any(grepl("^bpe_density_", names(result$plots))))
+})
+
+test_that("best_practice_estimate groups the factor summary table by bpe_equal/bpe_gltl", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+  config <- make_bpe_demo_config()
+  config$top_journal$bpe_equal <- 1
+  config$citations$bpe_gltl <- "median"
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  factor_summary <- result$tables$summary_by_factor
+  expect_true(is.data.frame(factor_summary))
+  expect_named(
+    factor_summary,
+    c("scope", "study_id", "study_label", "estimate", "standard_error", "ci_lower", "ci_upper", "n_obs")
+  )
+  expect_true(all(factor_summary$scope == "factor"))
+  expect_true(any(grepl("^Top Journal = 1$", factor_summary$study_label)))
+  expect_true(any(grepl("^Citations >=", factor_summary$study_label)))
+  expect_true(any(grepl("^Citations <", factor_summary$study_label)))
+})
+
+test_that("best_practice_estimate returns an empty factor summary table with no flagged variables", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = make_bpe_demo_config(),
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  expect_equal(nrow(result$tables$summary_by_factor), 0L)
 })


### PR DESCRIPTION
## Summary
- Adds an economic significance table to `best_practice_estimate` (1-SD and min-to-max change per BMA variable, as a level and as a percentage of the best-practice estimate, with an optional PIP filter).
- Adds per-factor BPE density plots and a sorted "miracle" scatter plot with a spline smoother, highlighting the author's own best-practice estimate.
- Adds a best-practice estimate summary table grouped by factor levels (`bpe_sum_stats`/`bpe_equal`/`bpe_gltl`), mirroring `effect_summary_stats`.
- Makes `infer_bpe_recommendation`'s fallback an explicit "no recommendation" outcome instead of silently blending into the mean, and surfaces it in `meta$overrides`.

## Test plan
- [x] `make test-file FILE=test-best-practice-estimate.R` (42 tests)
- [x] `make test-file FILE=test-generated-check-manifest.R`
- [x] `make lint` (no new lints introduced)
- [x] `make test` (full suite, 1450 tests, 0 failures)
- [x] `styler::style_file()` on all changed files

Closes #215
Closes #216
Closes #217
Closes #224