### PR TITLE
feat: add opt-in RoBMA runtime method

### DIFF
--- a/.github/workflows/R-CMD-check-extended.yaml
+++ b/.github/workflows/R-CMD-check-extended.yaml
@@ -57,6 +57,23 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      # RoBMA (Suggests) needs the JAGS system library. On Linux
+      # setup-r-dependencies installs it from the declared sysreqs; macOS and
+      # Windows need it installed explicitly.
+      - name: Install JAGS (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jags
+
+      - name: Install JAGS (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          curl -L -o jags-installer.exe \
+            https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.3.1.exe/download
+          ./jags-installer.exe //S
+          echo "JAGS_HOME=C:/Program Files/JAGS/JAGS-4.3.1" >> "$GITHUB_ENV"
+          echo "C:/Program Files/JAGS/JAGS-4.3.1/x64/bin" >> "$GITHUB_PATH"
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/R-CMD-check-extended.yaml
+++ b/.github/workflows/R-CMD-check-extended.yaml
@@ -68,9 +68,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          curl -L -o jags-installer.exe \
+          installer="$RUNNER_TEMP/jags-installer.exe"
+          curl -L -o "$installer" \
             https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.3.1.exe/download
-          ./jags-installer.exe //S
+          "$installer" //S
           echo "JAGS_HOME=C:/Program Files/JAGS/JAGS-4.3.1" >> "$GITHUB_ENV"
           echo "C:/Program Files/JAGS/JAGS-4.3.1/x64/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,6 +46,23 @@ jobs:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
+      # RoBMA (Suggests) needs the JAGS system library. On Linux
+      # setup-r-dependencies installs it from the declared sysreqs; macOS and
+      # Windows need it installed explicitly.
+      - name: Install JAGS (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jags
+
+      - name: Install JAGS (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          curl -L -o jags-installer.exe \
+            https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.3.1.exe/download
+          ./jags-installer.exe //S
+          echo "JAGS_HOME=C:/Program Files/JAGS/JAGS-4.3.1" >> "$GITHUB_ENV"
+          echo "C:/Program Files/JAGS/JAGS-4.3.1/x64/bin" >> "$GITHUB_PATH"
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,9 +57,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          curl -L -o jags-installer.exe \
+          installer="$RUNNER_TEMP/jags-installer.exe"
+          curl -L -o "$installer" \
             https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.3.1.exe/download
-          ./jags-installer.exe //S
+          "$installer" //S
           echo "JAGS_HOME=C:/Program Files/JAGS/JAGS-4.3.1" >> "$GITHUB_ENV"
           echo "C:/Program Files/JAGS/JAGS-4.3.1/x64/bin" >> "$GITHUB_PATH"
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     readxl (>= 1.4.0),
     rex (>= 1.2.1),
     rmarkdown (>= 2.30),
-    RoBMA (>= 3.1.0),
+    RoBMA (>= 4.0.0),
     roxygen2 (>= 7.3.3),
     testthat (>= 3.2.3),
     writexl (>= 1.4.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Suggests:
     readxl (>= 1.4.0),
     rex (>= 1.2.1),
     rmarkdown (>= 2.30),
+    RoBMA (>= 3.1.0),
     roxygen2 (>= 7.3.3),
     testthat (>= 3.2.3),
     writexl (>= 1.4.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Suggests:
     rddensity (>= 2.5),
     readxl (>= 1.4.0),
     rex (>= 1.2.1),
+    rjags (>= 4.15),
     rmarkdown (>= 2.30),
     RoBMA (>= 4.0.0),
     roxygen2 (>= 7.3.3),

--- a/R/artma.R
+++ b/R/artma.R
@@ -275,7 +275,14 @@ invoke_runtime_methods <- function(methods, df, modules_dir = NULL, ...) {
 
   resolve_methods <- function(methods_input) {
     if (rlang::is_string(methods_input) && methods_input == "all") {
-      return(supported_methods)
+      # Opt-in methods (typically too expensive to run by default) are excluded
+      # from "all" and must be requested by name.
+      is_opt_in <- vapply(
+        method_meta[supported_methods],
+        function(meta) isTRUE(meta$opt_in),
+        logical(1)
+      )
+      return(supported_methods[!is_opt_in])
     }
 
     if (is.factor(methods_input)) {

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -38,6 +38,7 @@ robma <- function(df) {
   parallel <- opt$parallel %||% FALSE
   autofit <- opt$autofit %||% TRUE
   seed <- opt$seed %||% NA_integer_
+  measure <- opt$measure %||% "SMD"
   effect_prior_scale <- opt$effect_prior_scale %||% 0.707
   heterogeneity_shape <- opt$heterogeneity_shape %||% 1
   heterogeneity_scale <- opt$heterogeneity_scale %||% 0.15
@@ -51,11 +52,16 @@ robma <- function(df) {
     is.logical(parallel),
     is.logical(autofit),
     is.numeric(seed) || is.na(seed),
+    is.character(measure),
     is.numeric(effect_prior_scale),
     is.numeric(heterogeneity_shape),
     is.numeric(heterogeneity_scale)
   )
 
+  assert(
+    measure %in% c("SMD", "ZCOR", "RR", "OR", "HR", "RD", "IRR", "GEN"),
+    "measure must be one of: SMD, ZCOR, RR, OR, HR, RD, IRR, GEN"
+  )
   assert(chains > 0, "chains must be positive")
   assert(samples > 0, "samples must be positive")
   assert(burnin > 0, "burnin must be positive")
@@ -98,10 +104,11 @@ robma <- function(df) {
   )
 
   fit <- RoBMA::RoBMA(
-    d = fit_data$effect,
-    se = fit_data$se,
-    priors_effect = effect_prior,
-    priors_heterogeneity = heterogeneity_prior,
+    yi = fit_data$effect,
+    sei = fit_data$se,
+    measure = measure,
+    prior_effect = effect_prior,
+    prior_heterogeneity = heterogeneity_prior,
     chains = as.integer(chains),
     sample = as.integer(samples),
     burnin = as.integer(burnin),
@@ -113,11 +120,11 @@ robma <- function(df) {
   )
 
   ensemble <- summary(fit)
-  models <- summary(fit, type = "models")
+  models <- RoBMA::summary_models(fit, type = "individual")
 
   estimates <- as_robma_table(ensemble$estimates, "parameter", round_to)
-  components <- as_robma_table(ensemble$components, "component", round_to)
-  model_table <- as_robma_table(models$summary, "model", round_to)
+  components <- as_robma_table(ensemble$inclusion_components, "component", round_to)
+  model_table <- as_robma_table(models$individual, "model", round_to)
 
   if (get_verbosity() >= 3) {
     cli::cli_h3("RoBMA: model-averaged estimates")

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -1,0 +1,196 @@
+# Minimum number of usable observations required to attempt a fit.
+MIN_OBSERVATIONS <- 3L
+
+#' @title Robust Bayesian Meta-Analysis
+#' @description
+#' Run robust Bayesian meta-analysis (RoBMA, Bartos et al.) over the effect
+#' estimates and their standard errors. The ensemble combines models with and
+#' without an effect, heterogeneity, and publication bias, and reports both the
+#' component inclusion probabilities and the model-averaged estimates.
+#'
+#' The prior structure follows the thesis specification: a Cauchy effect prior
+#' truncated to (0, Inf) and an inverse-gamma heterogeneity prior. Only the
+#' prior scale/shape values and the sampler settings are configurable.
+#'
+#' The method is computationally expensive and is registered as opt-in, so it
+#' runs only when requested by name.
+robma <- function(df) {
+  box::use(
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / modules / runtime_methods[new_method_result],
+    artma / options / index[get_option_group]
+  )
+
+  validate(is.data.frame(df))
+  validate_columns(df, c("effect", "se"))
+
+  if (get_verbosity() >= 4) {
+    cli::cli_alert_info("Running Robust Bayesian Meta-Analysis")
+  }
+
+  opt <- get_option_group("artma.methods.robma")
+
+  chains <- opt$chains %||% 3L
+  samples <- opt$samples %||% 5000L
+  burnin <- opt$burnin %||% 2000L
+  adapt <- opt$adapt %||% 500L
+  parallel <- opt$parallel %||% FALSE
+  autofit <- opt$autofit %||% TRUE
+  seed <- opt$seed %||% NA_integer_
+  effect_prior_scale <- opt$effect_prior_scale %||% 0.707
+  heterogeneity_shape <- opt$heterogeneity_shape %||% 1
+  heterogeneity_scale <- opt$heterogeneity_scale %||% 0.15
+  round_to <- getOption("artma.output.number_of_decimals", 3)
+
+  validate(
+    is.numeric(chains),
+    is.numeric(samples),
+    is.numeric(burnin),
+    is.numeric(adapt),
+    is.logical(parallel),
+    is.logical(autofit),
+    is.numeric(seed) || is.na(seed),
+    is.numeric(effect_prior_scale),
+    is.numeric(heterogeneity_shape),
+    is.numeric(heterogeneity_scale)
+  )
+
+  assert(chains > 0, "chains must be positive")
+  assert(samples > 0, "samples must be positive")
+  assert(burnin > 0, "burnin must be positive")
+  assert(adapt > 0, "adapt must be positive")
+  assert(effect_prior_scale > 0, "effect_prior_scale must be positive")
+  assert(heterogeneity_shape > 0, "heterogeneity_shape must be positive")
+  assert(heterogeneity_scale > 0, "heterogeneity_scale must be positive")
+
+  usable <- is.finite(df$effect) & is.finite(df$se) & df$se > 0
+  fit_data <- df[usable, , drop = FALSE]
+
+  if (nrow(fit_data) < MIN_OBSERVATIONS) {
+    reason <- sprintf(
+      "fewer than %d usable observations (%d available)",
+      MIN_OBSERVATIONS, nrow(fit_data)
+    )
+    if (get_verbosity() >= 2) {
+      cli::cli_alert_warning("Skipping RoBMA: {reason}")
+    }
+    return(new_method_result(
+      tables = list(summary = empty_robma_table()),
+      meta = list(model = NULL, n_obs = nrow(fit_data), skipped = reason)
+    ))
+  }
+
+  if (get_verbosity() >= 3) {
+    cli::cli_alert_info(
+      "Fitting RoBMA on {nrow(fit_data)} observations. This may take a while..."
+    )
+  }
+
+  effect_prior <- RoBMA::prior(
+    distribution = "cauchy",
+    parameters = list(location = 0, scale = effect_prior_scale),
+    truncation = list(lower = 0, upper = Inf)
+  )
+  heterogeneity_prior <- RoBMA::prior(
+    distribution = "invgamma",
+    parameters = list(shape = heterogeneity_shape, scale = heterogeneity_scale)
+  )
+
+  fit <- RoBMA::RoBMA(
+    d = fit_data$effect,
+    se = fit_data$se,
+    priors_effect = effect_prior,
+    priors_heterogeneity = heterogeneity_prior,
+    chains = as.integer(chains),
+    sample = as.integer(samples),
+    burnin = as.integer(burnin),
+    adapt = as.integer(adapt),
+    parallel = isTRUE(parallel),
+    autofit = isTRUE(autofit),
+    seed = if (is.na(seed)) NULL else as.integer(seed),
+    silent = get_verbosity() < 4
+  )
+
+  ensemble <- summary(fit)
+  models <- summary(fit, type = "models")
+
+  estimates <- as_robma_table(ensemble$estimates, "parameter", round_to)
+  components <- as_robma_table(ensemble$components, "component", round_to)
+  model_table <- as_robma_table(models$summary, "model", round_to)
+
+  if (get_verbosity() >= 3) {
+    cli::cli_h3("RoBMA: model-averaged estimates")
+    print(estimates) # nolint: undesirable_function_linter.
+  }
+
+  new_method_result(
+    tables = list(
+      summary = estimates,
+      components = components,
+      models = model_table
+    ),
+    meta = list(model = fit, n_obs = nrow(fit_data))
+  )
+}
+
+#' @title Empty RoBMA estimates table
+#' @description Column-compatible placeholder returned when the method is
+#'   skipped for lack of usable observations.
+#' @return *\[data.frame\]* A zero-row estimates table.
+empty_robma_table <- function() {
+  data.frame(
+    parameter = character(0),
+    Mean = numeric(0),
+    Median = numeric(0),
+    stringsAsFactors = FALSE
+  )
+}
+
+#' @title Coerce a RoBMA summary table to a plain data frame
+#' @description
+#' RoBMA (via BayesTools) returns tables carrying extra classes and attributes
+#' and holding the parameter labels in the row names. Flatten one into a plain
+#' `data.frame` with the labels in a leading column and numeric columns rounded.
+#' @param tbl *\[data.frame\]* A table from `summary.RoBMA`.
+#' @param label_column *\[character\]* Name of the leading label column.
+#' @param round_to *\[numeric\]* Number of decimals for numeric columns.
+#' @return *\[data.frame\]* A plain data frame.
+as_robma_table <- function(tbl, label_column, round_to) {
+  if (is.null(tbl) || nrow(tbl) == 0L) {
+    return(data.frame(stats::setNames(list(character(0)), label_column)))
+  }
+
+  labels <- rownames(tbl)
+  out <- as.data.frame(unclass(tbl), stringsAsFactors = FALSE)
+  rownames(out) <- NULL
+
+  if (is.numeric(round_to) && !is.na(round_to)) {
+    numeric_cols <- vapply(out, is.numeric, logical(1))
+    out[numeric_cols] <- lapply(out[numeric_cols], round, digits = round_to)
+  }
+
+  out <- cbind(
+    stats::setNames(
+      data.frame(labels %||% seq_len(nrow(out)), stringsAsFactors = FALSE),
+      label_column
+    ),
+    out
+  )
+
+  out
+}
+
+box::use(
+  artma / modules / runtime_methods[register_runtime_method]
+)
+
+run <- register_runtime_method(
+  robma,
+  stage = "robma",
+  required_columns = c("effect", "se"),
+  suggests = "RoBMA",
+  opt_in = TRUE
+)
+
+box::export(robma, run)

--- a/inst/artma/modules/runtime_methods.R
+++ b/inst/artma/modules/runtime_methods.R
@@ -64,6 +64,8 @@ METHOD_META_ATTR <- "artma_method_meta"
 #' * `suggests`: optional packages the method needs. A method whose suggested
 #'   packages are not installed is skipped (with an interactive install offer);
 #'   this is the single, declarative gate for optional-package dependencies.
+#' * `opt_in`: when `TRUE`, the method is left out of `methods = "all"` and must
+#'   be requested by name. Use it for methods too expensive to run by default.
 #'
 #' @param impl *\[function\]* The method implementation (its `run` worker).
 #' @param stage *\[character\]* Stage label used for cache keys and the cache
@@ -74,6 +76,9 @@ METHOD_META_ATTR <- "artma_method_meta"
 #'   the data frame. Defaults to none.
 #' @param suggests *\[character, optional\]* Optional packages the method needs.
 #'   Defaults to none.
+#' @param opt_in *\[logical, optional\]* If `TRUE`, exclude the method from
+#'   `methods = "all"`; it then runs only when named explicitly. Defaults to
+#'   `FALSE`.
 #' @param label *\[character, optional\]* Human-readable display label. Defaults
 #'   to `stage`.
 #' @param key_builder *\[function, optional\]* Cache signature builder. Defaults
@@ -85,6 +90,7 @@ register_runtime_method <- function(impl, stage,
                                     depends_on = character(),
                                     required_columns = character(),
                                     suggests = character(),
+                                    opt_in = FALSE,
                                     label = NULL,
                                     key_builder = NULL, ...) {
   box::use(
@@ -103,7 +109,8 @@ register_runtime_method <- function(impl, stage,
     label = if (is.null(label)) stage else label,
     depends_on = as.character(depends_on),
     required_columns = as.character(required_columns),
-    suggests = as.character(suggests)
+    suggests = as.character(suggests),
+    opt_in = isTRUE(opt_in)
   )
 
   run
@@ -116,7 +123,7 @@ register_runtime_method <- function(impl, stage,
 #' @param name *\[character, optional\]* Method name, used as the default stage
 #'   and label when the wrapper carries no metadata.
 #' @return *\[list\]* A list with `stage`, `label`, `depends_on`,
-#'   `required_columns`, and `suggests`.
+#'   `required_columns`, `suggests`, and `opt_in`.
 get_method_metadata <- function(run_fn, name = NULL) {
   meta <- attr(run_fn, METHOD_META_ATTR, exact = TRUE)
   if (is.null(meta)) {
@@ -128,7 +135,8 @@ get_method_metadata <- function(run_fn, name = NULL) {
     label = name %||% NA_character_,
     depends_on = character(),
     required_columns = character(),
-    suggests = character()
+    suggests = character(),
+    opt_in = FALSE
   )
 
   utils::modifyList(defaults, meta)
@@ -236,9 +244,10 @@ module_should_be_runtime_method <- function(module, module_name = NULL, marker =
 }
 
 gather_runtime_modules <- function(
-    modules,
-    include_predicate,
-    excluded_modules = NULL) {
+  modules,
+  include_predicate,
+  excluded_modules = NULL
+) {
   if (length(modules) == 0) {
     return(list(runtime = modules, skipped = character()))
   }
@@ -265,9 +274,10 @@ gather_runtime_modules <- function(
 }
 
 get_runtime_method_modules <- function(
-    modules_dir = PATHS$DIR_METHODS,
-    include_predicate = module_should_be_runtime_method,
-    excluded_modules = NULL) {
+  modules_dir = PATHS$DIR_METHODS,
+  include_predicate = module_should_be_runtime_method,
+  excluded_modules = NULL
+) {
   modules <- crawl_and_import_modules(modules_dir)
   split_modules <- gather_runtime_modules(modules, include_predicate, excluded_modules)
   runtime_modules <- split_modules$runtime

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -535,6 +535,14 @@ methods:
         Random seed for the RoBMA sampler, for reproducible fits.
         Leave unset (NA) to let the sampler pick its own seed.
 
+    measure:
+      type: "character"
+      default: "SMD"
+      help: |
+        Effect size measure passed to RoBMA. "SMD" (standardized mean
+        difference) matches the thesis specification. Use "GEN" for generic
+        effect sizes, or one of "ZCOR", "RR", "OR", "HR", "RD", "IRR".
+
     effect_prior_scale:
       type: "numeric"
       default: 0.707

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -489,6 +489,71 @@ methods:
         the factor levels of variables flagged with `bpe_sum_stats`,
         `bpe_equal`, or `bpe_gltl` in the data configuration.
 
+  robma:
+    chains:
+      type: "integer"
+      default: 3
+      help: |
+        Number of MCMC chains used to fit each model in the RoBMA ensemble.
+
+    samples:
+      type: "integer"
+      default: 5000
+      help: |
+        Number of posterior samples drawn per chain after burn-in.
+
+    burnin:
+      type: "integer"
+      default: 2000
+      help: |
+        Number of burn-in iterations discarded before sampling.
+
+    adapt:
+      type: "integer"
+      default: 500
+      help: |
+        Number of adaptation iterations run before burn-in.
+
+    parallel:
+      type: "logical"
+      default: false
+      help: |
+        If `TRUE`, fit the models of the RoBMA ensemble in parallel.
+
+    autofit:
+      type: "logical"
+      default: true
+      help: |
+        If `TRUE`, keep extending the sampling until the convergence checks
+        pass. Set to `FALSE` to cap the run at the requested sample count.
+
+    seed:
+      type: "integer"
+      allow_na: true
+      default: .na
+      help: |
+        Random seed for the RoBMA sampler, for reproducible fits.
+        Leave unset (NA) to let the sampler pick its own seed.
+
+    effect_prior_scale:
+      type: "numeric"
+      default: 0.707
+      help: |
+        Scale of the Cauchy prior on the effect, truncated to (0, Inf).
+        The default (1 / sqrt(2)) is the conventional Cohen's d prior scale.
+
+    heterogeneity_shape:
+      type: "numeric"
+      default: 1
+      help: |
+        Shape parameter of the inverse-gamma prior on the heterogeneity.
+
+    heterogeneity_scale:
+      type: "numeric"
+      default: 0.15
+      help: |
+        Scale parameter of the inverse-gamma prior on the heterogeneity.
+
   fma:
     round_to:
       type: "integer"

--- a/tests/testthat/test-robma.R
+++ b/tests/testthat/test-robma.R
@@ -1,0 +1,86 @@
+box::use(
+  testthat[
+    expect_equal, expect_false, expect_null, expect_s3_class, expect_true,
+    skip_if_not_installed, test_that
+  ],
+  withr[local_options]
+)
+
+box::use(
+  artma / methods / robma[robma]
+)
+
+make_demo_robma_data <- function(n_studies = 12L) {
+  set.seed(1234)
+  data.frame(
+    study_id = paste0("S", seq_len(n_studies)),
+    effect = stats::rnorm(n_studies, mean = 0.3, sd = 0.1),
+    se = stats::runif(n_studies, min = 0.05, max = 0.15),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("robma skips when too few usable observations remain", {
+  df <- data.frame(
+    effect = c(0.2, NA_real_, 0.4),
+    se = c(0.1, 0.1, 0)
+  )
+
+  local_options(list(artma.verbose = 0))
+
+  result <- robma(df)
+
+  expect_equal(result$meta$n_obs, 1L)
+  expect_null(result$meta$model)
+  expect_true(nzchar(result$meta$skipped))
+  expect_s3_class(result$tables$summary, "data.frame")
+  expect_equal(nrow(result$tables$summary), 0L)
+})
+
+test_that("robma fits the ensemble and returns estimates and components", {
+  skip_if_not_installed("RoBMA")
+
+  df <- make_demo_robma_data()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.output.save_results = FALSE,
+    artma.methods.robma.chains = 1L,
+    artma.methods.robma.samples = 200L,
+    artma.methods.robma.burnin = 100L,
+    artma.methods.robma.adapt = 100L,
+    artma.methods.robma.autofit = FALSE,
+    artma.methods.robma.seed = 42L
+  ))
+
+  # The tiny sample counts that keep this test fast also trip RoBMA's
+  # convergence checks, which is expected here.
+  result <- suppressWarnings(robma(df))
+
+  expect_false(isTRUE(nzchar(result$meta$skipped)))
+  expect_equal(result$meta$n_obs, nrow(df))
+  expect_true(!is.null(result$meta$model))
+
+  for (key in c("summary", "components", "models")) {
+    expect_s3_class(result$tables[[key]], "data.frame")
+    expect_true(nrow(result$tables[[key]]) > 0L)
+  }
+
+  expect_equal(names(result$tables$summary)[1], "parameter")
+  expect_equal(names(result$tables$components)[1], "component")
+  expect_equal(names(result$tables$models)[1], "model")
+})
+
+test_that("robma is registered as an opt-in method", {
+  box::use(
+    artma / methods / robma[run],
+    artma / modules / runtime_methods[get_method_metadata]
+  )
+
+  meta <- get_method_metadata(run, name = "robma")
+
+  expect_true(meta$opt_in)
+  expect_equal(meta$suggests, "RoBMA")
+  expect_equal(meta$required_columns, c("effect", "se"))
+})

--- a/tests/testthat/test-robma.R
+++ b/tests/testthat/test-robma.R
@@ -1,10 +1,19 @@
 box::use(
   testthat[
     expect_equal, expect_false, expect_null, expect_s3_class, expect_true,
-    skip_if_not_installed, test_that
+    skip, skip_if_not_installed, test_that
   ],
   withr[local_options]
 )
+
+# RoBMA fits through JAGS, a system library. rjags only loads when JAGS is
+# present, which makes it a reliable probe for a machine that can actually fit.
+skip_if_no_jags <- function() {
+  skip_if_not_installed("RoBMA")
+  if (!requireNamespace("rjags", quietly = TRUE)) {
+    skip("JAGS is not available")
+  }
+}
 
 box::use(
   artma / methods / robma[robma]
@@ -38,7 +47,7 @@ test_that("robma skips when too few usable observations remain", {
 })
 
 test_that("robma fits the ensemble and returns estimates and components", {
-  skip_if_not_installed("RoBMA")
+  skip_if_no_jags()
 
   df <- make_demo_robma_data()
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -93,6 +93,34 @@ test_that("invoke_runtime_methods expands the all keyword", {
   expect_setequal(names(results), names(fake_methods))
 })
 
+test_that("invoke_runtime_methods leaves opt-in methods out of the all keyword", {
+  fake_methods <- mock_methods()
+  fake_methods$method_c$meta <- list(stage = "method_c", opt_in = TRUE)
+  withr::local_options(list(artma.verbose = 0))
+  methods_dir <- local_mock_methods_dir(fake_methods)
+
+  df <- data.frame()
+  results <- artma:::invoke_runtime_methods(methods = "all", df = df, modules_dir = methods_dir)
+
+  expect_setequal(names(results), c("method_a", "method_b"))
+})
+
+test_that("invoke_runtime_methods still runs opt-in methods when named", {
+  fake_methods <- mock_methods()
+  fake_methods$method_c$meta <- list(stage = "method_c", opt_in = TRUE)
+  withr::local_options(list(artma.verbose = 0))
+  methods_dir <- local_mock_methods_dir(fake_methods)
+
+  df <- data.frame(x = 1:3)
+  results <- artma:::invoke_runtime_methods(
+    methods = "method_c",
+    df = df,
+    modules_dir = methods_dir
+  )
+
+  expect_equal(names(results), "method_c")
+})
+
 test_that("invoke_runtime_methods surfaces invalid inputs early", {
   fake_methods <- mock_methods()
   withr::local_options(list(artma.verbose = 0))

--- a/tests/testthat/test-runtime-methods.R
+++ b/tests/testthat/test-runtime-methods.R
@@ -93,6 +93,17 @@ test_that("register_runtime_method attaches declarative metadata", {
   expect_equal(meta$required_columns, c("effect", "se"))
   expect_equal(meta$suggests, "BMS")
   expect_equal(meta$stage, "demo")
+  expect_equal(meta$opt_in, FALSE)
+})
+
+test_that("register_runtime_method records the opt-in flag", {
+  box::use(
+    artma / modules / runtime_methods[get_method_metadata, register_runtime_method]
+  )
+
+  run <- register_runtime_method(function(df, ...) df, stage = "pricey", opt_in = TRUE)
+
+  expect_true(get_method_metadata(run, name = "pricey")$opt_in)
 })
 
 test_that("get_method_metadata fills defaults for methods without metadata", {
@@ -105,6 +116,7 @@ test_that("get_method_metadata fills defaults for methods without metadata", {
   expect_equal(meta$required_columns, character())
   expect_equal(meta$suggests, character())
   expect_equal(meta$stage, "bare")
+  expect_equal(meta$opt_in, FALSE)
 })
 
 test_that("get_runtime_method_modules ignores helper modules", {


### PR DESCRIPTION
Adds a `robma` runtime method reproducing the thesis RoBMA fit: `RoBMA::RoBMA` with a Cauchy effect prior truncated to (0, Inf) and an inverse-gamma heterogeneity prior, returning the model-averaged estimates, the component inclusion table, and the per-model summary. Since RoBMA is expensive, `register_runtime_method()` gains an `opt_in` flag: opt-in methods are left out of `methods = "all"` and run only when named explicitly. They remain listed by `artma::methods.list()` and in the interactive picker.

Closes #214