### PR TITLE
style: single-indent multiline function defs per lintr 3.4 tidyverse style

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -9,9 +9,10 @@
 #' @param options_dir *\[character, optional\]* Path to the directory that contains user options. Defaults to the directory specified in PATHS.
 #' @keywords internal
 runtime_setup <- function(
-    FUN,
-    options_file_name = NULL,
-    options_dir = NULL) {
+  FUN,
+  options_file_name = NULL,
+  options_dir = NULL
+) {
   if (is.null(options_file_name) && !interactive()) {
     if (getOption("artma.verbose", 3) >= 2) {
       cli::cli_alert_warning("Running in non-interactive mode without providing an options file name. Please provide an options file name or run in interactive mode.")

--- a/R/data_config.R
+++ b/R/data_config.R
@@ -95,7 +95,9 @@ config.overrides <- function(options_file_name = NULL, options_dir = NULL) {
     options_dir = options_dir,
     FUN = function() {
       overrides <- getOption("artma.data.columns", list())
-      if (!is.list(overrides)) return(list())
+      if (!is.list(overrides)) {
+        return(list())
+      }
       overrides
     }
   )

--- a/R/data_preview.R
+++ b/R/data_preview.R
@@ -65,10 +65,11 @@
 #'
 #' @export
 data.preview <- function(
-    data = NULL,
-    options = NULL,
-    options_dir = NULL,
-    preprocess = TRUE) {
+  data = NULL,
+  options = NULL,
+  options_dir = NULL,
+  preprocess = TRUE
+) {
   box::use(
     artma / data / read[read_data],
     artma / data / index[prepare_data],

--- a/inst/artma/data/interactive_mapping.R
+++ b/inst/artma/data/interactive_mapping.R
@@ -27,10 +27,11 @@ format_mapping_display <- function(mapping, required_cols, all_std_cols = NULL) 
 #' @param all_std_cols *\[character\]* All standard column names
 #' @return *\[character\]* User's choice: "accept", "modify", or "skip_optional"
 present_detected_mapping <- function(
-    auto_mapping,
-    df,
-    required_cols,
-    all_std_cols = NULL) {
+  auto_mapping,
+  df,
+  required_cols,
+  all_std_cols = NULL
+) {
   box::use(artma / libs / core / utils[get_verbosity])
 
   if (length(auto_mapping) == 0) {
@@ -518,11 +519,12 @@ save_column_mapping_to_options <- function(mapping, options_file_name = NULL) {
 #' @param force_interactive *\[logical\]* Force interactive mapping even if all columns recognized
 #' @return *\[list\]* Final column mapping
 column_mapping_workflow <- function(
-    df,
-    auto_mapping = NULL,
-    options_file_name = NULL,
-    min_confidence = 0.7,
-    force_interactive = FALSE) {
+  df,
+  auto_mapping = NULL,
+  options_file_name = NULL,
+  min_confidence = 0.7,
+  force_interactive = FALSE
+) {
   box::use(
     artma / data / column_recognition[
       recognize_columns,

--- a/inst/artma/data_config/read.R
+++ b/inst/artma/data_config/read.R
@@ -8,8 +8,9 @@
 #'   invalid. Defaults to `FALSE`.
 #' @return *\[list\]* The fully-resolved data config.
 get_data_config <- function(
-    create_if_missing = TRUE,
-    fix_if_invalid = FALSE) {
+  create_if_missing = TRUE,
+  fix_if_invalid = FALSE
+) {
   box::use(
     artma / libs / core / validation[validate],
     artma / libs / core / utils[get_verbosity],

--- a/inst/artma/data_config/utils.R
+++ b/inst/artma/data_config/utils.R
@@ -3,7 +3,8 @@
 #' @param config *\[list, optional\]* The data config to check. If `NULL` (default), the data config will be retrieved from the options.
 #' @return *\[logical\]* Whether the data config is valid.
 data_config_is_valid <- function(
-    config = NULL) {
+  config = NULL
+) {
   config <- if (is.null(config)) getOption("artma.data.columns", NULL) else config
   # There is potentially room for more checks here
   is.list(config)

--- a/inst/artma/data_config/write.R
+++ b/inst/artma/data_config/write.R
@@ -138,7 +138,8 @@ update_data_config <- function(changes) {
 #'   it does not exist. Defaults to `TRUE`.
 #' @return *\[list\]* The fixed data config.
 fix_data_config <- function(
-    create_if_missing = TRUE) {
+  create_if_missing = TRUE
+) {
   box::use(
     artma / libs / core / utils[get_verbosity],
     artma / data / utils[get_colnames_map],

--- a/inst/artma/options/ask.R
+++ b/inst/artma/options/ask.R
@@ -44,9 +44,10 @@ ask_for_options_file_name <- function(should_clean = TRUE, prompt = NULL) {
 #' @param multiple *\[logical, optional\]* Whether to allow the selction of multiple values. Defaults to FALSE.
 #' `character` Name of the selected file.
 ask_for_existing_options_file_name <- function(
-    options_dir = NULL,
-    prompt = NULL,
-    multiple = FALSE) {
+  options_dir = NULL,
+  prompt = NULL,
+  multiple = FALSE
+) {
   if (!interactive()) {
     cli::cli_abort("You must provide the options file name explicitly in non-interactive R sessions.")
   }
@@ -93,10 +94,11 @@ ask_for_existing_options_file_name <- function(
 #' @param max_retries *\[integer, optional\]* The maximum number of retries to ask for the option value. Defaults to 3.
 #' `any` The value of the option.
 ask_for_option_value <- function(
-    option_name,
-    option_type = NULL,
-    allow_na = FALSE,
-    max_retries = 3) {
+  option_name,
+  option_type = NULL,
+  allow_na = FALSE,
+  max_retries = 3
+) {
   box::use(
     artma / const[CONST],
     artma / options / utils[validate_option_value],

--- a/inst/artma/variable/bma.R
+++ b/inst/artma/variable/bma.R
@@ -286,12 +286,13 @@ remove_dummy_trap_variables <- function(df, var_names, priority_vars = character
 #' @param priority_vars *\[character, optional\]* Additional priority variables
 #' @return *\[data.frame\]* Suggested variables with metadata
 suggest_variables_for_bma <- function(
-    df,
-    config = NULL,
-    min_obs_per_split = 5,
-    min_variance_ratio = 0.01,
-    exclude_reference = TRUE,
-    priority_vars = NULL) {
+  df,
+  config = NULL,
+  min_obs_per_split = 5,
+  min_variance_ratio = 0.01,
+  exclude_reference = TRUE,
+  priority_vars = NULL
+) {
   box::use(
     artma / libs / core / validation[validate],
     artma / variable / suggestion[suggest_variables_for_effect_summary],

--- a/tests/testthat/modules/testing/mocks/mock_options.R
+++ b/tests/testthat/modules/testing/mocks/mock_options.R
@@ -3,7 +3,8 @@
 #' @param colnames *\[list, optional\]* A list of colnames to mock.
 #' @return *\[list\]* A list of mock colnames.
 create_mock_options_colnames <- function(
-    colnames = NULL) {
+  colnames = NULL
+) {
   box::use(artma / data / utils[get_standardized_colnames])
 
   colnames <- if (is.null(colnames)) list() else colnames


### PR DESCRIPTION
## Why

`make lint` reports 10 pre-existing `indentation_linter` lints ("Indentation should be 2 spaces but is 4 spaces"), all on function signature continuation lines. They come from the lintr 3.4.0 upgrade, not from any repo change: lintr 3.4.0 enforces the updated tidyverse style guide for multi-line function definitions (r-lib/lintr#2830), which drops the double-indented form in favor of single-indented formals with `) {` on its own line.

styler moved in lockstep: 1.11.0 adapts to the same single-indent semantics (r-lib/styler#1235) and rewrites the old form to the new one. The tools only appeared to disagree because `styler::style_pkg()` does not style `inst/`, where 8 of the 10 flagged signatures live; those files are only styled by the pre-commit hook when they change.

## What

Restyled with styler 1.11.0; no lint config changes needed since the two tools already agree:

- `styler::style_pkg()` output for `R/` and `tests/`: the flagged signatures in `R/aaa.R` and `R/data_preview.R`, one more in `tests/testthat/modules/testing/mocks/mock_options.R`, plus one guard `if` in `R/data_config.R` that styler now braces.
- `styler::style_file()` on the six `inst/artma` files carrying the other 8 flagged signatures; only the signatures changed.

All styling ran under `LC_ALL=en_US.UTF-8`. A first attempt under the C locale corrupted the UTF-8 comment separators in two test files (the failure mode `unicode_escape_linter` guards against) and was discarded.

## Verification

- `make lint`: No lints found (was 10 indentation lints).
- styler round-trip: a second `style_pkg()` plus `style_file()` pass changes 0 files.
- `make test`: 1596 passed, 0 failed (9 pre-existing statistical warnings).