### PR TITLE
chore(lint): enable box.linters box_usage_linter

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -4,19 +4,26 @@ custom_linters_env <- new.env()
 
 # Locate the repository root without the here package, which is not a
 # package dependency and may not be installed in the linting session.
+repo_root <- local({
+  path <- getwd()
+  while (!file.exists(file.path(path, "DESCRIPTION")) && dirname(path) != path) {
+    path <- dirname(path)
+  }
+  path
+})
+
 # The custom linters live under scripts/ so that the installed package does
 # not carry lintr as a runtime dependency.
 source(
-  local({
-    path <- getwd()
-    while (!file.exists(file.path(path, "DESCRIPTION")) && dirname(path) != path) {
-      path <- dirname(path)
-    }
-    file.path(path, "scripts", "linters.R")
-  }),
+  file.path(repo_root, "scripts", "linters.R"),
   local = custom_linters_env,
   chdir = TRUE
 )
+
+# Resolve box modules against the checkout being linted, overriding any
+# box.path inherited from .Rprofile that may point at a different checkout
+# (e.g. when linting inside a worktree). Required by box_usage_linter.
+options(box.path = file.path(repo_root, "inst"))
 
 linters <- c(
   lintr::linters_with_defaults(
@@ -65,18 +72,25 @@ linters <- c(
   # Disable the usage of 'dir.create' in favor of 'fs::dir_create'
   dir_create_linter = custom_linters_env$dir_create_linter(),
   # Flag literal '<U+XXXX>' escape text left behind by C-locale rewrites
-  unicode_escape_linter = custom_linters_env$unicode_escape_linter()
+  unicode_escape_linter = custom_linters_env$unicode_escape_linter(),
+  # Flag calls to functions neither defined in the file nor imported via
+  # box::use(); replaces object_usage_linter for the box module system
+  box_usage_linter = box.linters::box_usage_linter()
 )
 
 exclusions <- list(
   "local/",
   "scripts/",
-  ".githooks/"
+  ".githooks/",
+  # Test files import packages and modules in a single box::use() call, a
+  # style box_usage_linter cannot parse (it drops the package attachments and
+  # flags every use). Missing imports in tests fail at runtime anyway.
+  "tests/" = list(box_usage_linter = Inf)
 )
 
-# Clean up imported linters
+# Clean up helper objects so lintr does not report them as unused settings
 rm(list = ls(custom_linters_env), envir = custom_linters_env)
-rm(custom_linters_env)
+rm(custom_linters_env, repo_root)
 gc() # Clean up memory
 
 # nolint end.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,7 @@ VignetteBuilder:
 Config/Needs/coverage: covr, xml2
 Config/Needs/dev: box.linters, devtools, languageserver, remotes
 Config/Needs/e2e: remotes
-Config/Needs/lint: devtools, remotes
+Config/Needs/lint: box.linters, devtools, remotes
 Config/Needs/release: devtools, optparse, pkgbuild, remotes
 Config/Needs/website: pkgdown
 Config/testthat/edition: 3

--- a/R/artma.R
+++ b/R/artma.R
@@ -142,12 +142,10 @@ artma <- function(
       # User provided data directly - still need to preprocess and compute.
       # Mirror prepare_data's phases: decide the NA strategy (configure), run
       # the pure preprocess + compute, then persist the computed columns.
-      # nolint start: object_usage_linter.
       box::use(
         artma / data / preprocess[clean_data, preprocess_data, resolve_na_handling],
         artma / data / compute[compute_optional_columns, update_config_with_computed_columns]
       )
-      # nolint end
 
       if (get_verbosity() >= 3) {
         cli::cli_inform("Using provided data frame (skipping file read step).")
@@ -169,7 +167,7 @@ artma <- function(
 
     if (isTRUE(save_results) && isTRUE(open_results) && interactive()) {
       tryCatch(
-        results.open(),
+        results.open(), # nolint: box_usage_linter. # Package function from R/results.R
         error = function(e) {
           if (get_verbosity() >= 2) {
             cli::cli_alert_warning(
@@ -310,9 +308,7 @@ invoke_runtime_methods <- function(methods, df, modules_dir = NULL, ...) {
     invalid_methods <- setdiff(deduped_methods, supported_methods)
 
     if (length(invalid_methods) > 0L) {
-      # nolint start: object_usage_linter.
       selected_methods <- paste(as.character(invalid_methods), collapse = ", ")
-      # nolint end
       cli::cli_abort(c(
         "x" = "Invalid runtime methods selected: {.val {selected_methods}}",
         "i" = "To see a list of available methods, run {.code artma::methods.list()}"

--- a/inst/artma/econometric/bma.R
+++ b/inst/artma/econometric/bma.R
@@ -471,14 +471,14 @@ extract_bma_results <- function(bma_model, bma_data, input_var_list, print_resul
 
     main_plot_call <- bquote(
       graphics::image(bma_model,
-        col = .(color_spectrum), yprop2pip = FALSE, order.by.pip = TRUE,
+        col = .(color_spectrum), yprop2pip = FALSE, order.by.pip = TRUE, # nolint: box_usage_linter. # bquote substitution
         do.par = TRUE, do.grid = TRUE, do.axis = TRUE, xlab = "", main = ""
       )
     )
 
     dist_color_spectrum <- color_spectrum[color_spectrum != "white"]
     bma_dist_call <- bquote(
-      base::plot(bma_model, col = .(dist_color_spectrum))
+      base::plot(bma_model, col = .(dist_color_spectrum)) # nolint: box_usage_linter. # bquote substitution
     )
 
     has_corrplot <- requireNamespace("corrplot", quietly = TRUE)


### PR DESCRIPTION
## Summary

Wires `box.linters::box_usage_linter` into `.lintr.R`. It fills the gap left by disabling `object_usage_linter` for the box module system: calls to functions neither defined in the file nor imported via `box::use()` are now caught at lint time instead of at runtime. This matters most for interactive and error paths that tests rarely execute, since R CMD check cannot see `inst/artma/` at all.

- `.lintr.R` now sets `box.path` from the repository root, so modules resolve against the checkout being linted (correct inside worktrees regardless of what `.Rprofile` sets). Adds about 5 seconds to a full lint.
- `tests/` is excluded from the new linter only. Test files import packages and modules in a single `box::use()` call, a style box.linters cannot parse (it drops the package attachments and flags every use). Missing imports in tests fail at runtime anyway.
- Annotates the three known false positives: two `bquote()` `.()` substitutions in `inst/artma/econometric/bma.R` and one cross-file package function call in `R/artma.R`. The twelve existing `# nolint: box_usage_linter.` comments now refer to an active linter, which removes the "Could not find linter named box_usage_linter" warnings from lint runs.
- Removes two stale `# nolint: object_usage_linter.` blocks in `R/artma.R`; that linter is disabled globally, so the comments only produced the same class of warning.
- Adds box.linters to `Config/Needs/lint` so the CI lint workflow installs it.

## Verification

- `make lint`: zero warnings and no box_usage_linter findings. The only findings are 10 indentation_linter lints that reproduce on master with the unmodified config (tracked separately).
- Probe check: a temporary file in `inst/artma/` calling an unimported function is flagged through the project config.
- `make test`: 1570 passed, 0 failed.