### PR TITLE
feat(output): add LaTeX table export via output.table_formats

### DIFF
--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -807,6 +807,15 @@ output:
       If `TRUE`, automatically export tables (CSV) and graphics (PNG) to the output
       directory after each analysis run.
 
+  table_formats:
+    type: "character"
+    default: ["csv"]
+    help: |
+      File formats used when exporting result tables. Accepts {.val csv} and
+      {.val tex}. Add {.val tex} to also write booktabs LaTeX tables ready to be
+      included in a paper (requires `\usepackage{booktabs}` in your preamble).
+      Defaults to {.val csv} only.
+
   number_of_decimals:
     type: "integer"
     default: 3

--- a/inst/artma/output/export.R
+++ b/inst/artma/output/export.R
@@ -96,14 +96,75 @@ ensure_output_dirs <- function(output_dir) {
   }
 }
 
-#' Save a data frame as CSV
+SUPPORTED_TABLE_FORMATS <- c("csv", "tex")
+
+#' Resolve the table export formats
+#'
+#' @description
+#' Reads the `artma.output.table_formats` option and normalises it: values are
+#' lowercased and de-duplicated, unsupported ones are dropped with a warning,
+#' and an empty result falls back to CSV so a run never silently produces no
+#' tables.
+#'
+#' @return *\[character\]* The requested formats, a subset of `csv` and `tex`.
+#' @keywords internal
+resolve_table_formats <- function() {
+  box::use(artma / libs / core / utils[get_verbosity])
+
+  requested <- getOption("artma.output.table_formats", "csv")
+  formats <- unique(tolower(as.character(requested)))
+  formats <- formats[!is.na(formats)]
+
+  unsupported <- setdiff(formats, SUPPORTED_TABLE_FORMATS)
+  if (length(unsupported) > 0 && get_verbosity() >= 2) {
+    cli::cli_alert_warning(
+      "Ignoring unsupported table format{?s}: {.val {unsupported}}."
+    )
+  }
+
+  formats <- intersect(SUPPORTED_TABLE_FORMATS, formats)
+  if (length(formats) == 0) "csv" else formats
+}
+
+#' Turn a table basename into a human-readable caption
+#'
+#' @param name *\[character\]* The table basename.
+#' @return *\[character\]* The caption text.
+#' @keywords internal
+table_caption <- function(name) {
+  words <- strsplit(gsub("_", " ", name), " ", fixed = TRUE)[[1]]
+  words <- words[nzchar(words)]
+  if (length(words) == 0) {
+    return(name)
+  }
+  substr(words, 1, 1) <- toupper(substr(words, 1, 1))
+  paste(words, collapse = " ")
+}
+
+#' Save a data frame in the configured table formats
 #'
 #' @param df *\[data.frame\]* The data frame to save.
 #' @param name *\[character\]* File name (without extension).
 #' @param output_dir *\[character\]* The base output directory.
