### PR TITLE
fix: install MAIVE from CRAN instead of GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     jsonlite (>= 1.8.0),
     knitr (>= 1.50),
     lintr (>= 3.2.0),
-    MAIVE (>= 0.1.10),
+    MAIVE (>= 0.2.4),
     mathjaxr (>= 1.8-0),
     mice (>= 3.16.0),
     NlcOptim (>= 0.6),

--- a/inst/artma/calc/methods/maive.R
+++ b/inst/artma/calc/methods/maive.R
@@ -1,7 +1,7 @@
 #' @title MAIVE wrapper
 #' @description
 #' Wrapper for the MAIVE (Meta-Analysis Instrumental Variable Estimator) method
-#' from the PetrCala/maive GitHub package. This estimator addresses publication
+#' from the CRAN package \pkg{MAIVE}. This estimator addresses publication
 #' bias and p-hacking in meta-analysis using instrumental variables.
 #' @param dat *[data.frame]* Data with columns: bs (estimates), sebs (std errors),
 #'   Ns (sample sizes), studyid (study IDs, optional).
@@ -32,7 +32,7 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
   if (!requireNamespace("MAIVE", quietly = TRUE)) {
     cli::cli_abort(c(
       "Package {.pkg MAIVE} is required for MAIVE estimation.",
-      "i" = "Install with: devtools::install_github('PetrCala/maive@0.0.2.11')"
+      "i" = "Install with: install.packages('MAIVE')"
     ))
   }
 

--- a/tests/testthat/test-calc-maive.R
+++ b/tests/testthat/test-calc-maive.R
@@ -39,4 +39,5 @@ test_that("maive aborts when the MAIVE package is absent", {
   dat <- make_maive_data(n = 20)
   local_pretend_packages_absent("MAIVE")
   expect_error(maive(dat, SE = 1L), regexp = "MAIVE")
+  expect_error(maive(dat, SE = 1L), regexp = "install\\.packages")
 })


### PR DESCRIPTION
MAIVE is now on CRAN at 0.2.4, so the GitHub-only dependency that blocked a CRAN release of artma is gone. Verified against the 0.2.4 source that `maive()`'s signature, the `bs`/`sebs`/`Ns` column contract, and every return field consumed by `format_maive_results()` are unchanged, so this is a metadata and install-guidance fix only: the wrapper's install hint becomes `install.packages('MAIVE')`, and the Suggests floor moves from the never-on-CRAN `0.1.10` to `0.2.4`.

Closes #223