### PR TITLE
fix(p_hacking_tests): reliability pass on seeds, guards, skip reasons

### DIFF
--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -18,14 +18,21 @@ simulate_cdfs_block_cpp <- function(eps_block) {
 #' @param workers [integer] Number of workers to use.
 #' @param block_size [integer] Size of the block to process.
 #' @param show_progress [logical] Whether to show progress bar.
+#' @param seed [integer, optional] RNG seed to set before simulating. Leave
+#'   `NULL` to use (and consume) the caller's current RNG state.
 #' @return Numeric vector of simulated suprema.
 simulate_cdfs_parallel <- function(
   iterations = 10000,
   grid_points = 10000,
   workers = NULL,
   block_size = 256L,
-  show_progress = TRUE
+  show_progress = TRUE,
+  seed = NULL
 ) {
+  if (!is.null(seed)) {
+    set.seed(as.integer(seed))
+  }
+
   gp <- as.integer(grid_points)
   it <- as.integer(iterations)
   if (is.null(workers)) {
@@ -62,6 +69,21 @@ simulate_cdfs_parallel <- function(
   }
 
   use_cpp <- isTRUE(getOption("artma.methods.p_hacking_tests.simulate_cdfs.use_cpp", TRUE))
+  if (use_cpp) {
+    use_cpp <- tryCatch(
+      {
+        simulate_cdfs_block_cpp(matrix(0, nrow = 1, ncol = 1))
+        TRUE
+      },
+      error = function(e) {
+        cli::cli_warn(c(
+          "The compiled C++ implementation for CDF simulation is unavailable ({e$message}).",
+          "i" = "Falling back to the pure R implementation."
+        ))
+        FALSE
+      }
+    )
+  }
   if (use_cpp) {
     use_fork <- (.Platform$OS.type != "windows")
     if (!use_fork && workers > 1L) {
@@ -266,14 +288,19 @@ fisher_test <- function(P, p_min, p_max) {
 }
 
 #' Discontinuity test based on rddensity
-run_discontinuity_test <- function(P, c, h) {
-  h_band <- h - 0.001
-  repeat {
-    h_band <- h_band + 0.001
-    res <- rddensity::rddensity(P, c = c, h = h_band)
-    if (!is.na(res$test$p_jk)) {
-      break
-    }
+#' @param P [numeric] P-values to test.
+#' @param c [numeric] Cutoff to test for a discontinuity.
+#' @param h [numeric, optional] Manual bandwidth override. Leave `NULL`
+#'   (the canonical default) to let rddensity select its bandwidth
+#'   automatically.
+run_discontinuity_test <- function(P, c, h = NULL) {
+  res <- if (is.null(h)) {
+    rddensity::rddensity(P, c = c)
+  } else {
+    rddensity::rddensity(P, c = c, h = h)
+  }
+  if (is.na(res$test$p_jk)) {
+    return(skipped_result("rddensity returned no p-value (insufficient mass near the cutoff)"))
   }
   res$test$p_jk
 }

--- a/inst/artma/calc/methods/maive.R
+++ b/inst/artma/calc/methods/maive.R
@@ -13,9 +13,11 @@
 #'   4=Wild cluster boot, 5=Pairs boot.
 #' @param AR *[integer]* Anderson-Rubin CI: 0=no, 1=yes (default).
 #' @param first_stage *[integer]* First stage option (default 0).
+#' @param seed *[integer]* RNG seed for bootstrap SE modes (SE = 2..5), so
+#'   repeated runs on the same data reproduce identical results (default 123).
 #' @return *[list]* MAIVE output with beta, SE, F-test, Hausman test, etc.
 maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2L,
-                  SE = 1L, AR = 0L, first_stage = 0L) {
+                  SE = 1L, AR = 0L, first_stage = 0L, seed = 123L) {
   box::use(
     artma / libs / core / validation[validate, assert]
   )
@@ -25,7 +27,8 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
     is.numeric(method),
     is.numeric(weight),
     is.numeric(instrument),
-    is.numeric(studylevel)
+    is.numeric(studylevel),
+    is.numeric(seed)
   )
 
   # Check if MAIVE package is available
@@ -53,7 +56,8 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
       studylevel = as.integer(studylevel),
       SE = as.integer(SE),
       AR = as.integer(AR),
-      first_stage = as.integer(first_stage)
+      first_stage = as.integer(first_stage),
+      seed = as.integer(seed)
     ),
     error = function(e) {
       cli::cli_abort(c(

--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -26,6 +26,13 @@ box::use(
   artma / calc / methods / maive[maive]
 )
 
+#' @title Extract the skip reason attached to a `skipped_result()` value
+#' @param value *[numeric]* A test result, possibly a `skipped_result()`.
+#' @return *[character or NULL]* The reason, or `NULL` if `value` is not a skip.
+skip_reason <- function(value) {
+  attr(value, "reason")
+}
+
 # Caliper tests (Gerber & Malhotra, 2008) ---------------------------------
 
 #' @title Run single Caliper test
@@ -354,6 +361,28 @@ compute_pvalues <- function(effect, se) {
   2 * stats::pnorm(-abs(t_stats))
 }
 
+#' @title Resolve t-statistics, preferring a user-mapped column
+#' @description
+#' Uses `df$t_stat` where reported, which is more faithful to what the primary
+#' study published (e.g. clustered standard errors the meta-analyst cannot
+#' recompute from `effect`/`se` alone), falling back to `effect / se` for rows
+#' where `t_stat` is absent or `NA`.
+#' @param df *[data.frame]* Input data with effect, se, and optional t_stat columns.
+#' @return *[numeric]* Vector of t-statistics, one per row of `df`.
+resolve_t_stats <- function(df) {
+  validate(is.data.frame(df), is.numeric(df$effect), is.numeric(df$se))
+
+  fallback <- df$effect / df$se
+  if (!"t_stat" %in% colnames(df)) {
+    return(fallback)
+  }
+
+  reported <- suppressWarnings(as.numeric(df$t_stat))
+  missing <- is.na(reported)
+  reported[missing] <- fallback[missing]
+  reported
+}
+
 #' @title Run binomial test wrapper
 #' @param pvalues *[numeric]* P-values to test.
 #' @param p_min *[numeric]* Lower bound of interval.
@@ -373,7 +402,7 @@ run_binomial <- function(pvalues, p_min, p_max, type = "c") {
 
   tryCatch(
     binomial_test(pvalues, p_min, p_max, type),
-    error = function(e) NA_real_
+    error = function(e) skipped_result(e$message)
   )
 }
 
@@ -393,9 +422,13 @@ run_lcm <- function(pvalues, p_min, p_max, cdfs) {
 
   assert(p_min < p_max, "p_min must be less than p_max")
 
+  if (!requireNamespace("fdrtool", quietly = TRUE)) {
+    return(skipped_result("package 'fdrtool' is not installed"))
+  }
+
   tryCatch(
     lcm_test(pvalues, p_min, p_max, norm = 8, cdfs),
-    error = function(e) NA_real_
+    error = function(e) skipped_result(e$message)
   )
 }
 
@@ -415,33 +448,36 @@ run_fisher <- function(pvalues, p_min, p_max) {
 
   tryCatch(
     fisher_test(pvalues, p_min, p_max),
-    error = function(e) NA_real_
+    error = function(e) skipped_result(e$message)
   )
 }
 
 #' @title Run discontinuity test wrapper
 #' @param pvalues *[numeric]* P-values to test.
 #' @param cutoff *[numeric]* Significance threshold to test for discontinuity.
-#' @param bandwidth *[numeric]* Initial bandwidth for test.
+#' @param bandwidth *[numeric, optional]* Manual bandwidth override. Leave
+#'   `NULL` to let rddensity select its bandwidth automatically.
 #' @return *[numeric]* P-value from test.
-run_discontinuity <- function(pvalues, cutoff = 0.05, bandwidth = 0.05) {
+run_discontinuity <- function(pvalues, cutoff = 0.05, bandwidth = NULL) {
   validate(
     is.numeric(pvalues),
-    is.numeric(cutoff),
-    is.numeric(bandwidth)
+    is.numeric(cutoff)
   )
 
   assert(cutoff > 0 && cutoff < 1, "cutoff must be in (0, 1)")
-  assert(bandwidth > 0, "bandwidth must be positive")
+
+  if (!is.null(bandwidth)) {
+    validate(is.numeric(bandwidth))
+    assert(bandwidth > 0, "bandwidth must be positive")
+  }
 
   if (!requireNamespace("rddensity", quietly = TRUE)) {
-    cli::cli_warn("Package 'rddensity' not available - skipping discontinuity test")
-    return(NA_real_)
+    return(skipped_result("package 'rddensity' is not installed"))
   }
 
   tryCatch(
     run_discontinuity_test(pvalues, c = cutoff, h = bandwidth),
-    error = function(e) NA_real_
+    error = function(e) skipped_result(e$message)
   )
 }
 
@@ -487,13 +523,7 @@ run_cox_shi <- function(pvalues, study_id = NULL, p_min, p_max, n_bins = 10L,
     error = function(e) skipped_result(e$message)
   )
 
-  reason <- attr(result, "reason")
-  if (!is.null(reason)) {
-    cli::cli_alert_warning(
-      "Cox-Shi test on [{p_min}, {p_max}] skipped: {reason}."
-    )
-  }
-  as.numeric(result)
+  result
 }
 
 #' @title Run suite of p-hacking tests
@@ -506,24 +536,19 @@ run_cox_shi <- function(pvalues, study_id = NULL, p_min, p_max, n_bins = 10L,
 run_p_hacking_tests <- function(df, options) {
   validate(is.data.frame(df), is.list(options))
 
-  required_cols <- c("effect", "se")
-  missing_cols <- setdiff(required_cols, colnames(df))
-
-  if (length(missing_cols) > 0) {
-    cli::cli_alert_warning("Missing required columns: {.field {missing_cols}}")
-    return(list(
-      caliper = NULL,
-      elliott = NULL,
-      maive = NULL,
-      skipped = list(reason = paste("Missing columns:", paste(missing_cols, collapse = ", ")))
-    ))
-  }
-
   study_id <- if ("study_id" %in% colnames(df)) df$study_id else seq_len(nrow(df))
-  t_stats <- df$effect / df$se
-  pvalues <- compute_pvalues(df$effect, df$se)
+  t_stats <- resolve_t_stats(df)
+  pvalues <- 2 * stats::pnorm(-abs(t_stats))
 
   output <- list()
+  skipped <- list()
+  record_skip <- function(key, value) {
+    reason <- skip_reason(value)
+    if (!is.null(reason)) {
+      skipped[[key]] <<- reason
+    }
+    invisible(NULL)
+  }
 
   # 1. Caliper Tests
   if (options$include_caliper) {
@@ -550,14 +575,16 @@ run_p_hacking_tests <- function(df, options) {
     elliott_tests <- list()
 
     # Pre-simulate CDFs for LCM test
+    cdfs_reason <- NULL
     cdfs <- tryCatch(
       simulate_cdfs_parallel(
         iterations = options$lcm_iterations,
         grid_points = options$lcm_grid_points,
-        block_size = options$simulate_cdfs_chunk_size
+        block_size = options$simulate_cdfs_chunk_size,
+        seed = options$simulate_cdfs_seed
       ),
       error = function(e) {
-        cli::cli_warn("Failed to simulate CDFs for LCM test: {e$message}")
+        cdfs_reason <<- e$message
         numeric(0)
       }
     )
@@ -573,7 +600,8 @@ run_p_hacking_tests <- function(df, options) {
       p_value = run_binomial(pvalues, 0, 0.1, type = "c")
     )
 
-    # LCM tests
+    # LCM tests (always reported, even when the CDF simulation failed, so the
+    # skip reason surfaces instead of the rows silently disappearing)
     if (length(cdfs) > 0) {
       elliott_tests$lcm_005 <- list(
         test = "LCM [0, 0.05]",
@@ -584,6 +612,10 @@ run_p_hacking_tests <- function(df, options) {
         test = "LCM [0, 0.10]",
         p_value = run_lcm(pvalues, 0, 0.1, cdfs)
       )
+    } else {
+      lcm_skip <- skipped_result(cdfs_reason %||% "CDF simulation returned no draws")
+      elliott_tests$lcm_005 <- list(test = "LCM [0, 0.05]", p_value = lcm_skip)
+      elliott_tests$lcm_01 <- list(test = "LCM [0, 0.10]", p_value = lcm_skip)
     }
 
     # Fisher tests
@@ -628,6 +660,10 @@ run_p_hacking_tests <- function(df, options) {
       )
     }
 
+    for (key in names(elliott_tests)) {
+      record_skip(key, elliott_tests[[key]]$p_value)
+    }
+
     output$elliott <- build_elliott_summary(elliott_tests, pvalues, options)
   }
 
@@ -650,23 +686,28 @@ run_p_hacking_tests <- function(df, options) {
             studylevel = options$maive_studylevel,
             SE = options$maive_se,
             AR = options$maive_ar,
-            first_stage = options$maive_first_stage
+            first_stage = options$maive_first_stage,
+            seed = options$maive_seed
           )
         },
         error = function(e) {
-          cli::cli_warn("MAIVE estimation failed: {e$message}")
+          skipped[["maive"]] <<- paste("MAIVE estimation failed:", e$message)
           NULL
         }
       )
-      output$maive <- tryCatch(
-        format_maive_results(maive_results, options),
-        error = function(e) {
-          cli::cli_warn("MAIVE result formatting failed: {e$message}")
-          NULL
-        }
-      )
+      output$maive <- if (is.null(maive_results)) {
+        NULL
+      } else {
+        tryCatch(
+          format_maive_results(maive_results, options),
+          error = function(e) {
+            skipped[["maive"]] <<- paste("MAIVE result formatting failed:", e$message)
+            NULL
+          }
+        )
+      }
     } else {
-      cli::cli_warn("MAIVE requires 'n_obs' column - skipping MAIVE test")
+      skipped[["maive"]] <- "requires the 'n_obs' column, which is absent from the data"
       output$maive <- NULL
     }
   }
@@ -675,6 +716,7 @@ run_p_hacking_tests <- function(df, options) {
   output$n_significant_005 <- sum(pvalues <= 0.05, na.rm = TRUE)
   output$n_significant_010 <- sum(pvalues <= 0.10, na.rm = TRUE)
   output$options <- options
+  output$skipped <- if (length(skipped) > 0) skipped else NULL
 
   output
 }
@@ -725,9 +767,12 @@ box::export(
   run_p_hacking_tests,
   run_single_caliper,
   compute_pvalues,
+  resolve_t_stats,
   prepare_maive_data,
   maive_p_from_coef,
   run_binomial,
+  run_lcm,
+  run_discontinuity,
   run_cox_shi,
   run_fisher
 )

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -31,8 +31,15 @@ p_hacking_tests <- function(df) {
   lcm_iterations <- opt$lcm_iterations %||% 3000L
   lcm_grid_points <- opt$lcm_grid_points %||% 3000L
   simulate_cdfs_chunk_size <- opt[["simulate_cdfs.chunk_size"]] %||% 512L
+  simulate_cdfs_seed <- opt[["simulate_cdfs.seed"]] %||% 123L
+  if (length(simulate_cdfs_seed) == 1 && is.na(simulate_cdfs_seed)) {
+    simulate_cdfs_seed <- NULL
+  }
   include_discontinuity <- opt$include_discontinuity %||% TRUE
-  discontinuity_bandwidth <- opt$discontinuity_bandwidth %||% 0.05
+  discontinuity_bandwidth <- opt$discontinuity_bandwidth
+  if (length(discontinuity_bandwidth) == 1 && is.na(discontinuity_bandwidth)) {
+    discontinuity_bandwidth <- NULL
+  }
   include_cox_shi <- opt$include_cox_shi %||% TRUE
   cox_shi_bins <- opt$cox_shi_bins %||% 10L
   cox_shi_order <- opt$cox_shi_order %||% 2L
@@ -47,6 +54,7 @@ p_hacking_tests <- function(df) {
   maive_se <- opt$maive_se %||% 1L
   maive_ar <- opt$maive_ar %||% 0L
   maive_first_stage <- opt$maive_first_stage %||% 0L
+  maive_seed <- opt$maive_seed %||% 123L
 
   # General options
   add_significance_marks <- resolve_add_significance_marks()
@@ -61,8 +69,9 @@ p_hacking_tests <- function(df) {
     is.numeric(lcm_iterations),
     is.numeric(lcm_grid_points),
     is.numeric(simulate_cdfs_chunk_size),
+    is.null(simulate_cdfs_seed) || is.numeric(simulate_cdfs_seed),
     is.logical(include_discontinuity),
-    is.numeric(discontinuity_bandwidth),
+    is.null(discontinuity_bandwidth) || is.numeric(discontinuity_bandwidth),
     is.logical(include_cox_shi),
     is.numeric(cox_shi_bins),
     is.numeric(cox_shi_order),
@@ -75,6 +84,7 @@ p_hacking_tests <- function(df) {
     is.numeric(maive_se),
     is.numeric(maive_ar),
     is.numeric(maive_first_stage),
+    is.numeric(maive_seed),
     is.logical(add_significance_marks),
     is.numeric(round_to)
   )
@@ -84,7 +94,10 @@ p_hacking_tests <- function(df) {
   assert(lcm_iterations > 0, "lcm_iterations must be positive")
   assert(lcm_grid_points > 0, "lcm_grid_points must be positive")
   assert(simulate_cdfs_chunk_size > 0, "simulate_cdfs.chunk_size must be positive")
-  assert(discontinuity_bandwidth > 0, "discontinuity_bandwidth must be positive")
+  assert(
+    is.null(discontinuity_bandwidth) || discontinuity_bandwidth > 0,
+    "discontinuity_bandwidth must be positive"
+  )
   assert(cox_shi_bins > 0, "cox_shi_bins must be positive")
   assert(cox_shi_order >= 0, "cox_shi_order must be non-negative")
   assert(cox_shi_bounds %in% c(0, 1), "cox_shi_bounds must be 0 or 1")
@@ -105,6 +118,7 @@ p_hacking_tests <- function(df) {
     lcm_iterations = as.integer(lcm_iterations),
     lcm_grid_points = as.integer(lcm_grid_points),
     simulate_cdfs_chunk_size = as.integer(simulate_cdfs_chunk_size),
+    simulate_cdfs_seed = if (is.null(simulate_cdfs_seed)) NULL else as.integer(simulate_cdfs_seed),
     include_discontinuity = include_discontinuity,
     discontinuity_bandwidth = discontinuity_bandwidth,
     include_cox_shi = include_cox_shi,
@@ -119,6 +133,7 @@ p_hacking_tests <- function(df) {
     maive_se = as.integer(maive_se),
     maive_ar = as.integer(maive_ar),
     maive_first_stage = as.integer(maive_first_stage),
+    maive_seed = as.integer(maive_seed),
     add_significance_marks = add_significance_marks,
     round_to = round_to
   )
@@ -173,8 +188,8 @@ p_hacking_tests <- function(df) {
     }
 
     if (!is.null(results$skipped) && verbosity >= 2) {
-      for (msg in results$skipped) {
-        cli::cli_alert_warning("Skipped: {msg}")
+      for (key in names(results$skipped)) {
+        cli::cli_alert_warning("Skipped {key}: {results$skipped[[key]]}")
       }
     }
   }

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -632,6 +632,16 @@ methods:
           during LCM critical-value simulation. Larger chunks reduce overhead
           but make the progress bar less responsive.
 
+      seed:
+        type: "integer"
+        allow_na: true
+        default: 123
+        help: |
+          RNG seed for the Brownian bridge simulations behind the LCM test's
+          critical values. Fixed by default so repeated runs on the same data
+          reproduce identical LCM p-values. Leave unset (`NA`) to use
+          whatever RNG state the caller is in instead.
+
     lcm_iterations:
       type: "integer"
       default: 3000
@@ -655,10 +665,12 @@ methods:
 
     discontinuity_bandwidth:
       type: "numeric"
-      default: 0.05
+      allow_na: true
+      default: .na
       help: |
-        Initial bandwidth for the discontinuity test.
-        The algorithm will adaptively adjust if needed.
+        Manual bandwidth override for the discontinuity test. Leave unset to
+        let {.pkg rddensity} select its bandwidth automatically, matching the
+        canonical Elliott et al. implementation.
 
     include_cox_shi:
       type: "logical"
@@ -756,6 +768,14 @@ methods:
       default: 0
       help: |
         MAIVE first stage option (default: 0).
+
+    maive_seed:
+      type: "integer"
+      default: 123
+      help: |
+        RNG seed passed to MAIVE's bootstrap standard error modes
+        (maive_se = 2..5), so repeated runs on the same data reproduce
+        identical results.
 
 data:
   source_path:

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -5,21 +5,25 @@ box::use(
     expect_false,
     expect_match,
     expect_true,
+    skip_if_not_installed,
     test_that
   ],
   withr[local_options],
   artma / econometric / p_hacking[
     compute_pvalues,
+    resolve_t_stats,
     maive_p_from_coef,
     prepare_maive_data,
     run_single_caliper,
     run_binomial,
+    run_lcm,
+    run_discontinuity,
     run_cox_shi,
     run_fisher,
     run_caliper_tests,
     run_p_hacking_tests
   ],
-  artma / calc / methods / elliott[cox_shi_test]
+  artma / calc / methods / elliott[cox_shi_test, simulate_cdfs_parallel]
 )
 
 # compute_pvalues -----------------------------------------------------------
@@ -40,6 +44,19 @@ test_that("compute_pvalues returns two-sided normal p-values", {
 
 test_that("compute_pvalues errors on mismatched lengths", {
   expect_error(compute_pvalues(c(1, 2), c(1)))
+})
+
+# resolve_t_stats -------------------------------------------------------------
+
+test_that("resolve_t_stats falls back to effect / se when t_stat is absent", {
+  df <- data.frame(effect = c(1, 2), se = c(1, 2))
+  expect_equal(resolve_t_stats(df), c(1, 1))
+})
+
+test_that("resolve_t_stats prefers a reported t_stat over effect / se", {
+  df <- data.frame(effect = c(1, 2), se = c(1, 1), t_stat = c(5, NA))
+  # Row 1 uses the reported 5 (not effect/se = 1); row 2 falls back to 2/1 = 2.
+  expect_equal(resolve_t_stats(df), c(5, 2))
 })
 
 # maive_p_from_coef ---------------------------------------------------------
@@ -214,6 +231,7 @@ base_p_hacking_options <- function(...) {
     lcm_iterations = 50L,
     lcm_grid_points = 50L,
     simulate_cdfs_chunk_size = 512L,
+    simulate_cdfs_seed = 123L,
     include_discontinuity = FALSE,
     discontinuity_bandwidth = 0.05,
     include_cox_shi = FALSE,
@@ -228,6 +246,7 @@ base_p_hacking_options <- function(...) {
     maive_se = 1L,
     maive_ar = 0L,
     maive_first_stage = 0L,
+    maive_seed = 123L,
     add_significance_marks = TRUE,
     round_to = 3L
   )
@@ -282,16 +301,6 @@ test_that("run_p_hacking_tests dedupes duplicated caliper thresholds/widths with
   expect_equal(ncol(result$caliper), 2L)
 })
 
-test_that("run_p_hacking_tests skips gracefully when required columns are missing", {
-  local_options(artma.verbose = 1)
-  df <- data.frame(effect = c(0.1, 0.2, 0.3))
-
-  result <- run_p_hacking_tests(df, base_p_hacking_options())
-
-  expect_true(!is.null(result$skipped))
-  expect_true(grepl("se", result$skipped$reason))
-})
-
 test_that("run_p_hacking_tests runs the Elliott suite when requested", {
   local_options(
     artma.verbose = 1,
@@ -308,6 +317,131 @@ test_that("run_p_hacking_tests runs the Elliott suite when requested", {
   expect_true(is.data.frame(result$elliott))
   expect_true("Binomial [0, 0.05]" %in% result$elliott$Test)
   expect_true("Fisher [0, 0.05]" %in% result$elliott$Test)
+})
+
+# Skip reasons ---------------------------------------------------------------
+
+test_that("run_p_hacking_tests records a skip reason when the CDF simulation yields no draws", {
+  local_options(artma.verbose = 1)
+  df <- make_p_hacking_df()
+
+  result <- run_p_hacking_tests(
+    df,
+    base_p_hacking_options(
+      include_caliper = FALSE,
+      include_elliott = TRUE,
+      lcm_iterations = 0L
+    )
+  )
+
+  expect_true(!is.null(result$skipped$lcm_005))
+  expect_true(!is.null(result$skipped$lcm_01))
+  # The row is still reported (not silently absent), just as NA.
+  lcm_rows <- result$elliott[grepl("^LCM", result$elliott$Test), ]
+  expect_equal(nrow(lcm_rows), 2L)
+})
+
+test_that("run_p_hacking_tests records a skip reason for a singular Cox-Shi covariance", {
+  local_options(artma.verbose = 1)
+  set.seed(404, kind = "Mersenne-Twister", normal.kind = "Inversion")
+  t_stats <- abs(stats::rnorm(300, mean = 1, sd = 1))
+  df <- data.frame(effect = t_stats, se = rep(1, length(t_stats)))
+
+  result <- run_p_hacking_tests(
+    df,
+    base_p_hacking_options(
+      include_caliper = FALSE,
+      include_elliott = TRUE,
+      include_cox_shi = TRUE,
+      cox_shi_bins = 20L
+    )
+  )
+
+  expect_match(result$skipped$cox_shi_005, "singular")
+})
+
+test_that("run_p_hacking_tests records a skip reason when MAIVE lacks n_obs", {
+  local_options(artma.verbose = 1)
+  df <- make_p_hacking_df()
+  df$n_obs <- NULL
+
+  result <- run_p_hacking_tests(
+    df,
+    base_p_hacking_options(include_caliper = FALSE, include_maive = TRUE)
+  )
+
+  expect_match(result$skipped$maive, "n_obs")
+  expect_true(is.null(result$maive))
+})
+
+test_that("run_lcm skips with a reason instead of failing silently", {
+  local_pretend_packages_absent("fdrtool")
+
+  result <- run_lcm(c(0.01, 0.02, 0.03), 0, 0.05, cdfs = c(0.1, 0.2, 0.3))
+
+  expect_true(is.na(result))
+  expect_match(attr(result, "reason"), "fdrtool")
+})
+
+# LCM / MAIVE reproducibility --------------------------------------------
+
+test_that("simulate_cdfs_parallel is reproducible when seed is passed explicitly", {
+  res_a <- simulate_cdfs_parallel(iterations = 20, grid_points = 30, seed = 123, show_progress = FALSE)
+  res_b <- simulate_cdfs_parallel(iterations = 20, grid_points = 30, seed = 123, show_progress = FALSE)
+
+  expect_equal(res_a, res_b)
+})
+
+test_that("run_p_hacking_tests produces identical LCM p-values across two runs", {
+  local_options(artma.verbose = 1)
+  df <- make_p_hacking_df()
+  opts <- base_p_hacking_options(
+    include_caliper = FALSE,
+    include_elliott = TRUE,
+    lcm_iterations = 200L,
+    lcm_grid_points = 200L
+  )
+
+  result_a <- run_p_hacking_tests(df, opts)
+  result_b <- run_p_hacking_tests(df, opts)
+
+  lcm_a <- result_a$elliott[grepl("^LCM", result_a$elliott$Test), "P-value"]
+  lcm_b <- result_b$elliott[grepl("^LCM", result_b$elliott$Test), "P-value"]
+  expect_equal(lcm_a, lcm_b)
+})
+
+test_that("run_p_hacking_tests produces identical MAIVE bootstrap results across two runs", {
+  skip_if_not_installed("MAIVE")
+  local_options(artma.verbose = 1)
+  df <- make_p_hacking_df()
+  opts <- base_p_hacking_options(
+    include_caliper = FALSE,
+    include_maive = TRUE,
+    maive_se = 3L # Wild bootstrap: irreproducible without a threaded seed.
+  )
+
+  result_a <- run_p_hacking_tests(df, opts)
+  result_b <- run_p_hacking_tests(df, opts)
+
+  expect_equal(result_a$maive, result_b$maive)
+})
+
+# Discontinuity alignment -----------------------------------------------------
+
+test_that("run_discontinuity uses automatic bandwidth and never errors uncaught", {
+  local_options(artma.verbose = 1)
+  # Sparse, mass-near-cutoff p-values that used to trip the manual retry loop.
+  set.seed(40)
+  pvalues <- stats::runif(40)
+
+  result <- run_discontinuity(pvalues, cutoff = 0.05)
+
+  expect_true(is.numeric(result))
+  ok <- is.na(result) || (is.finite(result) && result >= 0 && result <= 1)
+  expect_true(ok)
+  if (is.na(result)) {
+    expect_true(!is.null(attr(result, "reason")))
+  }
 })
 
 # Cox-Shi ------------------------------------------------------------------
@@ -391,16 +525,14 @@ test_that("cox_shi_test skips with a reason when the covariance is singular", {
   expect_match(attr(result, "reason"), "singular")
 })
 
-test_that("run_cox_shi turns a skip reason into a warning and a plain NA", {
+test_that("run_cox_shi preserves the skip reason for the caller to record", {
   set.seed(404, kind = "Mersenne-Twister", normal.kind = "Inversion")
   pvalues <- 2 * (1 - stats::pnorm(abs(stats::rnorm(300, mean = 1, sd = 1))))
 
-  result <- suppressMessages(
-    run_cox_shi(pvalues, seq_along(pvalues), 0, 0.05, n_bins = 20L)
-  )
+  result <- run_cox_shi(pvalues, seq_along(pvalues), 0, 0.05, n_bins = 20L)
 
   expect_true(is.na(result))
-  expect_true(is.null(attr(result, "reason")))
+  expect_match(attr(result, "reason"), "singular")
 })
 
 test_that("run_p_hacking_tests reports numeric Cox-Shi rows on clustered data", {


### PR DESCRIPTION
## Summary

Reliability pass over p_hacking_tests from the 2026-07-21 review, following the merged Cox-Shi rewrite (#258) and caliper respecification (#259):

- Seed the LCM Brownian-bridge simulation (`simulate_cdfs.seed`, default 123) and thread a seed through MAIVE's bootstrap SE modes (`maive_seed`, default 123), so two runs on the same data reproduce identical numbers.
- Implement the automatic C++-to-R fallback for `simulate_cdfs_parallel()` that the `use_cpp` option help text already promised.
- Guard the `fdrtool` dependency in `run_lcm()`, mirroring the existing `rddensity` guard.
- Align the discontinuity test with the canonical Elliott et al. implementation: drop the unbounded bandwidth retry loop in favor of rddensity's automatic bandwidth selection, with an explicit skip on failure.
- Route every skip reason (LCM, Cox-Shi, discontinuity, MAIVE) into `meta$skipped`, printed as footnotes instead of bare NA rows; remove the dead missing-columns branch in `run_p_hacking_tests()` already covered by the method wrapper's `validate_columns`.
- Use a user-mapped `t_stat` per row when present (falling back to `effect / se`), which is more faithful to what primary studies reported.

Closes #260

## Test plan
- [x] `make lint` on touched files
- [x] `make test-file FILE=test-econometric-p-hacking.R` (80 pass)
- [x] `make test-file FILE=test-elliott-simulate-cdfs.R`, `test-calc-maive.R`, `test-output-export.R`, `test-methods-p-hacking-exogeneity.R`
- [x] Full `make test` (1584 pass)