### PR TITLE
perf(funnel_plot): split rows by study once in aggregate_study_medians

### DIFF
--- a/inst/artma/methods/funnel_plot.R
+++ b/inst/artma/methods/funnel_plot.R
@@ -206,13 +206,14 @@ aggregate_study_medians <- function(df) {
   validate("study_id" %in% names(df))
 
   studies <- unique(df$study_id)
+  study_rows <- unname(split(seq_len(nrow(df)), match(df$study_id, studies)))
 
-  result <- lapply(studies, function(sid) {
-    study_data <- df[df$study_id == sid, , drop = FALSE]
-    median_effect <- stats::median(study_data$effect, na.rm = TRUE)
+  result <- lapply(study_rows, function(rows) {
+    study_effects <- df$effect[rows]
+    median_effect <- stats::median(study_effects, na.rm = TRUE)
 
-    closest_idx <- which.min(abs(study_data$effect - median_effect))
-    median_precision <- study_data$precision[closest_idx]
+    closest_idx <- which.min(abs(study_effects - median_effect))
+    median_precision <- df$precision[rows][closest_idx]
 
     data.frame(
       effect = median_effect,


### PR DESCRIPTION
## Summary

`aggregate_study_medians` in `inst/artma/methods/funnel_plot.R` re-subset the full data frame for every unique study id (`df[df == sid, , drop = FALSE]` inside `lapply`), giving O(n * number_of_studies) behavior. It now computes row-index groups once with `split(seq_len(nrow(df)), match(df$study_id, studies))` and iterates over those groups.

Output is unchanged: `match` against `unique(df$study_id)` preserves first-appearance study ordering, and `unname` keeps the default row names produced by `rbind`. Verified old vs new implementations with `identical()` across 200 randomized data frames (character, numeric, and factor study ids, NA effects, interleaved and single-row studies), including identical error behavior on the pre-existing all-NA-effects edge case.

## Testing

- `make test-filter FILTER=funnel`: 34 passed, 0 failed
- `make lint`: no findings on the changed file
- styled with `styler::style_file()`