### PR TITLE
style(tests): replace <<- counters with explicit environment assignment

### DIFF
--- a/tests/testthat/modules/testing/fixtures/helper_test_cache.R
+++ b/tests/testthat/modules/testing/fixtures/helper_test_cache.R
@@ -10,14 +10,15 @@ local_cli_silence <- function(env = parent.frame()) {
 # relying on wall-clock sleeps to simulate cost.
 make_fake_modeller <- function() {
   calls <- 0L
+  self_env <- environment()
   modeller <- function(x) {
-    calls <<- calls + 1L
+    self_env$calls <- self_env$calls + 1L
     cli::cli_alert("Running model on {.val {x}}")
     x * 2
   }
   list(
     modeller = modeller,
-    calls = function() calls
+    calls = function() self_env$calls
   )
 }
 

--- a/tests/testthat/test-data-prepare-phases.R
+++ b/tests/testthat/test-data-prepare-phases.R
@@ -51,8 +51,9 @@ local_phase_runner <- function() {
   )
 
   compute_runs <- 0L
+  self_env <- environment()
   counted_compute <- function() {
-    compute_runs <<- compute_runs + 1L
+    self_env$compute_runs <- self_env$compute_runs + 1L
     compute_data_impl()
   }
   compute_cached <- cache_cli_runner(
@@ -71,7 +72,7 @@ local_phase_runner <- function() {
     df
   }
 
-  list(run = run, compute_runs = function() compute_runs)
+  list(run = run, compute_runs = function() self_env$compute_runs)
 }
 
 test_that("warm-cache run repopulates a deleted data config (motivating bug)", {


### PR DESCRIPTION
The last two `assignment_linter` violations in the repo, both call counters in test helpers:

- `tests/testthat/modules/testing/fixtures/helper_test_cache.R:14`
- `tests/testthat/test-data-prepare-phases.R:55`

Each blocked the pre-commit hook for anyone staging those files, the same way `p_hacking.R` did before f11ce82. Both now capture the enclosing frame with `self_env <- environment()` and increment through it, matching the idiom f11ce82 established in `format_maive_results()`. The accessor closures (`calls()`, `compute_runs()`) read through `self_env` too, so they still observe the mutations.

Behavior is unchanged: same counters, same values.

Verified:
- `LC_ALL=en_US.UTF-8 make lint` reports no `assignment_linter` hits repo-wide
- `make test-file FILE=test-libs-cache.R` passes (49 passing) - three of its tests call `make_fake_modeller()` and assert on `calls()`
- `make test-file FILE=test-data-prepare-phases.R` passes (7 passing)
- both commits went through without `--no-verify`