### PR TITLE
perf(stem): replace O(n^2) outer-product submatrix sums with cumsum

### DIFF
--- a/inst/artma/calc/methods/stem.R
+++ b/inst/artma/calc/methods/stem.R
@@ -18,28 +18,14 @@ weighted_mean <- function(beta, se, sigma) {
 #' @param sigma [numeric] Heterogeneity parameter.
 #' @return Numeric vector of weighted second moments.
 weighted_mean_squared <- function(beta, se, sigma) {
-  n <- length(beta)
   weights <- 1 / (se^2 + sigma^2)
-  weight_matrix <- outer(weights, weights)
   weighted_beta <- beta * weights
-  beta_matrix <- outer(weighted_beta, weighted_beta)
-  cumulative_matrix <- compute_submatrix_sums(weight_matrix)
-  cumulative_beta <- compute_submatrix_sums(beta_matrix)
-  numerator <- cumulative_beta - cumsum(weighted_beta^2)
-  denominator <- cumulative_matrix - cumsum(weights^2)
+  # The leading-submatrix sums of outer(x, x) are cumsum(x)^2.
+  numerator <- cumsum(weighted_beta)^2 - cumsum(weighted_beta^2)
+  denominator <- cumsum(weights)^2 - cumsum(weights^2)
   out <- numerator / denominator
   out[1] <- 0
   out
-}
-
-#' Compute cumulative sums for each leading principal submatrix
-#'
-#' @param matrix_input [matrix] Square matrix.
-#' @return Numeric vector with cumulative sums.
-compute_submatrix_sums <- function(matrix_input) {
-  cumulative_cols <- apply(matrix_input, 2, cumsum)
-  cumulative_rows <- t(apply(cumulative_cols, 1, cumsum))
-  diag(cumulative_rows)
 }
 
 #' Variance component for a given number of studies
@@ -239,7 +225,6 @@ data_median <- function(data, id_var, main_var, additional_var) {
 box::export(
   weighted_mean,
   weighted_mean_squared,
-  compute_submatrix_sums,
   variance_0,
   variance_b,
   stem_compute,

--- a/tests/testthat/test-calc-stem.R
+++ b/tests/testthat/test-calc-stem.R
@@ -6,9 +6,9 @@ box::use(
   ],
   artma / calc / methods / stem[
     weighted_mean,
+    weighted_mean_squared,
     variance_b,
     variance_0,
-    compute_submatrix_sums,
     stem
   ]
 )
@@ -52,12 +52,26 @@ test_that("variance_0 matches its closed form with excess dispersion", {
   expect_equal(variance_0(3, beta, se, mean_val), 3)
 })
 
-# compute_submatrix_sums ----------------------------------------------------
+# weighted_mean_squared ------------------------------------------------------
 
-test_that("compute_submatrix_sums returns leading principal block sums", {
-  m <- matrix(1:9, nrow = 3)
-  # top-left 1x1 = 1; 2x2 = 1+2+4+5 = 12; 3x3 = sum(1:9) = 45
-  expect_equal(compute_submatrix_sums(m), c(1, 12, 45))
+test_that("weighted_mean_squared matches the outer-product reference", {
+  set.seed(7)
+  n <- 25
+  se <- runif(n, 0.05, 0.5)
+  beta <- 0.3 + rnorm(n, 0, se)
+  sigma <- 0.1
+
+  weights <- 1 / (se^2 + sigma^2)
+  weighted_beta <- beta * weights
+  submatrix_sums <- function(m) {
+    vapply(seq_len(nrow(m)), function(i) sum(m[1:i, 1:i]), numeric(1))
+  }
+  numerator <- submatrix_sums(outer(weighted_beta, weighted_beta)) - cumsum(weighted_beta^2)
+  denominator <- submatrix_sums(outer(weights, weights)) - cumsum(weights^2)
+  expected <- numerator / denominator
+  expected[1] <- 0
+
+  expect_equal(weighted_mean_squared(beta, se, sigma), expected)
 })
 
 # stem ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`weighted_mean_squared` in `inst/artma/calc/methods/stem.R` built two n x n matrices (`outer(weights, weights)` and `outer(weighted_beta, weighted_beta)`) and reduced them with `compute_submatrix_sums`, which itself ran two full `apply`/`cumsum` passes over the matrix. Since both matrices are rank-1 outer products, the leading-submatrix sums are exactly `cumsum(weights)^2` and `cumsum(weighted_beta)^2`, so the whole thing collapses to O(n).

This code runs inside the `repeat` convergence loop of `stem_converge` and twice per `stem()` call (invoked from `run_stem` in `inst/artma/econometric/nonlinear.R` with all effect observations), so the O(n^2) allocation and reduction cost was paid on every iteration.

## Changes

- `weighted_mean_squared` now computes the cumulative sums directly with `cumsum(...)^2`; no matrices are allocated.
- Removed the now-unused `compute_submatrix_sums` helper and its export.
- Replaced its unit test with a test that checks `weighted_mean_squared` against a brute-force outer-product reference.

## Verification

- Compared old and new `weighted_mean_squared` on random inputs (n = 2, 5, 40, 200; sigma = 0, 0.1, 0.7): max absolute difference ~1e-16 (floating-point noise).
- Full `stem()` output on a 40-study example is identical to a reference implementation using the old code path (all seven estimate columns match to 1e-12).
- `make test-filter FILTER=stem` (13 pass) and `make test-filter FILTER=nonlinear` (23 pass), `make lint` clean for the changed files, styler unchanged.