-save_table <- function(df, name, output_dir) {
-  path <- file.path(output_dir, "tables", paste0(name, ".csv"))
-  utils::write.csv(df, file = path, row.names = FALSE)
+#' @param formats *\[character\]* The formats to write, from `resolve_table_formats()`.
+save_table <- function(df, name, output_dir, formats = resolve_table_formats()) {
+  tables_dir <- file.path(output_dir, "tables")
+
+  if ("csv" %in% formats) {
+    utils::write.csv(df, file = file.path(tables_dir, paste0(name, ".csv")), row.names = FALSE)
+  }
+
+  if ("tex" %in% formats) {
+    box::use(artma / output / latex[write_latex_table])
+    write_latex_table(
+      df,
+      path = file.path(tables_dir, paste0(name, ".tex")),
+      caption = table_caption(name),
+      label = paste0("tab:", name)
+    )
+  }
+
+  invisible()
 }
 
 #' Export all results to the output directory
@@ -160,25 +221,31 @@ resolve_table_basename <- function(method_name, key) {
 #'
 #' @description
 #' A generic walk over the standard return contract. Every `data.frame` in the
-#' result's `tables` slot is written as a CSV; everything else (`plots`, `meta`)
-#' is ignored here. There are no per-method branches.
+#' result's `tables` slot is written in each configured table format (see
+#' `resolve_table_formats()`); everything else (`plots`, `meta`) is ignored
+#' here. There are no per-method branches.
 #'
 #' @param result The method's return value (a `list` with a `tables` slot).
 #' @param method_name *\[character\]* The method name.
 #' @param output_dir *\[character\]* The base output directory.
 #' @keywords internal
 export_method_result <- function(result, method_name, output_dir) {
-  if (!is.list(result)) return(invisible())
+  if (!is.list(result)) {
+    return(invisible())
+  }
 
   tables <- result$tables
-  if (!is.list(tables) || length(tables) == 0L) return(invisible())
+  if (!is.list(tables) || length(tables) == 0L) {
+    return(invisible())
+  }
 
+  formats <- resolve_table_formats()
   table_names <- names(tables)
   for (i in seq_along(tables)) {
     tbl <- tables[[i]]
     if (!is.data.frame(tbl)) next
     key <- if (is.null(table_names)) NULL else table_names[[i]]
-    save_table(tbl, resolve_table_basename(method_name, key), output_dir)
+    save_table(tbl, resolve_table_basename(method_name, key), output_dir, formats = formats)
   }
 
   invisible()

--- a/inst/artma/output/latex.R
+++ b/inst/artma/output/latex.R
@@ -1,0 +1,131 @@
+#' @title LaTeX Table Rendering
+#' @description
+#' Renders result data frames as booktabs LaTeX tables ready to be included
+#' in a paper. Significance asterisks and rounding are already baked into the
+#' table cells by the methods themselves, so the rendering here is purely
+#' presentational: escaping, column alignment, and the table environment.
+NULL
+
+BACKSLASH_SENTINEL <- "artmabackslash"
+
+#' Escape LaTeX special characters
+#'
+#' @description
+#' Escapes the characters LaTeX treats specially. Asterisks are left alone:
+#' they carry significance marks and render as-is in text mode. Backslashes are
+#' parked on a sentinel first so that the braces introduced by the replacement
+#' macros are not escaped a second time.
+#'
+#' @param x *\[character\]* The values to escape.
+#' @return *\[character\]* The escaped values.
+#' @keywords internal
+escape_latex <- function(x) {
+  x <- as.character(x)
+  if (!length(x)) {
+    return(character(0))
+  }
+
+  x <- gsub("\\", BACKSLASH_SENTINEL, x, fixed = TRUE)
+  x <- gsub("([&%$#_{}])", "\\\\\\1", x)
+  x <- gsub("~", "\\\\textasciitilde{}", x)
+  x <- gsub("\\^", "\\\\textasciicircum{}", x)
+  gsub(BACKSLASH_SENTINEL, "\\textbackslash{}", x, fixed = TRUE)
+}
+
+#' Format a single column for LaTeX output
+#'
+#' @param column The column to format.
+#' @param digits *\[integer\]* Number of decimals used for numeric columns.
+#' @return *\[character\]* The formatted, escaped cells. `NA` becomes an empty cell.
+#' @keywords internal
+format_latex_column <- function(column, digits) {
+  box::use(artma / libs / formatting / results[format_number])
+
+  formatted <- if (is.numeric(column) && !is.integer(column)) {
+    format_number(column, digits)
+  } else {
+    as.character(column)
+  }
+
+  formatted <- escape_latex(formatted)
+  formatted[is.na(column) | is.na(formatted)] <- ""
+  formatted
+}
+
+#' Resolve the column alignment string
+#'
+#' @param df *\[data.frame\]* The table to align.
+#' @return *\[character\]* A single string such as `"lrr"`.
+#' @keywords internal
+resolve_alignment <- function(df) {
+  alignments <- vapply(
+    df,
+    function(column) if (is.numeric(column)) "r" else "l",
+    character(1)
+  )
+  paste(alignments, collapse = "")
+}
+
+#' Render a data frame as a booktabs LaTeX table
+#'
+#' @param df *\[data.frame\]* The table to render.
+#' @param caption *\[character, optional\]* Table caption. Omitted when `NULL`.
+#' @param label *\[character, optional\]* Table label. Omitted when `NULL`.
+#' @param digits *\[integer, optional\]* Number of decimals for numeric columns.
+#'   Defaults to the `artma.output.number_of_decimals` option.
+#' @return *\[character\]* The LaTeX source, one element per line.
+#' @keywords internal
+df_to_latex <- function(df,
+                        caption = NULL,
+                        label = NULL,
+                        digits = getOption("artma.output.number_of_decimals", 3)) {
+  box::use(artma / libs / core / validation[assert])
+
+  assert(is.data.frame(df), "The table to render as LaTeX must be a data frame.")
+
+  header <- paste(escape_latex(names(df)), collapse = " & ")
+
+  body <- character(0)
+  if (nrow(df) > 0 && ncol(df) > 0) {
+    cells <- lapply(df, format_latex_column, digits = digits)
+    body <- vapply(
+      seq_len(nrow(df)),
+      function(i) paste0(paste(vapply(cells, `[`, character(1), i), collapse = " & "), " \\\\"),
+      character(1)
+    )
+  }
+
+  c(
+    "% Requires \\usepackage{booktabs} in the document preamble.",
+    "\\begin{table}[htbp]",
+    "\\centering",
+    if (!is.null(caption)) paste0("\\caption{", escape_latex(caption), "}"),
+    if (!is.null(label)) paste0("\\label{", label, "}"),
+    paste0("\\begin{tabular}{", resolve_alignment(df), "}"),
+    "\\toprule",
+    paste0(header, " \\\\"),
+    "\\midrule",
+    body,
+    "\\bottomrule",
+    "\\end{tabular}",
+    "\\end{table}"
+  )
+}
+
+#' Write a data frame to a `.tex` file
+#'
+#' @param df *\[data.frame\]* The table to render.
+#' @param path *\[character\]* Destination file path.
+#' @param caption *\[character, optional\]* Table caption.
+#' @param label *\[character, optional\]* Table label.
+#' @keywords internal
+write_latex_table <- function(df, path, caption = NULL, label = NULL) {
+  writeLines(df_to_latex(df, caption = caption, label = label), con = path)
+  invisible(path)
+}
+
+box::export(
+  escape_latex,
+  df_to_latex,
+  write_latex_table
+)

--- a/tests/testthat/test-output-export.R
+++ b/tests/testthat/test-output-export.R
@@ -127,6 +127,62 @@ test_that("export_results ignores plots and meta and skips NULL results", {
   expect_equal(length(files), 1L)
 })
 
+# table formats -------------------------------------------------------------
+
+test_that("export_results writes CSV only by default", {
+  dir <- setup_output_dir()
+
+  export_results(list(bma = list(tables = list(summary = data.frame(a = 1)))), dir)
+
+  expect_equal(list.files(file.path(dir, "tables")), "bma.csv")
+})
+
+test_that("export_results writes LaTeX alongside CSV when both formats are set", {
+  dir <- setup_output_dir()
+  local_options(artma.output.table_formats = c("csv", "tex"))
+
+  export_results(list(bma = list(tables = list(summary = data.frame(term = "a", est = 1)))), dir)
+
+  tex_path <- file.path(dir, "tables", "bma.tex")
+  expect_true(file.exists(file.path(dir, "tables", "bma.csv")))
+  expect_true(file.exists(tex_path))
+
+  contents <- readLines(tex_path)
+  expect_true(any(grepl("\\begin{tabular}", contents, fixed = TRUE)))
+  expect_true("\\label{tab:bma}" %in% contents)
+})
+
+test_that("export_results writes LaTeX only when tex is the sole format", {
+  dir <- setup_output_dir()
+  local_options(artma.output.table_formats = "tex")
+
+  export_results(list(bma = list(tables = list(summary = data.frame(a = 1)))), dir)
+
+  expect_equal(list.files(file.path(dir, "tables")), "bma.tex")
+})
+
+test_that("export_results falls back to CSV for unrecognised formats", {
+  dir <- setup_output_dir()
+  local_options(artma.output.table_formats = "docx")
+
+  export_results(list(bma = list(tables = list(summary = data.frame(a = 1)))), dir)
+
+  expect_equal(list.files(file.path(dir, "tables")), "bma.csv")
+})
+
+test_that("export_results applies the sub-table naming rule to LaTeX files", {
+  dir <- setup_output_dir()
+  local_options(artma.output.table_formats = "tex")
+
+  export_results(
+    list(p_hacking_tests = list(tables = list(caliper = data.frame(x = 1), elliott = data.frame(y = 2)))),
+    dir
+  )
+
+  expect_true(file.exists(file.path(dir, "tables", "p_hacking_tests_caliper.tex")))
+  expect_true(file.exists(file.path(dir, "tables", "p_hacking_tests_elliott.tex")))
+})
+
 test_that("export_results skips non-data-frame entries in the tables slot", {
   dir <- setup_output_dir()
 

--- a/tests/testthat/test-output-latex.R
+++ b/tests/testthat/test-output-latex.R
@@ -1,0 +1,111 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_true,
+    test_that
+  ],
+  withr[local_options],
+  artma / output / latex[df_to_latex, escape_latex, write_latex_table]
+)
+
+# escape_latex --------------------------------------------------------------
+
+test_that("escape_latex escapes the LaTeX special characters", {
+  expect_equal(escape_latex("p_value"), "p\\_value")
+  expect_equal(escape_latex("50%"), "50\\%")
+  expect_equal(escape_latex("a & b"), "a \\& b")
+  expect_equal(escape_latex("$5 #1"), "\\$5 \\#1")
+  expect_equal(escape_latex("{x}"), "\\{x\\}")
+})
+
+test_that("escape_latex leaves significance asterisks untouched", {
+  expect_equal(escape_latex("0.123***"), "0.123***")
+})
+
+test_that("escape_latex replaces backslashes without double-escaping the macro", {
+  expect_equal(escape_latex("a\\b"), "a\\textbackslash{}b")
+  expect_equal(escape_latex("a~b"), "a\\textasciitilde{}b")
+  expect_equal(escape_latex("a^b"), "a\\textasciicircum{}b")
+})
+
+test_that("escape_latex handles empty input", {
+  expect_equal(escape_latex(character(0)), character(0))
+})
+
+# df_to_latex ---------------------------------------------------------------
+
+test_that("df_to_latex emits a booktabs table environment", {
+  lines <- df_to_latex(data.frame(term = c("a", "b"), estimate = c(1, 2)))
+
+  expect_true("\\begin{table}[htbp]" %in% lines)
+  expect_true("\\toprule" %in% lines)
+  expect_true("\\midrule" %in% lines)
+  expect_true("\\bottomrule" %in% lines)
+  expect_true("\\end{tabular}" %in% lines)
+  expect_true("\\end{table}" %in% lines)
+})
+
+test_that("df_to_latex right-aligns numeric columns and left-aligns the rest", {
+  df <- data.frame(term = c("a", "b"), estimate = c(1, 2), flag = c(TRUE, FALSE))
+  lines <- df_to_latex(df)
+
+  expect_true("\\begin{tabular}{lrl}" %in% lines)
+})
+
+test_that("df_to_latex writes one body row per data row", {
+  local_options(artma.output.number_of_decimals = 2)
+  df <- data.frame(term = c("a", "b"), estimate = c(1.234, 2.345))
+  lines <- df_to_latex(df)
+
+  expect_true("term & estimate \\\\" %in% lines)
+  expect_true("a & 1.23 \\\\" %in% lines)
+  expect_true("b & 2.35 \\\\" %in% lines)
+})
+
+test_that("df_to_latex renders NA as an empty cell", {
+  df <- data.frame(term = c("a", NA), estimate = c(NA_real_, 2))
+  lines <- df_to_latex(df, digits = 1)
+
+  expect_true("a &  \\\\" %in% lines)
+  expect_true(" & 2.0 \\\\" %in% lines)
+})
+
+test_that("df_to_latex includes the caption and label only when supplied", {
+  df <- data.frame(a = 1)
+
+  with_meta <- df_to_latex(df, caption = "My table", label = "tab:my_table")
+  expect_true("\\caption{My table}" %in% with_meta)
+  expect_true("\\label{tab:my_table}" %in% with_meta)
+
+  without_meta <- df_to_latex(df)
+  expect_false(any(grepl("\\caption", without_meta, fixed = TRUE)))
+  expect_false(any(grepl("\\label", without_meta, fixed = TRUE)))
+})
+
+test_that("df_to_latex escapes headers and cells", {
+  df <- data.frame(p_value = "a & b", stringsAsFactors = FALSE)
+  lines <- df_to_latex(df)
+
+  expect_true("p\\_value \\\\" %in% lines)
+  expect_true("a \\& b \\\\" %in% lines)
+})
+
+test_that("df_to_latex handles a table with no rows", {
+  lines <- df_to_latex(data.frame(a = character(0), b = numeric(0)))
+
+  expect_true("a & b \\\\" %in% lines)
+  expect_equal(sum(grepl("\\midrule", lines, fixed = TRUE)), 1L)
+})
+
+# write_latex_table ---------------------------------------------------------
+
+test_that("write_latex_table writes the rendered source to disk", {
+  path <- tempfile(fileext = ".tex")
+  write_latex_table(data.frame(a = 1), path = path, caption = "Cap")
+
+  expect_true(file.exists(path))
+  contents <- readLines(path)
+  expect_true("\\caption{Cap}" %in% contents)
+  unlink(path)
+})

--- a/vignettes/options-files.Rmd
+++ b/vignettes/options-files.Rmd
@@ -121,8 +121,10 @@ Method-specific parameters for each analysis method:
 
 Controls output formatting:
 
-- `round_to`: Number of decimal places for numeric output
-- `format`: Output format options
+- `dir`: Directory where tables and graphics are saved (`auto` for a temporary directory)
+- `save_results`: Whether to export tables and graphics after each run
+- `table_formats`: Formats used when exporting tables (`csv`, `tex`, or both)
+- `number_of_decimals`: Number of decimal places for numeric output
 
 ### 6. `cli`
 


### PR DESCRIPTION
Result tables can now be exported as booktabs LaTeX alongside the CSVs. A new `output.table_formats` option accepts `csv` and `tex` (default `csv` only, so existing behaviour is unchanged); adding `tex` writes a `.tex` file per table into the same `tables/` directory, with a caption, a `tab:<name>` label, LaTeX escaping, and numeric columns right-aligned. Rendering is hand-rolled in `inst/artma/output/latex.R`, so no new package dependency. Significance asterisks and rounding already arrive baked into the cells from the methods, so they carry over as-is.

Closes #222