### PR TITLE
perf(linear): speed up bootstrap in linear tests

### DIFF
--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -115,6 +115,10 @@ resample_by_cluster <- function(df, cluster_column, cluster_splits = NULL) {
 }
 
 #' @title Compute bootstrap confidence intervals
+#' @description Only point estimates are needed per replication, so the spec's
+#'   cheap `boot_coefs` extractor is used instead of the full `tidy` path, and
+#'   the data is trimmed to the columns the fit actually touches before
+#'   resampling.
 #' @param spec *[list]* Linear model specification.
 #' @param data *[data.frame]* Prepared dataset.
 #' @param replications *[integer]* Number of bootstrap replications.
@@ -124,6 +128,12 @@ bootstrap_confidence <- function(spec, data, replications, conf_level) {
   if (replications <= 0) {
     return(matrix(NA_real_, nrow = 0, ncol = 2))
   }
+
+  keep_columns <- intersect(
+    unique(c(spec$required_columns, spec$weight_column, spec$cluster_column)),
+    colnames(data)
+  )
+  data <- data[, keep_columns, drop = FALSE]
 
   samples <- matrix(NA_real_, nrow = replications, ncol = length(spec$terms))
   colnames(samples) <- spec$terms
@@ -137,9 +147,10 @@ bootstrap_confidence <- function(spec, data, replications, conf_level) {
     boot_data <- resample_by_cluster(data, cluster_column, cluster_splits)
     fit <- tryCatch(spec$fit(boot_data), error = function(e) NULL)
     if (is.null(fit)) next
-    tidy <- tryCatch(spec$tidy(fit, boot_data), error = function(e) NULL)
-    if (is.null(tidy)) next
-    samples[i, tidy$term] <- tidy$estimate
+    coefs <- tryCatch(spec$boot_coefs(fit), error = function(e) NULL)
+    if (is.null(coefs)) next
+    coefs <- coefs[intersect(names(coefs), spec$terms)]
+    samples[i, names(coefs)] <- coefs
   }
 
   ci <- matrix(NA_real_, nrow = length(spec$terms), ncol = 2, dimnames = list(spec$terms, c("lower", "upper")))
@@ -255,6 +266,39 @@ tidy_plm_within <- function(model, data) {
   rbind(intercept_row, slope[c("term", "estimate", "std_error", "statistic", "p_value")])
 }
 
+#' Extract bootstrap point estimates from an intercept + `se` slope model.
+#'
+#' Cheap counterpart of the `tidy` functions for use inside the bootstrap:
+#' no clustered vcov, no coeftest, just the coefficients.
+#'
+#' @param model A fitted `lm` or `plm` model with an explicit intercept.
+#' @return A named numeric vector with `effect` and `publication_bias`.
+boot_coefs_intercept_slope <- function(model) {
+  coefs <- stats::coef(model)
+  c(
+    effect = unname(coefs["(Intercept)"]),
+    publication_bias = unname(coefs["se"])
+  )
+}
+
+#' Extract bootstrap point estimates from a within (FE) plm model.
+#'
+#' `plm::within_intercept` is called without a custom vcov: the default is far
+#' cheaper than `plm::vcovHC` and only the point estimate is used.
+#'
+#' @param model A fitted `plm` model with `model = "within"`.
+#' @return A named numeric vector with `effect` and `publication_bias`.
+boot_coefs_within <- function(model) {
+  intercept <- tryCatch(
+    plm::within_intercept(model),
+    error = function(e) NA_real_
+  )
+  c(
+    effect = if (is.numeric(intercept)) intercept[[1]] else NA_real_,
+    publication_bias = unname(stats::coef(model)["se"])
+  )
+}
+
 linear_model_specs <- function() {
   list(
     list(
@@ -266,6 +310,7 @@ linear_model_specs <- function() {
       terms = c("effect", "publication_bias"),
       fit = function(df) stats::lm(effect ~ se, data = df),
       tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
+      boot_coefs = boot_coefs_intercept_slope,
       supports_bootstrap = TRUE
     ),
     list(
@@ -278,6 +323,7 @@ linear_model_specs <- function() {
       required_packages = "plm",
       fit = function(df) plm::plm(effect ~ se, data = df, model = "within", index = "study_id"),
       tidy = tidy_plm_within,
+      boot_coefs = boot_coefs_within,
       supports_bootstrap = TRUE
     ),
     list(
@@ -290,6 +336,7 @@ linear_model_specs <- function() {
       required_packages = "plm",
       fit = function(df) plm::plm(effect ~ se, data = df, model = "between", index = "study_id"),
       tidy = tidy_plm_generic,
+      boot_coefs = boot_coefs_intercept_slope,
       supports_bootstrap = FALSE
     ),
     list(
@@ -302,6 +349,7 @@ linear_model_specs <- function() {
       required_packages = "plm",
       fit = function(df) plm::plm(effect ~ se, data = df, model = "random", index = "study_id"),
       tidy = tidy_plm_generic,
+      boot_coefs = boot_coefs_intercept_slope,
       supports_bootstrap = TRUE
     ),
     list(
@@ -314,6 +362,7 @@ linear_model_specs <- function() {
       terms = c("effect", "publication_bias"),
       fit = function(df) stats::lm(effect ~ se, data = df, weights = (df$study_size^2)),
       tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
+      boot_coefs = boot_coefs_intercept_slope,
       supports_bootstrap = TRUE
     ),
     list(
@@ -326,6 +375,7 @@ linear_model_specs <- function() {
       terms = c("effect", "publication_bias"),
       fit = function(df) stats::lm(effect ~ se, data = df, weights = (df$precision^2)),
       tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
+      boot_coefs = boot_coefs_intercept_slope,
       supports_bootstrap = TRUE
     )
   )

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -106,6 +106,62 @@ test_that("linear tests gracefully skip models with missing columns", {
   expect_true(grepl("Missing required columns", res$meta$skipped$ols_precision_weighted$reason))
 })
 
+test_that("bootstrap CIs are deterministic and seed-identical to the tidy-path implementation", {
+  skip_if_not_installed("plm")
+
+  df <- make_demo_data()
+  opts <- list(
+    add_significance_marks = FALSE,
+    bootstrap_replications = 50L,
+    conf_level = 0.9,
+    round_to = 3L
+  )
+
+  set.seed(123)
+  res <- run_linear_models(df, options = opts)
+
+  set.seed(123)
+  res_repeat <- run_linear_models(df, options = opts)
+
+  ci_cols <- c("model", "term", "bootstrap_lower", "bootstrap_upper")
+  ci <- res$coefficients[, ci_cols]
+  rownames(ci) <- NULL
+  expect_equal(ci, res_repeat$coefficients[, ci_cols], ignore_attr = TRUE)
+
+  finite_rows <- is.finite(ci$bootstrap_lower) & is.finite(ci$bootstrap_upper)
+  expect_true(all(ci$bootstrap_lower[finite_rows] <= ci$bootstrap_upper[finite_rows]))
+
+  # Reference values computed with the pre-optimization implementation, which
+  # ran the full clustered-vcov tidy path in every bootstrap replication. The
+  # fast boot_coefs path must stay seed-identical to it.
+  expected <- data.frame(
+    model = rep(
+      c("ols", "fe", "be", "re", "ols_study_weighted", "ols_precision_weighted"),
+      each = 2L
+    ),
+    term = rep(c("effect", "publication_bias"), times = 6L),
+    bootstrap_lower = c(
+      0.160739545997458, -0.601087904579698,
+      0.140819890400399, -0.600311615629511,
+      NA, NA,
+      0.155088688976474, -0.649012667394041,
+      0.162905232119029, -0.812806189499674,
+      0.120950452943169, -0.593431488826163
+    ),
+    bootstrap_upper = c(
+      0.237035405467370, 0.165658257380718,
+      0.243966037478644, 0.440057444128715,
+      NA, NA,
+      0.251343193299353, 0.228828857125176,
+      0.259964458196330, 0.177322819406577,
+      0.249764223666147, 0.467372767218415
+    ),
+    stringsAsFactors = FALSE
+  )
+
+  expect_equal(ci, expected, tolerance = 1e-8, ignore_attr = TRUE)
+})
+
 test_that("panel models are skipped with a clear message when plm is unavailable", {
   df <- make_demo_data()
 


### PR DESCRIPTION
## What

Two changes to `bootstrap_confidence` in `inst/artma/econometric/linear.R`, targeting the hot loop that profiling flagged (~6.5s of a 7.3s `linear_tests` run on 3000 rows / 200 studies, ~2.4s of it in `spec$tidy` calls whose output is mostly discarded):

1. Each spec now carries a cheap `boot_coefs` extractor used inside the bootstrap instead of the full `tidy` path. The tidy functions compute clustered vcov matrices (`sandwich::vcovCL` / `plm::vcovHC`), `lmtest::coeftest`, and `plm::within_intercept` with a custom vcov, but the bootstrap only uses point estimates. For lm and plm random/between specs the extractor maps `coef(model)` to the effect / publication_bias terms; for the within (FE) spec it takes the slope from `coef` and the intercept from `plm::within_intercept` without a custom vcov. The main (non-bootstrap) fit still uses the full `tidy` path.
2. The data is trimmed to `spec$required_columns` plus `weight_column` / `cluster_column` before the resampling loop, so the 100 per-replication row subsets no longer copy every column of the input data frame.

## Correctness

Bootstrap CIs are quantiles of point estimates and the resampling RNG sequence is untouched, so results with a fixed seed are bit-identical to before. Verified on both the demo dataset and a 3000-row / 200-study benchmark: all CI values match the old implementation to full printed precision. Benchmark wall clock went from 6.65s to 5.64s (remaining time is the model fits themselves).

A new test pins seed-fixed CI values captured from the pre-optimization implementation (tolerance 1e-8) and checks determinism across repeated seeded runs.

## Checks

- `styler` clean on changed files
- `make lint`: no findings in changed files
- `make test-filter FILTER=linear`: 93 passed