### PR TITLE
Fix study_id false warning and column data_type override

### DIFF
--- a/inst/artma/data/compute.R
+++ b/inst/artma/data/compute.R
@@ -69,11 +69,11 @@ add_study_id_column <- function(df) {
   }
 
   if ("study_id" %in% colnames(df)) {
-    invalid_or_missing_ids <- which(is.na(df$study_id) | df$study_id != valid_ids)
+    invalid_or_missing_ids <- which(is.na(study_src) | trimws(as.character(study_src)) == "")
     if (length(invalid_or_missing_ids) > 0) {
       if (get_verbosity() >= 2) {
         cli::cli_alert_warning(c(
-          "!" = "Found {length(invalid_or_missing_ids)} invalid or missing study IDs in the column {.val study_id}.",
+          "!" = "Found {length(invalid_or_missing_ids)} invalid or missing study IDs in the column {.val study_id}. ",
           "i" = "Resetting them to sequential integers."
         ))
       }

--- a/inst/artma/interactive/effect_summary_stats.R
+++ b/inst/artma/interactive/effect_summary_stats.R
@@ -442,11 +442,15 @@ specify_variable_split <- function(var_name, df, config) {
     return(NULL)
   }
 
-  # Determine data type
-  data_type <- tryCatch(
-    determine_vector_type(var_data, CONST$DATA_CONFIG$DATA_TYPES),
-    error = function(e) "unknown"
-  )
+  # Determine data type, honoring an explicit config override
+  data_type <- if (!is.null(var_config$data_type) && !is.na(var_config$data_type)) {
+    var_config$data_type
+  } else {
+    tryCatch(
+      determine_vector_type(var_data, CONST$DATA_CONFIG$DATA_TYPES),
+      error = function(e) "unknown"
+    )
+  }
 
   # Display variable summary
   cli::cli_text("Data type: {.val {data_type}}")

--- a/inst/artma/variable/suggestion.R
+++ b/inst/artma/variable/suggestion.R
@@ -129,11 +129,16 @@ suggest_variables_for_effect_summary <- function(df, config = NULL,
       next
     }
 
-    # Determine data type
-    data_type <- tryCatch(
-      determine_vector_type(var_data, CONST$DATA_CONFIG$DATA_TYPES),
-      error = function(e) "unknown"
-    )
+    # Determine data type, honoring an explicit config override
+    var_config <- config[[make.names(var_name)]]
+    data_type <- if (!is.null(var_config$data_type) && !is.na(var_config$data_type)) {
+      var_config$data_type
+    } else {
+      tryCatch(
+        determine_vector_type(var_data, CONST$DATA_CONFIG$DATA_TYPES),
+        error = function(e) "unknown"
+      )
+    }
 
     # Decision logic based on data type and values
     suggestion <- decide_variable_suggestion(

--- a/tests/testthat/test-data-compute.R
+++ b/tests/testthat/test-data-compute.R
@@ -1,5 +1,5 @@
 box::use(
-  testthat[expect_equal, expect_true, test_that]
+  testthat[expect_equal, expect_message, expect_no_message, expect_true, test_that]
 )
 
 box::use(
@@ -109,6 +109,30 @@ test_that("compute_optional_columns keeps a user-supplied precision column when 
   result <- compute_optional_columns(df)
 
   expect_equal(result$precision, c(999, 999, 999))
+})
+
+
+test_that("compute_optional_columns does not warn about study_id for valid string labels", {
+  df <- sample_study_df()
+  local_compute_options()
+  withr::local_options(list("artma.verbose" = 2))
+
+  expect_no_message(compute_optional_columns(df))
+})
+
+
+test_that("compute_optional_columns warns about study_id only for genuinely missing values", {
+  df <- data.frame(
+    study_id = c("Study A", NA, "", "Study B"),
+    effect = c(0.2, 0.5, 0.1, 0.3),
+    se = c(0.1, 0.2, 0.1, 0.2),
+    n_obs = c(120, 150, 120, 130),
+    stringsAsFactors = FALSE
+  )
+  local_compute_options()
+  withr::local_options(list("artma.verbose" = 2))
+
+  expect_message(compute_optional_columns(df), "Found 2 invalid or missing study IDs")
 })
 
 

--- a/tests/testthat/test-variable-suggestion.R
+++ b/tests/testthat/test-variable-suggestion.R
@@ -663,6 +663,33 @@ test_that("suggest_variables_for_effect_summary uses config when provided", {
 
 # Integration tests -----------------------------------------------------------
 
+test_that("suggest_variables_for_effect_summary honors an explicit data_type override over auto-detection", {
+  # citation_count falls entirely within [0, 100], so auto-detection alone
+  # would classify it as "perc"; an explicit "int" override must win.
+  df <- data.frame(
+    effect = rnorm(100),
+    citation_count = sample(17:60, 100, replace = TRUE),
+    stringsAsFactors = FALSE
+  )
+
+  config <- list(
+    citation_count = list(
+      var_name = "citation_count",
+      data_type = "int"
+    )
+  )
+
+  result <- suggest_variables_for_effect_summary(df, config = config)
+
+  row <- result[result$var_name == "citation_count", ]
+  expect_true(nrow(row) > 0)
+  if (row$suggested) {
+    expect_equal(row$split_method, "gltl")
+    expect_true(row$split_value %in% c("mean", "median"))
+  }
+})
+
+
 test_that("full workflow: detect groups and suggest variables", {
   df <- make_test_data()
 


### PR DESCRIPTION
Fixes two independent bugs surfaced by user reports.

- add_study_id_column() compared raw study_id values against freshly computed integer codes, so every valid string dataset triggered a false "invalid or missing study IDs" warning. Now it only flags genuinely NA/blank values.
- determine_vector_type()'s int/perc heuristic misclassifies count columns (e.g. citation counts in [0, 100]) as percentages. Rather than redesigning the heuristic, two call sites (suggest_variables_for_effect_summary and specify_variable_split) now honor an explicit data_type set in the column config, which already existed as a documented override field but was being bypassed.

Closes #250
Closes #253