### PR TITLE
fix(effect_summary_stats): default effect column when nothing configured

### DIFF
--- a/inst/artma/methods/effect_summary_stats.R
+++ b/inst/artma/methods/effect_summary_stats.R
@@ -167,16 +167,12 @@ effect_summary_stats <- function(df) {
       effect_vars <- names(config)[vapply(config, is_effect_var, logical(1))]
     }
 
-    # If still no variables (user declined or non-interactive), return empty
-    if (!length(effect_vars)) {
-      if (get_verbosity() >= 2) {
-        cli::cli_alert_warning("No variables selected to compute summary statistics for.")
-      }
-      empty <- data.frame(matrix(nrow = 0, ncol = length(CONST$EFFECT_SUMMARY_STATS$NAMES)), stringsAsFactors = FALSE)
-      colnames(empty) <- CONST$EFFECT_SUMMARY_STATS$NAMES
-      return(new_method_result(tables = list(summary = empty)))
-    }
+    # If still no variables (user declined or non-interactive), fall through
+    # with the effect column defaulted in, so the table still gets at least
+    # the "All Data" row computed below.
   }
+
+  rows_env <- environment()
 
   add_row <- function(label, class_name, subset_data) {
     if (!length(subset_data$effect)) {
@@ -187,7 +183,7 @@ effect_summary_stats <- function(df) {
     unweighted <- compute_unweighted_stats(subset_data$effect)
     weighted <- compute_weighted_stats(subset_data$effect, weights)
 
-    rows[[length(rows) + 1]] <<- data.frame(
+    new_row <- data.frame(
       `Var Name` = label,
       `Var Class` = class_name,
       Mean = format_numeric(unweighted$mean),
@@ -204,6 +200,7 @@ effect_summary_stats <- function(df) {
       check.names = FALSE,
       stringsAsFactors = FALSE
     )
+    assign("rows", c(rows_env$rows, list(new_row)), envir = rows_env)
 
     TRUE
   }

--- a/tests/testthat/test-effect-summary-stats-integration.R
+++ b/tests/testthat/test-effect-summary-stats-integration.R
@@ -36,7 +36,7 @@ test_that("interactive effect-summary module exports its readline entry points",
 
 # Workflow integration tests --------------------------------------------------
 
-test_that("effect_summary_stats handles empty config gracefully in non-interactive mode", {
+test_that("effect_summary_stats defaults to the All Data row in non-interactive mode", {
   box::use(
     artma / methods / effect_summary_stats[effect_summary_stats]
   )
@@ -67,11 +67,12 @@ test_that("effect_summary_stats handles empty config gracefully in non-interacti
     "artma.verbose" = 1
   )
 
-  # Should return empty result without error (non-interactive)
+  # Should default the effect column in, producing the "All Data" row
   result <- effect_summary_stats(df)$tables$summary
 
   expect_true(is.data.frame(result))
-  expect_equal(nrow(result), 0)
+  expect_equal(nrow(result), 1)
+  expect_equal(result$`Var Name`, "All Data")
 })
 
 test_that("effect_summary_stats processes configured variables correctly", {


### PR DESCRIPTION
When no column has `effect_sum_stats` configured, `effect_summary_stats` now falls through to compute the "All Data" row instead of returning an empty table with a warning. The warning is now only raised for columns that are configured but missing or non-numeric in the data.

Closes #252