### PR TITLE
Fix options file suffix handling and variable_summary_stats Obs count

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -17,11 +17,12 @@
 #' @return *\[list\]* The validation errors
 #' @export
 options.validate <- function(
-    options_file_name = NULL,
-    options_dir = NULL,
-    should_flag_redundant = FALSE,
-    template_path = NULL,
-    failure_action = "abort_verbose") {
+  options_file_name = NULL,
+  options_dir = NULL,
+  should_flag_redundant = FALSE,
+  template_path = NULL,
+  failure_action = "abort_verbose"
+) {
   box::use(
     artma / const[CONST],
     artma / options / ask[ask_for_existing_options_file_name],
@@ -147,10 +148,11 @@ options.validate <- function(
 #' @return `NULL`
 #' @export
 options.copy <- function(
-    options_file_name_from = NULL,
-    options_file_name_to = NULL,
-    options_dir = NULL,
-    should_overwrite = NULL) {
+  options_file_name_from = NULL,
+  options_file_name_to = NULL,
+  options_dir = NULL,
+  should_overwrite = NULL
+) {
   box::use(
     artma / options / ask[ask_for_options_file_name, ask_for_existing_options_file_name],
     artma / options / files[
@@ -191,9 +193,10 @@ options.copy <- function(
 #' @return `NULL`
 #' @export
 options.delete <- function(
-    options_file_name = NULL,
-    options_dir = NULL,
-    skip_confirmation = FALSE) {
+  options_file_name = NULL,
+  options_dir = NULL,
+  skip_confirmation = FALSE
+) {
   box::use(
     artma / options / ask[ask_for_existing_options_file_name],
     artma / options / files[
@@ -257,7 +260,7 @@ options.list <- function(options_dir = NULL, should_return_verbose_names = FALSE
 #' @title Load user options
 #' @description Load user options by their name and return them as a list.
 #' @details In case the options name is not passed, the function will attempt to load the current options configuration. If none is found, it will then attempt to load the default options. If that fails too, an error is raised.
-#' @param options_file_name *\[character, optional\]* Name of the options to load, including the .yaml suffix. Defaults to `NULL`.
+#' @param options_file_name *\[character, optional\]* Name of the options to load. The `.yaml` suffix is appended automatically if missing. Defaults to `NULL`.
 #' @param options_dir *\[character, optional\]* Path to the folder in which to look for user options files. Defaults to `NULL`.
 #' @param create_options_if_null *\[logical, optional\]* If set to TRUE and the options file name is set to NULL, the function will prompt the user to create a new options file. Defaults to TRUE.
 #' @param load_with_prefix *\[logical, optional\]* Whether the options should be loaded with the package prefix. Defaults to TRUE.
@@ -268,14 +271,15 @@ options.list <- function(options_dir = NULL, should_return_verbose_names = FALSE
 #' @return *\[list|NULL\]* The loaded options as a list or `NULL`.
 #' @export
 options.load <- function(
-    options_file_name = NULL,
-    options_dir = NULL,
-    create_options_if_null = TRUE,
-    load_with_prefix = TRUE,
-    template_path = NULL,
-    should_validate = TRUE,
-    should_add_temp_options = FALSE,
-    should_return = TRUE) {
+  options_file_name = NULL,
+  options_dir = NULL,
+  create_options_if_null = TRUE,
+  load_with_prefix = TRUE,
+  template_path = NULL,
+  should_validate = TRUE,
+  should_add_temp_options = FALSE,
+  should_return = TRUE
+) {
   box::use(
     artma / const[CONST],
     artma / options / files[
@@ -290,8 +294,8 @@ options.load <- function(
       get_option_defs,
       get_template_defaults
     ],
-    artma / options / utils[get_expected_type, validate_option_value],
-    artma / libs / core / validation[validate, assert],
+    artma / options / utils[get_expected_type, validate_option_value, parse_options_file_name],
+    artma / libs / core / validation[validate],
     artma / libs / core / utils[get_verbosity]
   )
 
@@ -344,10 +348,7 @@ options.load <- function(
     }
   }
 
-  assert(
-    grepl(".yaml$|.yml$", options_file_name),
-    sprintf("Please pass the name of the options to load with the .yaml suffix. Got: %s.", options_file_name)
-  )
+  options_file_name <- parse_options_file_name(options_file_name)
 
   options_path <- options_file_path(options_dir, options_file_name)
   nested_options <- read_options_file(options_path)
@@ -435,11 +436,12 @@ options.load <- function(
 #' @return `NULL`
 #' @export
 options.modify <- function(
-    options_file_name = NULL,
-    options_dir = NULL,
-    template_path = NULL,
-    user_input = list(),
-    should_validate = TRUE) {
+  options_file_name = NULL,
+  options_dir = NULL,
+  template_path = NULL,
+  user_input = list(),
+  should_validate = TRUE
+) {
   box::use(
     artma / options / ask[
       ask_for_existing_options_file_name,
@@ -500,8 +502,9 @@ options.modify <- function(
 #' @return `NULL` Opens the file for editing
 #' @export
 options.open <- function(
-    options_file_name = NULL,
-    options_dir = NULL) {
+  options_file_name = NULL,
+  options_dir = NULL
+) {
   box::use(
     artma / options / files[resolve_options_dir],
     artma / options / ask[ask_for_existing_options_file_name],
@@ -554,8 +557,9 @@ options.open <- function(
 #'   to the console.
 #' @export
 options.help <- function(
-    options = NULL,
-    template_path = NULL) {
+  options = NULL,
+  template_path = NULL
+) {
   box::use(
     artma / const[CONST],
     artma / options / files[resolve_template_path],
@@ -655,10 +659,11 @@ options.print_default_dir <- function(...) { # nolint: object_name_linter.
 #' @return `NULL` Fixes the user options file.
 #' @export
 options.fix <- function(
-    options_file_name = NULL,
-    options_dir = NULL,
-    template_path = NULL,
-    force_default_overwrites = TRUE) {
+  options_file_name = NULL,
+  options_dir = NULL,
+  template_path = NULL,
+  force_default_overwrites = TRUE
+) {
   box::use(
     artma / const[CONST],
     artma / options / ask[ask_for_existing_options_file_name, ask_for_option_value],
@@ -804,13 +809,14 @@ options.fix <- function(
 #' @return `NULL`
 #' @export
 options.create <- function(
-    options_file_name = NULL,
-    options_dir = NULL,
-    template_path = NULL,
-    user_input = list(),
-    should_validate = TRUE,
-    should_overwrite = FALSE,
-    action_name = "creating") {
+  options_file_name = NULL,
+  options_dir = NULL,
+  template_path = NULL,
+  user_input = list(),
+  should_validate = TRUE,
+  should_overwrite = FALSE,
+  action_name = "creating"
+) {
   box::use(
     artma / options / ask[ask_for_options_file_name],
     artma / options / template[parse_options_from_template, flatten_user_options, collect_leaf_paths],

--- a/inst/artma/methods/variable_summary_stats.R
+++ b/inst/artma/methods/variable_summary_stats.R
@@ -60,7 +60,7 @@ variable_summary_stats <- function(df) {
     var_sd <- round(stats::sd(var_data, na.rm = TRUE), round_to)
     var_min <- round(base::min(var_data, na.rm = TRUE), round_to)
     var_max <- round(base::max(var_data, na.rm = TRUE), round_to)
-    var_obs <- sum(!is.na(var_data) & var_data != 0)
+    var_obs <- sum(!is.na(var_data))
     var_missing <- round((sum(is.na(var_data)) / length(var_data)) * 100, 1)
     var_missing_verbose <- paste0(as.character(var_missing), "%")
 

--- a/man/options.load.Rd
+++ b/man/options.load.Rd
@@ -16,7 +16,7 @@ options.load(
 )
 }
 \arguments{
-\item{options_file_name}{\emph{[character, optional]} Name of the options to load, including the .yaml suffix. Defaults to \code{NULL}.}
+\item{options_file_name}{\emph{[character, optional]} Name of the options to load. The \code{.yaml} suffix is appended automatically if missing. Defaults to \code{NULL}.}
 
 \item{options_dir}{\emph{[character, optional]} Path to the folder in which to look for user options files. Defaults to \code{NULL}.}
 

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -129,6 +129,36 @@ test_that("options lifecycle helpers operate on user files", {
   expect_false(file.exists(file.path(tmp_dir, "copied.yaml")))
 })
 
+test_that("options.load accepts a file name without the .yaml suffix", {
+  box::use(artma[options.load])
+
+  tmp_dir <- withr::local_tempdir()
+  template_path <- file.path(tmp_dir, "template.yaml")
+
+  template <- list(
+    general = list(
+      name = list(
+        type = "character",
+        default = "Default Config",
+        help = "Friendly name for the configuration"
+      )
+    )
+  )
+  yaml::write_yaml(template, template_path)
+  yaml::write_yaml(list(general = list(name = "Primary")), file.path(tmp_dir, "dummy_run.yaml"))
+
+  loaded <- options.load(
+    options_file_name = "dummy_run",
+    options_dir = tmp_dir,
+    template_path = template_path,
+    should_validate = TRUE,
+    should_add_temp_options = TRUE,
+    should_return = TRUE
+  )
+  expect_equal(loaded$`artma.general.name`, "Primary")
+  expect_equal(loaded$`artma.temp.file_name`, "dummy_run.yaml")
+})
+
 test_that("options.load backfills missing and invalid values with template defaults", {
   box::use(artma[options.load])
 

--- a/tests/testthat/test-variable-summary-stats.R
+++ b/tests/testthat/test-variable-summary-stats.R
@@ -1,0 +1,49 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_identical,
+    expect_named,
+    test_that
+  ],
+  withr[local_options]
+)
+
+box::use(
+  artma / methods / variable_summary_stats[variable_summary_stats]
+)
+
+make_config_entry <- function(name, verbose, data_type) {
+  list(
+    var_name = name,
+    var_name_verbose = verbose,
+    data_type = data_type,
+    variable_summary = TRUE
+  )
+}
+
+test_that("Obs counts non-missing observations, not the count of ones for dummy variables", {
+  local_options(
+    "artma.data.columns" = list(
+      effect = make_config_entry("effect", "Effect", "float"),
+      is_rct = make_config_entry("is_rct", "Is RCT", "int")
+    ),
+    "artma.methods.variable_summary_stats.use_verbose_names" = TRUE,
+    "artma.output.number_of_decimals" = 3,
+    "artma.verbose" = 1
+  )
+
+  df <- data.frame(
+    effect = c(0.1, 0.2, 0.3, NA),
+    is_rct = c(1, 0, 0, NA)
+  )
+
+  result <- variable_summary_stats(df)$tables$summary
+
+  expect_named(result, c(
+    "Var Name", "Var Class", "Mean", "Median",
+    "Min", "Max", "SD", "Obs", "Missing obs"
+  ))
+  expect_identical(result$`Var Name`, c("Effect", "Is RCT"))
+  # 3 non-missing rows for each variable, even though `is_rct` has only one 1.
+  expect_equal(result$Obs, c("3", "3"))
+})


### PR DESCRIPTION
Normalizes the `.yaml` suffix consistently between `options.create()` and the load path, and fixes `variable_summary_stats` so the `Obs` column counts non-missing observations instead of the count of ones for dummy variables.

Closes #249
Closes #254