### PR TITLE
CRAN readiness: methods vignette, pkgdown site, clean R CMD check

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,11 @@
 ^\.\.Rcheck$
 ^\.artma$
 ^\.github$
+^\.git$
+^\.githooks$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$
 ^\.covrignore$
 ^README\.md$
 ^README-dev\.md$

--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,5 +1,6 @@
 {{ range .Versions }}
 <a name="{{ .Tag.Name }}"></a>
+
 ## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }}
 
 > {{ datetime "2006-01-02" .Tag.Date }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ inst/doc
 /doc/
 /Meta/
 cran-comments.md
+/docs/
+/pkgdown/
 
 # Local
 .artma/*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,6 +67,7 @@ Config/Needs/dev: box.linters, devtools, languageserver, remotes
 Config/Needs/e2e: remotes
 Config/Needs/lint: devtools, remotes
 Config/Needs/release: devtools, optparse, pkgbuild, remotes
+Config/Needs/website: pkgdown
 Config/testthat/edition: 3
 Config/testthat/parallel: TRUE
 Config/testthat/start-first: github-actions, release

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #   make build      - Build package tarball
 #   make clean      - Clean build artifacts
 
-.PHONY: help install test test-file test-filter test-e2e check check-fast lint document generate-check-manifest build clean coverage coverage-report style desc-normalize all dev quick setup hooks vignettes preview-vignette fix-options clear-cache stats
+.PHONY: help install test test-file test-filter test-e2e check check-fast lint document generate-check-manifest build clean coverage coverage-report style desc-normalize all dev quick setup hooks vignettes preview-vignette fix-options clear-cache stats site
 
 # Default target
 help:
@@ -28,6 +28,7 @@ help:
 	@echo "  make document         Generate documentation with roxygen2"
 	@echo "  make build            Build source package"
 	@echo "  make vignettes        Build vignettes"
+	@echo "  make site             Build the pkgdown site"
 	@echo "  make preview-vignette Render and open a vignette (VIGNETTE=name)"
 	@echo "  make clean            Remove build artifacts"
 	@echo "  make coverage         Generate test coverage report"
@@ -135,6 +136,15 @@ ifeq ($(strip $(VIGNETTE)),)
 else
 	@bash scripts/previewVignette.sh $(VIGNETTE)
 endif
+
+# Build the pkgdown site
+# pkgdown auto-publishes every root-level *.md file it doesn't recognize as
+# README/LICENSE/NEWS; strip the agent-instruction files it would otherwise
+# expose (they aren't user-facing package documentation).
+site:
+	@echo "Building pkgdown site..."
+	@Rscript -e "pkgdown::build_site()"
+	@rm -f docs/CLAUDE.html docs/CLAUDE.md docs/AGENTS.html docs/AGENTS.md
 
 # Clean build artifacts
 clean:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 
 <a name="unreleased"></a>
+
 ## Unreleased
 
 ### Breaking Changes
@@ -17,12 +18,14 @@
 
 
 <a name="v0.3.3"></a>
+
 ## [v0.3.3](https://github.com/PetrCala/artma/compare/v0.3.2...v0.3.3)
 
 > 2026-02-11
 
 
 <a name="v0.3.2"></a>
+
 ## [v0.3.2](https://github.com/PetrCala/artma/compare/v0.3.1...v0.3.2)
 
 > 2025-10-07
@@ -40,6 +43,7 @@
 
 
 <a name="v0.3.1"></a>
+
 ## [v0.3.1](https://github.com/PetrCala/artma/compare/v0.3.0...v0.3.1)
 
 > 2025-10-06
@@ -52,6 +56,7 @@
 
 
 <a name="v0.3.0"></a>
+
 ## [v0.3.0](https://github.com/PetrCala/artma/compare/v0.2.2...v0.3.0)
 
 > 2025-10-06
@@ -72,6 +77,7 @@
 
 
 <a name="v0.2.2"></a>
+
 ## [v0.2.2](https://github.com/PetrCala/artma/compare/v0.2.1...v0.2.2)
 
 > 2025-10-01
@@ -135,6 +141,7 @@
 
 
 <a name="v0.2.1"></a>
+
 ## [v0.2.1](https://github.com/PetrCala/artma/compare/v0.2.0...v0.2.1)
 
 > 2025-04-25
@@ -169,6 +176,7 @@
 
 
 <a name="v0.2.0"></a>
+
 ## [v0.2.0](https://github.com/PetrCala/artma/compare/v0.1.30...v0.2.0)
 
 > 2025-04-24
@@ -205,6 +213,7 @@ the new templates are now incompatible with old ones
 
 
 <a name="v0.1.30"></a>
+
 ## [v0.1.30](https://github.com/PetrCala/artma/compare/v0.1.29...v0.1.30)
 
 > 2025-04-16
@@ -239,6 +248,7 @@ the new templates are now incompatible with old ones
 
 
 <a name="v0.1.29"></a>
+
 ## [v0.1.29](https://github.com/PetrCala/artma/compare/v0.1.28...v0.1.29)
 
 > 2025-04-15
@@ -249,24 +259,28 @@ the new templates are now incompatible with old ones
 
 
 <a name="v0.1.28"></a>
+
 ## [v0.1.28](https://github.com/PetrCala/artma/compare/v0.1.27...v0.1.28)
 
 > 2025-04-15
 
 
 <a name="v0.1.27"></a>
+
 ## [v0.1.27](https://github.com/PetrCala/artma/compare/v0.1.26...v0.1.27)
 
 > 2025-04-15
 
 
 <a name="v0.1.26"></a>
+
 ## [v0.1.26](https://github.com/PetrCala/artma/compare/v0.1.25...v0.1.26)
 
 > 2025-04-15
 
 
 <a name="v0.1.25"></a>
+
 ## [v0.1.25](https://github.com/PetrCala/artma/compare/v0.1.24...v0.1.25)
 
 > 2025-04-15
@@ -281,6 +295,7 @@ the new templates are now incompatible with old ones
 
 
 <a name="v0.1.24"></a>
+
 ## [v0.1.24](https://github.com/PetrCala/artma/compare/v0.1.23...v0.1.24)
 
 > 2025-04-14
@@ -291,6 +306,7 @@ the new templates are now incompatible with old ones
 
 
 <a name="v0.1.23"></a>
+
 ## [v0.1.23](https://github.com/PetrCala/artma/compare/v0.1.22...v0.1.23)
 
 > 2025-04-14
@@ -321,6 +337,7 @@ the new templates are now incompatible with old ones
 
 
 <a name="v0.1.22"></a>
+
 ## [v0.1.22](https://github.com/PetrCala/artma/compare/v0.1.21...v0.1.22)
 
 > 2025-04-14
@@ -332,90 +349,105 @@ the new templates are now incompatible with old ones
 
 
 <a name="v0.1.21"></a>
+
 ## [v0.1.21](https://github.com/PetrCala/artma/compare/v0.1.20...v0.1.21)
 
 > 2025-04-11
 
 
 <a name="v0.1.20"></a>
+
 ## [v0.1.20](https://github.com/PetrCala/artma/compare/v0.1.19...v0.1.20)
 
 > 2025-04-10
 
 
 <a name="v0.1.19"></a>
+
 ## [v0.1.19](https://github.com/PetrCala/artma/compare/v0.1.18...v0.1.19)
 
 > 2025-04-10
 
 
 <a name="v0.1.18"></a>
+
 ## [v0.1.18](https://github.com/PetrCala/artma/compare/v0.1.17...v0.1.18)
 
 > 2025-04-09
 
 
 <a name="v0.1.17"></a>
+
 ## [v0.1.17](https://github.com/PetrCala/artma/compare/v0.1.16...v0.1.17)
 
 > 2025-04-09
 
 
 <a name="v0.1.16"></a>
+
 ## [v0.1.16](https://github.com/PetrCala/artma/compare/v0.1.15...v0.1.16)
 
 > 2025-04-09
 
 
 <a name="v0.1.15"></a>
+
 ## [v0.1.15](https://github.com/PetrCala/artma/compare/v0.1.14...v0.1.15)
 
 > 2025-04-09
 
 
 <a name="v0.1.14"></a>
+
 ## [v0.1.14](https://github.com/PetrCala/artma/compare/v0.1.13...v0.1.14)
 
 > 2025-04-08
 
 
 <a name="v0.1.13"></a>
+
 ## [v0.1.13](https://github.com/PetrCala/artma/compare/v0.1.12...v0.1.13)
 
 > 2025-04-08
 
 
 <a name="v0.1.12"></a>
+
 ## [v0.1.12](https://github.com/PetrCala/artma/compare/v0.1.11...v0.1.12)
 
 > 2025-04-07
 
 
 <a name="v0.1.11"></a>
+
 ## [v0.1.11](https://github.com/PetrCala/artma/compare/v0.1.10...v0.1.11)
 
 > 2025-04-07
 
 
 <a name="v0.1.10"></a>
+
 ## [v0.1.10](https://github.com/PetrCala/artma/compare/v0.1.9...v0.1.10)
 
 > 2025-04-05
 
 
 <a name="v0.1.9"></a>
+
 ## [v0.1.9](https://github.com/PetrCala/artma/compare/v0.1.8...v0.1.9)
 
 > 2025-04-05
 
 
 <a name="v0.1.8"></a>
+
 ## [v0.1.8](https://github.com/PetrCala/artma/compare/v0.1.7...v0.1.8)
 
 > 2025-04-05
 
 
 <a name="v0.1.7"></a>
+
 ## v0.1.7
 
 > 2025-04-04

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,19 @@
+url: https://petrcala.github.io/artma/
+
+template:
+  bootstrap: 5
+
+navbar:
+  components:
+    news:
+      text: Changelog
+      href: https://github.com/PetrCala/artma/blob/master/NEWS.md
+
+articles:
+  - title: Get started
+    navbar: ~
+    contents:
+      - getting-started
+      - methods-overview
+      - options-files
+      - release-cycle

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -85,7 +85,7 @@ Methods are the analytical functions that perform specific meta-analysis tasks. 
 - `p_hacking_tests` - Detect p-hacking patterns
 - `variable_summary_stats` - Summary statistics for variables
 
-You can run one method, multiple methods, or all methods in a single call.
+You can run one method, multiple methods, or all methods in a single call. For a full description of every method, see the [Methods Overview](methods-overview.html) vignette.
 
 ## Common Workflows
 

--- a/vignettes/methods-overview.Rmd
+++ b/vignettes/methods-overview.Rmd
@@ -1,0 +1,80 @@
+---
+title: "Methods Overview"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Methods Overview}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+## Introduction
+
+**artma** ships a set of runtime methods: the analytical functions that `artma()` runs on your data. This vignette describes what each method does, what it depends on, and what it returns, so you can pick the right ones for your analysis. For a hands-on introduction to running methods, see the [Getting Started](getting-started.html) vignette.
+
+List the methods available in your installed version at any time with:
+
+```r
+artma::methods.list()
+```
+
+## How methods execute
+
+Each method is a plain function registered with `register_runtime_method()`, which attaches declarative metadata: a `depends_on` list of upstream methods, a `required_columns` list of data columns it needs, and a `suggests` list of optional packages it needs.
+
+When you call `artma(methods = ...)`, the requested methods are topologically sorted by their `depends_on` edges, so a method that builds on another method's output (for example, `best_practice_estimate` builds on `bma`) always runs after it and receives its result as a `<dependency>_result` argument. Ties preserve discovery order; dependency cycles abort the run.
+
+Before each method runs, its `required_columns` are checked against your data and its `suggests` packages against what's installed. A method that fails either check is skipped with an explanation instead of aborting the whole run, the only exception being a non-interactive run that requested exactly that one method with a missing suggested package, which aborts with a clear error. A method that throws an error is likewise caught and skipped; the run continues, and skipped/failed methods are reported at the end (as the `failed_methods` attribute on the returned list).
+
+Every method returns a `tables`/`plots`/`meta` triple: `tables` are exported as CSV, `plots` are available for programmatic access and printing, and `meta` holds anything else (fitted models, fit parameters, skip reasons).
+
+## Descriptive and exploratory methods
+
+These methods summarize or visualize the data; none depend on another method.
+
+| Method | What it does | Required columns |
+| --- | --- | --- |
+| `effect_summary_stats` | Summary statistics (mean, weighted mean, CIs, median, SD) of the main effect, grouped by variables flagged in the data config | `effect`, `study_size` |
+| `variable_summary_stats` | Descriptive statistics (mean, median, min, max, SD, missingness) for each variable flagged for summary in the data config | none |
+| `funnel_plot` | Funnel plot of effect against precision, for spotting publication bias/asymmetry, with configurable outlier filtering | `effect`, `precision` |
+| `box_plot` | Box plots of the effect grouped by a categorical variable, auto-splitting into multiple plots when there are many groups | `effect` |
+| `prima_facie_graphs` | Density/histogram overlays of the effect distribution split by detected categorical groups (e.g. published vs. unpublished) | `effect` |
+| `t_stat_histogram` | Histograms of the t-statistic distribution, with a full-range and a zoomed-in view, plus significance reference lines | `t_stat` |
+
+## Publication-bias diagnostics
+
+These methods test for publication bias and selective reporting; none depend on another method.
+
+| Method | What it does | Required columns |
+| --- | --- | --- |
+| `linear_tests` | Linear funnel-asymmetry regressions of effect on standard error (FAT-PET): OLS, panel Fixed/Between/Random Effects, and study-size/precision-weighted variants | `effect`, `se`, `study_id` |
+| `nonlinear_tests` | Non-linear publication-bias corrections: WAAP, Top10, STEM (funnel and MSE variants), a hierarchical Bayesian model, a selection-model (p-uniform-style) estimator, and the endogenous kink test | `effect`, `se`, `study_id` |
+| `exogeneity_tests` | Diagnostics that relax the exogeneity assumption: instrumental-variable regression and the p-uniform* test | `effect`, `se`, `study_id`, `n_obs`, `study_size` |
+| `p_hacking_tests` | Caliper tests around significance thresholds, the Elliott et al. (2022) battery, and the MAIVE estimator | `effect`, `se`, `t_stat`, `study_id` |
+
+`exogeneity_tests` needs the `AER` and `ivmodel` packages; the others in this group work with the package's own dependencies.
+
+## Moderator and heterogeneity analysis
+
+These methods examine how the effect varies with moderator variables. `fma` and `best_practice_estimate` both build on `bma`.
+
+| Method | What it does | Depends on | Required columns |
+| --- | --- | --- | --- |
+| `bma` | Bayesian Model Averaging over moderator variables, estimating posterior inclusion probability and posterior mean/SD for each candidate moderator | none | `effect`, `se` |
+| `fma` | Frequentist Model Averaging over the same moderators, using the BMA model (computed on demand if not already available) to order and select predictors | `bma` | `effect`, `se` |
+| `best_practice_estimate` | A "best-practice" point estimate and CI for the effect, plugging literature-informed or user-supplied moderator values into the BMA coefficients; also computes economic-significance metrics | `bma` | `effect`, `study_id` |
+
+`bma`, `fma`, and `best_practice_estimate` all need the `BMS` package; `fma` additionally needs `quadprog`. If you request both `bma` and `fma` (directly or via a dependency) and both produce coefficient tables, artma adds a unified `ma_table` entry to the results combining them.
+
+## Choosing methods
+
+Methods whose required columns are missing from your data, or whose suggested packages aren't installed, are skipped with an explanation rather than aborting the run, so it's safe to request `methods = "all"` even if your data or R environment doesn't support every method:
+
+```r
+# Run everything artma supports for your data
+results <- artma(methods = "all", options = "my_analysis.yaml")
+
+# Run a specific combination
+results <- artma(methods = c("funnel_plot", "bma", "fma"), options = "my_analysis.yaml")
+```
+
+See the [Getting Started](getting-started.html) vignette for the full workflow, and the [Understanding Options Files](options-files.html) vignette for how to configure each method's parameters.


### PR DESCRIPTION
Adds the remaining CRAN-readiness pieces from #227: a methods-overview vignette summarizing every runtime method (dependencies, required columns, optional packages, return shape), a pkgdown site config (build-only, no GitHub Pages deploy), and a fix for the "hidden files and directories" R CMD check NOTE (`.git`/`.githooks` weren't in `.Rbuildignore`). Also fixes the git-chglog template so generated NEWS.md headings have the blank line pandoc/pkgdown needs to parse them, and points the pkgdown "Changelog" nav link at the GitHub-rendered NEWS.md instead of pkgdown's own changelog parser, which doesn't understand our compare-link heading style.

Closes #227