### PR TITLE
test: add missing testthat imports to test file box::use blocks

### DIFF
--- a/tests/testthat/test-bma-auto-select.R
+++ b/tests/testthat/test-bma-auto-select.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_error,
     expect_false,
     expect_gt,
     expect_true,

--- a/tests/testthat/test-calc-endo-kink.R
+++ b/tests/testthat/test-calc-endo-kink.R
@@ -2,6 +2,7 @@ box::use(
   testthat[
     expect_equal,
     expect_false,
+    expect_length,
     expect_named,
     expect_true,
     test_that

--- a/tests/testthat/test-calc-selection-model.R
+++ b/tests/testthat/test-calc-selection-model.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_length,
     expect_true,
     test_that
   ],

--- a/tests/testthat/test-data-config-resolve.R
+++ b/tests/testthat/test-data-config-resolve.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_false,
     expect_null,
     expect_true,
     expect_length,

--- a/tests/testthat/test-libs-editor.R
+++ b/tests/testthat/test-libs-editor.R
@@ -1,3 +1,13 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_null,
+    expect_true,
+    test_that
+  ]
+)
+
 test_that("extract_editor_exe parses common editor command formats", {
   box::use(artma / interactive / editor[extract_editor_exe])
 

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -1,4 +1,4 @@
-box::use(testthat[test_that, expect_equal, expect_true, expect_false, expect_null, expect_setequal, expect_length, expect_no_error])
+box::use(testthat[test_that, expect_equal, expect_true, expect_false, expect_null, expect_setequal, expect_length, expect_no_error, expect_error, expect_identical])
 
 test_that("options lifecycle helpers operate on user files", {
   box::use(artma[options.create, options.copy, options.delete, options.fix, options.list, options.load, options.validate])

--- a/tests/testthat/test-polyfills.R
+++ b/tests/testthat/test-polyfills.R
@@ -1,3 +1,10 @@
+box::use(
+  testthat[
+    expect_equal,
+    test_that
+  ]
+)
+
 test_that("str_remove removes first match", {
   box::use(artma / libs / infrastructure / polyfills[str_remove])
 

--- a/tests/testthat/test-variable-suggestion.R
+++ b/tests/testthat/test-variable-suggestion.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_error,
     expect_false,
     expect_true,
     test_that


### PR DESCRIPTION
## Summary

Test files import testthat explicitly via `box::use(testthat[...])`, but `tests/testthat.R` also runs `library(testthat)` before `test_check()`, so any name missing from a file's import list still resolves through the global attach and the lists drift silently. `box.linters::box_usage_linter` cannot catch this in `tests/` because test files import packages and modules in a single `box::use()` call, which is why `tests/` is excluded from that linter in `.lintr.R`.

This PR audits every `.R` file under `tests/testthat/` (including `modules/`) and `tests/E2E/` with a parse-based script: it collects the bindings introduced by each `box::use()` call and every bare function call in the file (namespace-qualified calls and function-as-value uses handled separately), intersects the calls with `getNamespaceExports("testthat")`, and subtracts locally defined names and imports from other modules. That found 14 missing names across 8 files:

- `test-bma-auto-select.R`: `expect_error`
- `test-calc-endo-kink.R`: `expect_length`
- `test-calc-selection-model.R`: `expect_length`
- `test-data-config-resolve.R`: `expect_false`
- `test-libs-editor.R`: new `testthat[...]` block (`expect_equal`, `expect_false`, `expect_null`, `expect_true`, `test_that`); the file had no testthat imports at all
- `test-options.R`: `expect_error`, `expect_identical`
- `test-polyfills.R`: new `testthat[...]` block (`expect_equal`, `test_that`)
- `test-variable-suggestion.R`: `expect_error`

Changes are import lists only. Helper files (`helper-*.R`) and `tests/E2E/test-installation.R` use `testthat::`-qualified calls or none at all, and the test-only box modules under `tests/testthat/modules/` were already correct (box module scoping would have made a missing import fail loudly there).

## Verification

- Re-ran the audit after the fix: zero missing imports.
- `styler::style_file()` on all touched files: unchanged.
- `make test`: 1596 passed, 0 failed, 0 skipped (9 pre-existing MAIVE "essentially perfect fit" warnings, unrelated).