### PR TITLE
Output polish: mojibake ellipsis, raw NA cells, scaled BPE values

### DIFF
--- a/inst/artma/data/compute.R
+++ b/inst/artma/data/compute.R
@@ -328,7 +328,7 @@ compute_optional_columns <- function(df) {
   box::use(artma / libs / core / utils[get_verbosity])
 
   if (get_verbosity() >= 3) {
-    cli::cli_alert_info("Computing optional columns for {.val {nrow(df)}} observations…")
+    cli::cli_alert_info("Computing optional columns for {.val {nrow(df)}} observations...")
   }
 
   df |>

--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -627,6 +627,21 @@ run_exogeneity_tests <- function(df, options) {
 #' @param puniform_results *[list]* Results from p-uniform* test.
 #' @param options *[list]* Options.
 #' @return *[data.frame]* Formatted summary table.
+#' @title Placeholder for a metric that could not be computed
+#' @description
+#' Used in the exogeneity summary table wherever a coefficient, test
+#' statistic, or p-value is unavailable, so the printed table reads legibly
+#' instead of leaking raw `NA`/`<NA>` formatting.
+NOT_COMPUTABLE <- "not computable"
+
+#' @title Replace NA entries in a character vector with the placeholder
+#' @param x *[character]* Vector to sanitize.
+#' @return *[character]* Vector with `NA` values replaced by `NOT_COMPUTABLE`.
+na_to_not_computable <- function(x) {
+  x[is.na(x)] <- NOT_COMPUTABLE
+  x
+}
+
 build_exogeneity_summary <- function(iv_results, puniform_results, options) {
   row_labels <- c(
     "Publication Bias",
@@ -649,16 +664,16 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
     pb <- iv_coef[iv_coef$term == "publication_bias", , drop = FALSE]
     eff <- iv_coef[iv_coef$term == "effect", , drop = FALSE]
 
-    summary[["IV"]] <- c(
+    summary[["IV"]] <- na_to_not_computable(c(
       if (nrow(pb) > 0) pb$estimate_formatted else NA_character_,
       if (nrow(pb) > 0) pb$std_error_formatted else NA_character_,
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
       if (nrow(eff) > 0) eff$std_error_formatted else NA_character_,
       if (nrow(iv_coef) > 0) format_number(iv_coef$n_obs[1], 0) else NA_character_,
       format_number(iv_results$ar_fstat, options$round_to)
-    )
+    ))
   } else {
-    summary[["IV"]] <- rep(NA_character_, length(row_labels))
+    summary[["IV"]] <- rep(NOT_COMPUTABLE, length(row_labels))
   }
 
   # p-uniform* column
@@ -668,28 +683,28 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
     eff <- pu_coef[pu_coef$term == "effect", , drop = FALSE]
 
     # Format publication bias test as "L = X.XX (p = Y.YY)"
-    pb_test_str <- if (nrow(pb_test) > 0) {
+    pb_test_str <- if (nrow(pb_test) > 0 && is.finite(pb_test$statistic)) {
       paste0("L = ", format_number(pb_test$statistic, options$round_to))
     } else {
       NA_character_
     }
 
-    pb_p_str <- if (nrow(pb_test) > 0) {
+    pb_p_str <- if (nrow(pb_test) > 0 && is.finite(pb_test$p_value)) {
       paste0("(p = ", format_number(pb_test$p_value, options$round_to), ")")
     } else {
       NA_character_
     }
 
-    summary[["p-Uniform*"]] <- c(
+    summary[["p-Uniform*"]] <- na_to_not_computable(c(
       pb_test_str,
       pb_p_str,
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
       if (nrow(eff) > 0) eff$std_error_formatted else NA_character_,
       if (nrow(pu_coef) > 0) format_number(pu_coef$n_obs[1], 0) else NA_character_,
       "" # No F-test for p-uniform
-    )
+    ))
   } else {
-    summary[["p-Uniform*"]] <- rep(NA_character_, length(row_labels))
+    summary[["p-Uniform*"]] <- rep(NOT_COMPUTABLE, length(row_labels))
   }
 
   attr(summary, "row.names") <- row_labels

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -215,7 +215,8 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     coef_post_mean = coef_post_mean,
     predictor_values = author_values,
     include_intercept = include_intercept,
-    round_to = round_to
+    round_to = round_to,
+    standardized_predictors = detect_bpe_standardized_predictors(bma_data, predictors)
   )
 
   tables <- list(summary = summary)
@@ -1366,7 +1367,25 @@ resolve_bpe_value <- function(values, override) {
   )
 }
 
-build_bpe_formula_string <- function(coef_post_mean, predictor_values, include_intercept, round_to) {
+#' @title Detect which BPE predictors were z-scaled for BMA
+#' @description
+#' `get_bma_data()` standardizes every non-binary predictor before handing the
+#' data to BMA, so the values `compute_context_values()` reads back out of
+#' `bma_data` are on the standardized scale for those columns. This flags
+#' which predictors that applies to, so the formula string can label them
+#' instead of silently printing standardized values as if they were raw ones.
+#' @param bma_data *\[data.frame\]* The (possibly standardized) BMA data.
+#' @param predictors *\[character\]* Predictor names to check.
+#' @return *\[logical\]* Named vector, TRUE where the predictor is standardized.
+detect_bpe_standardized_predictors <- function(bma_data, predictors) {
+  stats::setNames(
+    vapply(predictors, function(var_name) length(unique(bma_data[[var_name]])) != 2, logical(1)),
+    predictors
+  )
+}
+
+build_bpe_formula_string <- function(coef_post_mean, predictor_values, include_intercept, round_to,
+                                     standardized_predictors = NULL) {
   parts <- character(0)
 
   if (include_intercept && "(Intercept)" %in% names(coef_post_mean)) {
@@ -1379,13 +1398,15 @@ build_bpe_formula_string <- function(coef_post_mean, predictor_values, include_i
     if (!is.finite(beta) || !is.finite(value)) {
       next
     }
+    is_standardized <- isTRUE(standardized_predictors[[var_name]])
     parts <- c(
       parts,
       sprintf(
-        "%s * %s (%s)",
+        "%s * %s (%s%s)",
         format(round(beta, round_to), nsmall = round_to),
         format(round(value, round_to), nsmall = round_to),
-        var_name
+        var_name,
+        if (is_standardized) ", standardized" else ""
       )
     )
   }


### PR DESCRIPTION
Three cosmetic output-quality fixes: plain `...` instead of a mojibake ellipsis under Rscript, a legible "not computable" placeholder instead of raw `NA`/`<NA>` in the exogeneity_tests summary table, and a "standardized" label on z-scaled predictor values in the BPE verbose "Author formula" output.

Closes #256