### PR TITLE
fix(p-hacking): rewrite Cox-Shi against canonical Elliott et al. implementation

### DIFF
--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -285,9 +285,9 @@ lambda2 <- function(x1, x2, h) {
 }
 
 #' Compute bounds for the p-curve and its derivatives
-compute_bounds <- function(pmax, J, order) {
+compute_bounds <- function(p_min, p_max, J, order) {
   h <- seq(0, 100, by = 0.001)
-  grid <- linspace(0, pmax, J + 1)
+  grid <- linspace(p_min, p_max, J + 1)
   order <- as.integer(order)
   if (!order %in% 0:2) {
     cli::cli_abort("Unsupported order")
@@ -306,13 +306,15 @@ compute_bounds <- function(pmax, J, order) {
       bounds[j] <- max(abs(lambda_mid - 2 * lambda2(grid[j + 1], grid[j + 2], h) + lambda_left))
     }
   }
-  bounds[1] <- 1
+  if (p_min == 0) {
+    bounds[1] <- 1
+  }
   matrix(bounds, ncol = 1)
 }
 
-bound0 <- function(pmax, J) compute_bounds(pmax, J, 0)
-bound1 <- function(pmax, J) compute_bounds(pmax, J, 1)
-bound2 <- function(pmax, J) compute_bounds(pmax, J, 2)
+bound0 <- function(p_min, p_max, J) compute_bounds(p_min, p_max, J, 0)
+bound1 <- function(p_min, p_max, J) compute_bounds(p_min, p_max, J, 1)
+bound2 <- function(p_min, p_max, J) compute_bounds(p_min, p_max, J, 2)
 
 #' Filter p-values and optional study identifiers
 filter_pvalues <- function(Q, ind, p_min, p_max) {
@@ -333,26 +335,38 @@ compute_phat <- function(P, J, p_min, p_max) {
 
 #' Covariance matrix of the empirical distribution under clustering
 compute_omega <- function(P, ind, phat, bins) {
+  N <- length(P)
+  J <- length(phat) + 1
   if (length(ind) > 1) {
     omega <- matrix(0, length(phat), length(phat))
     for (cluster in unique(ind)) {
-      X <- P[ind == cluster]
-      mq <- build_indicator_matrix(X, bins, phat)
-      omega <- omega + mq %*% t(mq)
+      mq <- build_indicator_matrix(P[ind == cluster], bins, phat)
+      # Outer product of the per-cluster sum of (indicator - phat). The canonical
+      # implementation writes this as mq %*% ones(n_c, n_c) %*% t(mq) on the
+      # transposed (bins x observations) layout.
+      cluster_sum <- matrix(colSums(mq), ncol = 1)
+      omega <- omega + cluster_sum %*% t(cluster_sum)
     }
-    omega / length(P)
+    omega / N
+  } else if (min(phat) == 0) {
+    qhat <- matrix(phat * N / (N + 1) + 1 / (J * (N + 1)), ncol = 1)
+    diag(c(qhat)) - qhat %*% t(qhat)
   } else {
-    qhat <- phat * length(P) / (length(P) + 1) + 1 / (length(phat) + 1) / (length(P) + 1)
-    diag(qhat) - qhat %*% t(qhat)
+    p <- matrix(phat, ncol = 1)
+    diag(c(p)) - p %*% t(p)
   }
 }
 
 build_indicator_matrix <- function(X, bins, phat) {
   J <- length(phat) + 1
   mq <- matrix(0, nrow = length(X), ncol = J - 1)
+  lower <- bins[1:(J - 1)]
+  upper <- bins[2:J]
   for (q in seq_along(X)) {
-    mq[q, ] <- as.numeric((X[q] > head(bins, -1)) & (X[q] <= tail(bins, -1)))
-    mq[q, X[q] == 0 & seq_len(J - 1) == 1] <- 1
+    mq[q, ] <- as.numeric((X[q] > lower) & (X[q] <= upper))
+    if (X[q] == 0) {
+      mq[q, 1] <- 1
+    }
   }
   sweep(mq, 2, phat, `-`)
 }
@@ -379,17 +393,25 @@ extend_difference_matrix <- function(D, J, K) {
   dk
 }
 
-build_constraint_vector <- function(B0, B1, B2, Galpha, use_bounds, J, K) { # nolint: object_name_linter.
-  if (identical(use_bounds, 0)) {
-    return(c(-B0))
+#' Constraint vector for the Cox-Shi programme
+#'
+#' Mirrors the canonical construction: the bound block (or a vector of -1 when
+#' bounds are switched off) followed by the zero block for the shape
+#' restrictions. The zero block has `(K + 1) * (J - K / 2)` entries; without it
+#' R recycles the bound block and slackens the shape constraints.
+build_constraint_vector <- function(B0, B1, B2, bnd_adj, use_bounds, J, K, p_min = 0) { # nolint: object_name_linter.
+  zeros <- rep(0, (K + 1) * (J - K / 2))
+  if (use_bounds == 0) {
+    return(c(rep(-1, J), zeros))
   }
-  b0 <- -B0 / Galpha
-  b1 <- -B1 / Galpha
-  b2 <- -B2 / Galpha
-  b0[1] <- -1
-  b1[1] <- -1
-  b2[1] <- -1
-  c(b0, b1, b2)
+  bounds <- list(-B0 / bnd_adj, -B1 / bnd_adj, -B2 / bnd_adj)[seq_len(K + 1)]
+  if (p_min == 0) {
+    bounds <- lapply(bounds, function(b) {
+      b[1] <- -1
+      b
+    })
+  }
+  c(unlist(lapply(bounds, as.vector)), zeros)
 }
 
 fmincon <- function(x0, fn, gr = NULL, ..., method = "SQP",
@@ -469,67 +491,85 @@ fmincon <- function(x0, fn, gr = NULL, ..., method = "SQP",
   )
 }
 
-solve_coxshi_problem <- function(t0, fn, A, b) {
+#' Solve the Cox-Shi quadratic programme, retrying from random starts
+#'
+#' Returns `NULL` once the retry budget is exhausted so that callers can report
+#' nonconvergence instead of looping forever on a deterministic failure.
+solve_coxshi_problem <- function(t0, fn, A, b, max_restarts = 10L) { # nolint: object_name_linter.
   res <- tryCatch(fmincon(t0, fn, A = A, b = b), error = function(e) NULL)
-  while (is.null(res) || !is.list(res)) {
-    ru <- runif(length(t0))
+  restarts <- 0L
+  while ((is.null(res) || !is.list(res)) && restarts < max_restarts) {
+    ru <- stats::runif(length(t0))
     t0 <- matrix(ru / sum(ru), ncol = 1)
     res <- tryCatch(fmincon(t0, fn, A = A, b = b), error = function(e) NULL)
+    restarts <- restarts + 1L
   }
-  res
+  if (is.null(res) || !is.list(res)) NULL else res
+}
+
+#' NA carrying a human-readable reason for skipping a test
+skipped_result <- function(reason) {
+  out <- NA_real_
+  attr(out, "reason") <- reason
+  out
 }
 
 cox_shi_test <- function(Q, ind, p_min, p_max, J, K, use_bounds) {
+  use_bounds <- as.integer(use_bounds)
+  K <- as.integer(K) # nolint: object_name_linter.
+  J <- as.integer(J) # nolint: object_name_linter.
   filtered <- filter_pvalues(Q, ind, p_min, p_max)
   P <- filtered$P
   ind_filtered <- filtered$ind
   N <- length(P)
-  Galpha <- N / length(Q) # nolint: object_name_linter.
+  bnd_adj <- N / length(Q)
   phat_data <- compute_phat(P, J, p_min, p_max)
   phat <- phat_data$phat
   bins <- phat_data$bins
-  B0 <- bound0(p_max, J)
-  B1 <- bound1(p_max, J)
-  B2 <- bound2(p_max, J)
-  if (identical(use_bounds, 0)) {
-    B0 <- rep(1, J)
-  }
+  B0 <- bound0(p_min, p_max, J)
+  B1 <- bound1(p_min, p_max, J)
+  B2 <- bound2(p_min, p_max, J)
   omega <- compute_omega(P, ind_filtered, phat, bins)
+  omega_inv <- if (is.finite(det(omega)) && abs(det(omega)) > 0) {
+    tryCatch(solve(omega), error = function(e) NULL)
+  } else {
+    NULL
+  }
+  if (is.null(omega_inv)) {
+    return(skipped_result(paste0(
+      "the bin covariance matrix is singular with J = ", J,
+      " bins on [", p_min, ", ", p_max, "] (", N,
+      " p-values in the window); try fewer bins"
+    )))
+  }
   D <- build_difference_matrix(J)
   dk <- extend_difference_matrix(D, J, K)
-  if (identical(use_bounds, 0)) {
-    dk <- rbind(-diag(J), diag(J), dk)
+  dk <- if (use_bounds == 0) {
+    rbind(-diag(J), diag(J), dk)
   } else {
-    dk <- rbind(-diag(J), -dk, diag(J), dk)
+    rbind(-diag(J), -dk, diag(J), dk)
   }
   ej <- rep(0, J)
   ej[J] <- 1
-  F1 <- rbind(-diag(J - 1), rep(1, J - 1))
-  constraint_vector <- if (identical(use_bounds, 0)) {
-    rep(0, nrow(dk))
-  } else {
-    build_constraint_vector(B0, B1, B2, Galpha, use_bounds, J, K)
-  }
-  A <- dk %*% F1
+  F1 <- rbind(-diag(J - 1), rep(1, J - 1)) # nolint: object_name_linter.
+  constraint_vector <- build_constraint_vector(B0, B1, B2, bnd_adj, use_bounds, J, K, p_min)
+  A <- dk %*% F1 # nolint: object_name_linter.
   b_vec <- dk %*% ej - constraint_vector
   fn <- function(t) {
     diff_vec <- phat - t
-    N * t(diff_vec) %*% solve(omega) %*% diff_vec
+    N * t(diff_vec) %*% omega_inv %*% diff_vec
   }
-  start <- matrix(1 / (J - 1), ncol = 1, nrow = J - 1)
+  start <- matrix(1 / J, ncol = 1, nrow = J - 1)
   result <- solve_coxshi_problem(start, fn, A, b_vec)
-  if (is.null(result) || is.null(result$par)) {
-    return(NA_real_)
+  if (is.null(result) || is.null(result$par) || result$convergence != 0) {
+    return(skipped_result("the constrained optimisation did not converge"))
   }
-  t_opt <- result$par
-  stat <- fn(t_opt)
+  stat <- fn(result$par)
   ba <- A[result$info$lambda$ineqlin > 0, , drop = FALSE]
-  JX <- qr(ba)$rank
-  if (result$convergence == 0 && JX > 0) {
-    1 - stats::pchisq(stat, df = JX)
-  } else {
-    NA_real_
-  }
+  JX <- qr(ba)$rank # nolint: object_name_linter.
+  # JX == 0 is the interior (unconstrained) solution: no shape restriction
+  # binds, so the p-curve is compatible with the null and p = 1.
+  as.numeric(1 - stats::pchisq(stat, df = JX) * (JX > 0))
 }
 
 box::export(
@@ -553,5 +593,6 @@ box::export(
   extend_difference_matrix,
   build_constraint_vector,
   solve_coxshi_problem,
+  skipped_result,
   cox_shi_test
 )

--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -20,7 +20,8 @@ box::use(
     lcm_test,
     fisher_test,
     run_discontinuity_test,
-    cox_shi_test
+    cox_shi_test,
+    skipped_result
   ],
   artma / calc / methods / maive[maive]
 )
@@ -493,7 +494,7 @@ run_discontinuity <- function(pvalues, cutoff = 0.05, bandwidth = 0.05) {
 #' @param monotonicity_order *[integer]* Order of monotonicity (K).
 #' @param use_bounds *[integer]* Whether to use bounds (0 or 1).
 #' @return *[numeric]* P-value from test.
-run_cox_shi <- function(pvalues, study_id = NULL, p_min, p_max, n_bins = 20L,
+run_cox_shi <- function(pvalues, study_id = NULL, p_min, p_max, n_bins = 10L,
                         monotonicity_order = 2L, use_bounds = 1L) {
   validate(
     is.numeric(pvalues),
@@ -513,7 +514,7 @@ run_cox_shi <- function(pvalues, study_id = NULL, p_min, p_max, n_bins = 20L,
     study_id <- seq_along(pvalues)
   }
 
-  tryCatch(
+  result <- tryCatch(
     cox_shi_test(
       Q = pvalues,
       ind = study_id,
@@ -523,8 +524,16 @@ run_cox_shi <- function(pvalues, study_id = NULL, p_min, p_max, n_bins = 20L,
       K = as.integer(monotonicity_order),
       use_bounds = as.integer(use_bounds)
     ),
-    error = function(e) NA_real_
+    error = function(e) skipped_result(e$message)
   )
+
+  reason <- attr(result, "reason")
+  if (!is.null(reason)) {
+    cli::cli_alert_warning(
+      "Cox-Shi test on [{p_min}, {p_max}] skipped: {reason}."
+    )
+  }
+  as.numeric(result)
 }
 
 #' @title Run suite of p-hacking tests
@@ -760,5 +769,6 @@ box::export(
   prepare_maive_data,
   maive_p_from_coef,
   run_binomial,
+  run_cox_shi,
   run_fisher
 )

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -34,7 +34,7 @@ p_hacking_tests <- function(df) {
   include_discontinuity <- opt$include_discontinuity %||% TRUE
   discontinuity_bandwidth <- opt$discontinuity_bandwidth %||% 0.05
   include_cox_shi <- opt$include_cox_shi %||% TRUE
-  cox_shi_bins <- opt$cox_shi_bins %||% 20L
+  cox_shi_bins <- opt$cox_shi_bins %||% 10L
   cox_shi_order <- opt$cox_shi_order %||% 2L
   cox_shi_bounds <- opt$cox_shi_bounds %||% 1L
 

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -669,10 +669,11 @@ methods:
 
     cox_shi_bins:
       type: "integer"
-      default: 20
+      default: 10
       help: |
         Number of bins for discretization in Cox-Shi tests.
-        More bins provide finer resolution but require more observations.
+        More bins provide finer resolution but require more observations; empty
+        bins make the covariance matrix singular and the test is then skipped.
 
     cox_shi_order:
       type: "integer"

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -3,6 +3,7 @@ box::use(
     expect_equal,
     expect_error,
     expect_false,
+    expect_match,
     expect_true,
     test_that
   ],
@@ -13,10 +14,12 @@ box::use(
     prepare_maive_data,
     run_single_caliper,
     run_binomial,
+    run_cox_shi,
     run_fisher,
     run_caliper_tests,
     run_p_hacking_tests
-  ]
+  ],
+  artma / calc / methods / elliott[cox_shi_test]
 )
 
 # compute_pvalues -----------------------------------------------------------
@@ -256,4 +259,124 @@ test_that("run_p_hacking_tests runs the Elliott suite when requested", {
   expect_true(is.data.frame(result$elliott))
   expect_true("Binomial [0, 0.05]" %in% result$elliott$Test)
   expect_true("Fisher [0, 0.05]" %in% result$elliott$Test)
+})
+
+# Cox-Shi ------------------------------------------------------------------
+
+# Golden values below were produced once with the authors' canonical `Tests.R`
+# (nvkudrin/Detecting-p-hacking-Code, Elliott, Kudrin & Wuthrich 2022) on the
+# panels built by `cox_shi_panel()`. They are hard-coded on purpose: the tests
+# must not reach out to GitHub.
+cox_shi_panel <- function(seed, n = 800L) {
+  set.seed(seed, kind = "Mersenne-Twister", normal.kind = "Inversion")
+  t_stats <- abs(stats::rnorm(n, mean = 1.5, sd = 1))
+  list(
+    pvalues = 2 * (1 - stats::pnorm(t_stats)),
+    t_stats = t_stats,
+    study_id = 1 + ((seq_len(n) - 1) %/% 20)
+  )
+}
+
+test_that("cox_shi_test matches the canonical implementation, unclustered", {
+  panel <- cox_shi_panel(101)
+
+  # ind of length 1 selects the multinomial (unclustered) covariance.
+  expect_equal(
+    cox_shi_test(panel$pvalues, 0, 0, 0.05, J = 10, K = 1, use_bounds = 0),
+    0.052081436460,
+    tolerance = 1e-6
+  )
+  expect_equal(
+    cox_shi_test(panel$pvalues, 0, 0, 0.10, J = 10, K = 2, use_bounds = 1),
+    0.019154644996,
+    tolerance = 1e-6
+  )
+})
+
+test_that("cox_shi_test matches the canonical implementation, clustered", {
+  panel <- cox_shi_panel(202)
+
+  expect_equal(
+    cox_shi_test(panel$pvalues, panel$study_id, 0, 0.05, J = 10, K = 1, use_bounds = 0),
+    0.558552296381,
+    tolerance = 1e-6
+  )
+  expect_equal(
+    cox_shi_test(panel$pvalues, panel$study_id, 0, 0.10, J = 10, K = 2, use_bounds = 1),
+    0.635590223696,
+    tolerance = 1e-6
+  )
+})
+
+test_that("cox_shi_test returns 1 for a monotone p-curve with no binding constraint", {
+  # Strictly decreasing bin counts: the interior solution leaves JX = 0, which
+  # canonically yields p = 1 rather than NA.
+  n_bins <- 10L
+  bins <- seq(0, 0.05, length.out = n_bins + 1)
+  counts <- c(200, 150, 110, 80, 60, 45, 34, 26, 20, 15)
+  pvalues <- unlist(lapply(
+    seq_len(n_bins),
+    function(j) rep(mean(c(bins[j], bins[j + 1])), counts[j])
+  ))
+
+  expect_equal(
+    cox_shi_test(pvalues, 0, 0, 0.05, J = n_bins, K = 1, use_bounds = 0),
+    1,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    cox_shi_test(pvalues, 0, 0, 0.05, J = n_bins, K = 2, use_bounds = 0),
+    1,
+    tolerance = 1e-12
+  )
+})
+
+test_that("cox_shi_test skips with a reason when the covariance is singular", {
+  # Too few p-values in the window for 20 bins: empty bins make omega singular.
+  set.seed(404, kind = "Mersenne-Twister", normal.kind = "Inversion")
+  pvalues <- 2 * (1 - stats::pnorm(abs(stats::rnorm(300, mean = 1, sd = 1))))
+
+  result <- cox_shi_test(pvalues, seq_along(pvalues), 0, 0.05, J = 20L, K = 2L, use_bounds = 1L)
+
+  expect_true(is.na(result))
+  expect_match(attr(result, "reason"), "singular")
+})
+
+test_that("run_cox_shi turns a skip reason into a warning and a plain NA", {
+  set.seed(404, kind = "Mersenne-Twister", normal.kind = "Inversion")
+  pvalues <- 2 * (1 - stats::pnorm(abs(stats::rnorm(300, mean = 1, sd = 1))))
+
+  result <- suppressMessages(
+    run_cox_shi(pvalues, seq_along(pvalues), 0, 0.05, n_bins = 20L)
+  )
+
+  expect_true(is.na(result))
+  expect_true(is.null(attr(result, "reason")))
+})
+
+test_that("run_p_hacking_tests reports numeric Cox-Shi rows on clustered data", {
+  local_options(
+    artma.verbose = 1,
+    artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
+  )
+  panel <- cox_shi_panel(202)
+  df <- data.frame(
+    effect = panel$t_stats,
+    se = rep(1, length(panel$t_stats)),
+    study_id = panel$study_id
+  )
+
+  result <- run_p_hacking_tests(
+    df,
+    base_p_hacking_options(
+      include_caliper = FALSE,
+      include_elliott = TRUE,
+      include_cox_shi = TRUE,
+      cox_shi_bins = 10L
+    )
+  )
+
+  cox_rows <- result$elliott[grepl("^Cox-Shi", result$elliott$Test), ]
+  expect_equal(nrow(cox_rows), 2)
+  expect_false(any(grepl("NA", cox_rows$`P-value`)))
 })


### PR DESCRIPTION
The Cox-Shi rows of `p_hacking_tests` never produced a number: every run errored internally and the error was swallowed into `NA`. This rewrites the internals in `inst/artma/calc/methods/elliott.R` against the authors' canonical `Tests.R` (Elliott, Kudrin & Wuthrich, Econometrica 2022), fixing all ten defects listed in the issue: namespaced `utils`/`stats` calls, the J vs J-1 indicator length, the clustered covariance (outer product of per-cluster sums), zero-padding of the constraint vector instead of silent recycling, integer-safe `use_bounds == 0`, `p = 1` for the interior solution, an explicit singular-omega skip with a reason surfaced via `cli`, a single omega inversion outside the objective, a bounded retry loop, and a default of 10 bins instead of 20.

New tests cover golden values against the canonical implementation (unclustered and clustered, K = 1 bounds off and K = 2 bounds on, on [0, 0.05] and [0, 0.10], hard-coded so nothing fetches GitHub), the monotone p-curve returning 1, the singular-omega skip, and numeric Cox-Shi rows through `run_p_hacking_tests` on clustered data.

Closes #258