### PR TITLE
fix(p_hacking_tests): quick wins from p-hacking suite review

### DIFF
--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -145,7 +145,6 @@ simulate_cdfs_parallel <- function(
       hky <- hull$y.knots
       hks <- hull$slope.knots
 
-      # keep interpolation logic aligned with your original code
       for (s in 2:length(hkx)) {
         a <- hky[s] - hks[s - 1L] * hkx[s]
         b_slope <- hks[s - 1L]
@@ -258,7 +257,7 @@ binomial_test <- function(P, p_min, p_max, type) {
 }
 
 #' LCM-based test for shape restrictions
-lcm_test <- function(P, p_min, p_max, norm, cdfs) {
+lcm_test <- function(P, p_min, p_max, cdfs) {
   filtered <- P[P <= p_max & P >= p_min]
   nn <- length(filtered)
   f <- stats::ecdf(filtered)
@@ -441,6 +440,7 @@ build_constraint_vector <- function(B0, B1, B2, bnd_adj, use_bounds, J, K, p_min
   c(unlist(lapply(bounds, as.vector)), zeros)
 }
 
+#' Adapted from pracma::fmincon (GPL-3, compatible with this package's license)
 fmincon <- function(x0, fn, gr = NULL, ..., method = "SQP",
                     A = NULL, b = NULL, Aeq = NULL, beq = NULL, # nolint: object_name_linter.
                     lb = NULL, ub = NULL, hin = NULL, heq = NULL,

--- a/inst/artma/calc/methods/maive.R
+++ b/inst/artma/calc/methods/maive.R
@@ -1,3 +1,13 @@
+MAIVE_MIN_VERSION <- "0.2.4"
+
+#' @title Check whether the installed MAIVE version meets the minimum requirement
+#' @param installed_version *[character]* Version string to check, e.g. from `packageVersion("MAIVE")`.
+#' @param min_version *[character]* Minimum required version.
+#' @return *[logical]* TRUE if `installed_version >= min_version`.
+maive_version_ok <- function(installed_version, min_version = MAIVE_MIN_VERSION) {
+  package_version(installed_version) >= package_version(min_version)
+}
+
 #' @title MAIVE wrapper
 #' @description
 #' Wrapper for the MAIVE (Meta-Analysis Instrumental Variable Estimator) method
@@ -9,9 +19,9 @@
 #' @param weight *[integer]* Weighting scheme: 0=none (default), 1=weights, 2=adjusted.
 #' @param instrument *[integer]* Instrument SEs: 0=no, 1=yes (default).
 #' @param studylevel *[integer]* Study-level correlation: 0=none, 1=fixed, 2=cluster (default).
-#' @param SE *[integer]* SE estimation: 1=Asymptotic, 2=Pairs cluster boot, 3=Wild boot (default),
+#' @param SE *[integer]* SE estimation: 1=Asymptotic (default), 2=Pairs cluster boot, 3=Wild boot,
 #'   4=Wild cluster boot, 5=Pairs boot.
-#' @param AR *[integer]* Anderson-Rubin CI: 0=no, 1=yes (default).
+#' @param AR *[integer]* Anderson-Rubin CI: 0=no (default), 1=yes.
 #' @param first_stage *[integer]* First stage option (default 0).
 #' @param seed *[integer]* RNG seed for bootstrap SE modes (SE = 2..5), so
 #'   repeated runs on the same data reproduce identical results (default 123).
@@ -36,6 +46,14 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
     cli::cli_abort(c(
       "Package {.pkg MAIVE} is required for MAIVE estimation.",
       "i" = "Install with: install.packages('MAIVE')"
+    ))
+  }
+
+  installed_version <- as.character(utils::packageVersion("MAIVE"))
+  if (!maive_version_ok(installed_version)) {
+    cli::cli_abort(c(
+      "Package {.pkg MAIVE} {MAIVE_MIN_VERSION} or higher is required for MAIVE estimation.",
+      "i" = "Installed version: {installed_version}. Upgrade with: install.packages('MAIVE')"
     ))
   }
 
@@ -70,4 +88,4 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
   result
 }
 
-box::export(maive)
+box::export(maive, maive_version_ok)

--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -427,7 +427,7 @@ run_lcm <- function(pvalues, p_min, p_max, cdfs) {
   }
 
   tryCatch(
-    lcm_test(pvalues, p_min, p_max, norm = 8, cdfs),
+    lcm_test(pvalues, p_min, p_max, cdfs),
     error = function(e) skipped_result(e$message)
   )
 }
@@ -691,7 +691,7 @@ run_p_hacking_tests <- function(df, options) {
           )
         },
         error = function(e) {
-          skipped[["maive"]] <<- paste("MAIVE estimation failed:", e$message)
+          skipped[["maive"]] <<- e$message
           NULL
         }
       )
