### PR TITLE
style(p_hacking): replace <<- accumulator with an environment

### DIFF
--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -292,8 +292,9 @@ format_maive_results <- function(maive_output, options) {
   }
 
   rd <- options$round_to
-  rows <- list()
-  add <- function(stat, val) rows[[length(rows) + 1L]] <<- list(stat = stat, val = val)
+  acc <- new.env(parent = emptyenv())
+  acc$rows <- list()
+  add <- function(stat, val) acc$rows[[length(acc$rows) + 1L]] <- list(stat = stat, val = val)
   sep <- function() add("", "")
 
   # --- Estimates ---
@@ -352,8 +353,8 @@ format_maive_results <- function(maive_output, options) {
   }
 
   # Build data frame
-  stats <- vapply(rows, `[[`, "", "stat")
-  vals <- vapply(rows, `[[`, "", "val")
+  stats <- vapply(acc$rows, `[[`, "", "stat")
+  vals <- vapply(acc$rows, `[[`, "", "val")
 
   data.frame(
     Statistic = stats,


### PR DESCRIPTION
`format_maive_results()` built its row list with a `<<-` super-assignment, which trips `assignment_linter` and blocked the pre-commit hook for anyone staging `inst/artma/econometric/p_hacking.R` (it forced a `--no-verify` commit on #268).

The accumulator now lives in an explicit `new.env(parent = emptyenv())`, so `add()` mutates it with a plain `<-`. Behavior is unchanged: same rows, same order, same resulting data frame.

Verified:
- `LC_ALL=en_US.UTF-8 make lint` no longer reports an `assignment_linter` hit in `p_hacking.R`
- `make test-file FILE=test-econometric-p-hacking.R` passes (45 passing, 0 failures)
- the commit went through without `--no-verify`

The two remaining `assignment_linter` hits in test files (`tests/testthat/modules/testing/fixtures/helper_test_cache.R:14`, `tests/testthat/test-data-prepare-phases.R:55`) are left alone; they don't block this change.