### PR TITLE
fix: detect dummy/categorical type even when group_category is set

### DIFF
--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -728,6 +728,12 @@ data:
       var_name_verbose, var_name_description, data_type, group_category,
       variable_summary, effect_sum_stats, equal, gltl, bma, bma_reference_var,
       bma_to_log, bpe, bpe_sum_stats, bpe_equal, and bpe_gltl.
+      {.strong group_category} sets the display label used to group variables together
+      (e.g. in BMA plots); it does not change whether a variable is structurally
+      detected as a dummy/categorical/transformation group, which is still inferred
+      from the data and column names. Methods like prima_facie_graphs rely on that
+      structural detection, so setting group_category on dummy columns will not hide
+      them from it.
       For more details, read the 'data_config' vignette.
 
   expected_schema_columns:

--- a/inst/artma/variable/detection.R
+++ b/inst/artma/variable/detection.R
@@ -53,7 +53,12 @@ bind_group_rows <- function(results) {
 #' @param var_names *\[character, optional\]* Vector of variable names to analyze.
 #' If NULL, all columns except reserved names are analyzed.
 #' @param config *\[list, optional\]* Data configuration list. If provided,
-#' uses existing group_category values where available.
+#' uses existing group_category values as the group_id/group_base for variables
+#' that set it, instead of a detected group name. Structural type detection
+#' (dummy, transformation, power, categorical) still runs and populates
+#' group_type even for these variables, so setting group_category only
+#' overrides the group's display label, not whether it is detected as a
+#' structural group.
 #'
 #' @return A data frame with columns:
 #' - var_name: Variable name
@@ -140,11 +145,17 @@ detect_variable_groups <- function(df, var_names = NULL, config = NULL) {
   for (i in seq_len(nrow(all_detected))) {
     var_idx <- which(groups$var_name == all_detected$var_name[i])
     if (length(var_idx)) {
-      # Only override if not already set from config
       if (is.na(groups$group_id[var_idx])) {
+        # Not set from config: adopt the detected group wholesale
         groups$group_id[var_idx] <- all_detected$group_id[i]
         groups$group_type[var_idx] <- all_detected$group_type[i]
         groups$group_base[var_idx] <- all_detected$group_base[i]
+        groups$is_reference[var_idx] <- all_detected$is_reference[i]
+      } else if (groups$group_type[var_idx] == "singleton") {
+        # group_id/group_base came from config (group_category): keep them as
+        # the display grouping, but still record the structural type detected
+        # from the data so methods like prima_facie_graphs can find the group.
+        groups$group_type[var_idx] <- all_detected$group_type[i]
         groups$is_reference[var_idx] <- all_detected$is_reference[i]
       }
     }

--- a/tests/testthat/test-variable-suggestion.R
+++ b/tests/testthat/test-variable-suggestion.R
@@ -301,6 +301,28 @@ test_that("detect_variable_groups uses existing config groups when available", {
   expect_equal(result$group_id[result$var_name == "var2"], "my_custom_group")
 })
 
+test_that("detect_variable_groups still detects dummy type when group_category is set from config", {
+  df <- data.frame(
+    effect = rnorm(10),
+    region_asia = sample(c(0, 1), 10, replace = TRUE),
+    region_americas = sample(c(0, 1), 10, replace = TRUE),
+    region_africa = sample(c(0, 1), 10, replace = TRUE),
+    stringsAsFactors = FALSE
+  )
+
+  config <- list(
+    region_asia = list(var_name = "region_asia", group_category = "region"),
+    region_americas = list(var_name = "region_americas", group_category = "region"),
+    region_africa = list(var_name = "region_africa", group_category = "region")
+  )
+
+  result <- detect_variable_groups(df, config = config)
+  region_rows <- result[result$var_name %in% names(config), ]
+
+  expect_true(all(region_rows$group_id == "region"))
+  expect_true(all(region_rows$group_type == "dummy"))
+})
+
 
 # Tests for decide_variable_suggestion ---------------------------------------
 


### PR DESCRIPTION
group_category pre-fills group_id in detect_variable_groups(), which previously short-circuited structural type detection (dummy/categorical/etc), leaving group_type as "singleton" and silently hiding those variables from methods like prima_facie_graphs. Structural detection now still runs and sets group_type even when group_id came from config; group_category continues to control only the display grouping (group_id/group_base). Documented this in the options template help text and detect_variable_groups roxygen docs.

Closes #251