@@ -744,15 +744,12 @@ build_elliott_summary <- function(elliott_tests, pvalues, options) {
   )
 
   # Add observation count rows
-  n_total <- length(pvalues)
-  n_010 <- sum(pvalues <= 0.1, na.rm = TRUE)
-  n_005 <- sum(pvalues <= 0.05, na.rm = TRUE)
   n_01_range <- sum(pvalues >= 0 & pvalues <= 0.1, na.rm = TRUE)
   n_005_range <- sum(pvalues >= 0 & pvalues <= 0.05, na.rm = TRUE)
 
   obs_rows <- data.frame(
-    Test = c("Observations in [0, 0.1]", "Observations in [0, 0.05]", "Observations <= 0.1"),
-    `P-value` = c(as.character(n_01_range), as.character(n_005_range), as.character(n_010)),
+    Test = c("Observations in [0, 0.1]", "Observations in [0, 0.05]"),
+    `P-value` = c(as.character(n_01_range), as.character(n_005_range)),
     stringsAsFactors = FALSE,
     check.names = FALSE
   )

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -182,7 +182,7 @@ p_hacking_tests <- function(df) {
     # Overall note
     if (!is.null(results$caliper) || !is.null(results$elliott) || !is.null(results$maive)) {
       cli::cli_text("Note: Low p-values indicate potential p-hacking or selective reporting.")
-      cli::cli_text("Significance marks: * p < 0.05, ** p < 0.01, *** p < 0.001")
+      cli::cli_text("Significance marks: * p <= 0.1, ** p <= 0.05, *** p <= 0.01")
     } else {
       cli::cli_alert_warning("No p-hacking tests were successfully completed.")
     }

--- a/tests/testthat/helper-mocking.R
+++ b/tests/testthat/helper-mocking.R
@@ -37,3 +37,35 @@ local_pretend_packages_absent <- function(pkgs, .local_envir = parent.frame()) {
   )
   invisible(NULL)
 }
+
+#' Pretend a package reports a specific version for the duration of the caller.
+#'
+#' @param pkg *[character]* Package name that `utils::packageVersion` should report
+#'   `version` for. Every other package resolves normally.
+#' @param version *[character]* Version string to report for `pkg`.
+#' @param .local_envir *[environment]* Frame whose exit restores the original
+#'   binding. Defaults to the calling frame.
+#' @return Invisibly `NULL`. Registers a `withr::defer` cleanup.
+local_pretend_package_version <- function(pkg, version, .local_envir = parent.frame()) {
+  ns <- getNamespace("utils")
+  original <- get("packageVersion", envir = ns)
+  unlockBinding("packageVersion", ns)
+  assign(
+    "packageVersion", # nolint: object_name_linter.
+    function(package, ...) {
+      if (identical(package, pkg)) {
+        return(package_version(version))
+      }
+      original(package, ...)
+    },
+    envir = ns
+  )
+  withr::defer(
+    {
+      assign("packageVersion", original, envir = ns) # nolint: object_name_linter.
+      lockBinding("packageVersion", ns)
+    },
+    envir = .local_envir
+  )
+  invisible(NULL)
+}

--- a/tests/testthat/test-calc-maive.R
+++ b/tests/testthat/test-calc-maive.R
@@ -1,11 +1,12 @@
 box::use(
   testthat[
     expect_error,
+    expect_false,
     expect_true,
     skip_if_not_installed,
     test_that
   ],
-  artma / calc / methods / maive[maive]
+  artma / calc / methods / maive[maive, maive_version_ok]
 )
 
 make_maive_data <- function(seed = 9, n = 40) {
@@ -40,4 +41,24 @@ test_that("maive aborts when the MAIVE package is absent", {
   local_pretend_packages_absent("MAIVE")
   expect_error(maive(dat, SE = 1L), regexp = "MAIVE")
   expect_error(maive(dat, SE = 1L), regexp = "install\\.packages")
+})
+
+# maive_version_ok -----------------------------------------------------------
+
+test_that("maive_version_ok accepts versions at or above the floor", {
+  expect_true(maive_version_ok("0.2.4", min_version = "0.2.4"))
+  expect_true(maive_version_ok("0.3.0", min_version = "0.2.4"))
+})
+
+test_that("maive_version_ok rejects versions below the floor", {
+  expect_false(maive_version_ok("0.1.10", min_version = "0.2.4"))
+  expect_false(maive_version_ok("0.2.3", min_version = "0.2.4"))
+})
+
+test_that("maive aborts with an upgrade message when the installed MAIVE version is too old", {
+  skip_if_not_installed("MAIVE")
+  dat <- make_maive_data(n = 20)
+  local_pretend_package_version("MAIVE", "0.1.9")
+  expect_error(maive(dat, SE = 1L), regexp = "or higher is required")
+  expect_error(maive(dat, SE = 1L), regexp = "Upgrade with: install\\.packages")
 })

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -185,6 +185,16 @@ test_that("run_caliper_tests dedupes duplicated thresholds and widths", {
   expect_equal(length(results), 1L)
 })
 
+test_that("run_caliper_tests defaults thresholds to match the options template", {
+  set.seed(103)
+  t_stats <- rnorm(30)
+
+  results <- run_caliper_tests(t_stats, widths = c(0.1), show_progress = FALSE)
+
+  thresholds_seen <- sort(unique(vapply(results, function(x) x$threshold, numeric(1))))
+  expect_equal(thresholds_seen, c(1.645, 1.96, 2.58))
+})
+
 # Elliott wrappers ----------------------------------------------------------
 
 test_that("run_binomial matches the upper-tail binomial p-value", {
@@ -317,6 +327,8 @@ test_that("run_p_hacking_tests runs the Elliott suite when requested", {
   expect_true(is.data.frame(result$elliott))
   expect_true("Binomial [0, 0.05]" %in% result$elliott$Test)
   expect_true("Fisher [0, 0.05]" %in% result$elliott$Test)
+  expect_equal(sum(result$elliott$Test == "Observations in [0, 0.1]"), 1L)
+  expect_false("Observations <= 0.1" %in% result$elliott$Test)
 })
 
 # Skip reasons ---------------------------------------------------------------

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -13,25 +13,33 @@ box::use(
 
 # p_hacking_tests wrapper ---------------------------------------------------
 
-test_that("p_hacking_tests returns the standard contract with a caliper table", {
+# Keep the run fast and dependency-light: caliper only.
+local_caliper_only_options <- function(.local_envir = parent.frame()) {
   local_options(
     artma.verbose = 1,
-    # Keep the run fast and dependency-light: caliper only.
     artma.methods.p_hacking_tests.include_elliott = FALSE,
     artma.methods.p_hacking_tests.include_discontinuity = FALSE,
     artma.methods.p_hacking_tests.include_cox_shi = FALSE,
-    artma.methods.p_hacking_tests.include_maive = FALSE
+    artma.methods.p_hacking_tests.include_maive = FALSE,
+    .local_envir = .local_envir
   )
-  set.seed(1)
-  n <- 60
+}
+
+make_p_hacking_df <- function(seed = 1, n = 60) {
+  set.seed(seed)
   df <- data.frame(
     effect = rnorm(n, 0.3, 0.1),
     se = runif(n, 0.05, 0.3),
     study_id = rep(seq_len(15), length.out = n)
   )
   df$t_stat <- df$effect / df$se
+  df
+}
 
-  result <- p_hacking_tests(df)
+test_that("p_hacking_tests returns the standard contract with a caliper table", {
+  local_caliper_only_options()
+
+  result <- p_hacking_tests(make_p_hacking_df())
 
   expect_true(is.list(result))
   expect_true(is.data.frame(result$tables$caliper))
@@ -42,6 +50,14 @@ test_that("p_hacking_tests aborts when a required column is missing", {
   local_options(artma.verbose = 1)
   # Missing t_stat and study_id.
   expect_error(p_hacking_tests(data.frame(effect = 1:3, se = rep(1, 3))))
+})
+
+test_that("p_hacking_tests prints a significance legend matching significance_mark thresholds", {
+  local_caliper_only_options()
+
+  output <- utils::capture.output(p_hacking_tests(make_p_hacking_df()), type = "message")
+
+  expect_true(any(grepl("Significance marks: \\* p <= 0.1, \\*\\* p <= 0.05, \\*\\*\\* p <= 0.01", output)))
 })
 
 # exogeneity_tests wrapper --------------------------------------------------


### PR DESCRIPTION
Ships the independent quick-win fixes flagged in the 2026-07-21 p-hacking suite review: corrects the printed significance legend to match `significance_mark()`, adds a runtime version floor for MAIVE (with upgrade message), removes a doubled error prefix, fixes stale roxygen defaults, drops two unused parameters, removes a duplicated summary row, aligns the caliper threshold default with the options template, and cleans up a stale comment while attributing `fmincon()` to `pracma`.

Closes #257