### PR TITLE
perf(linear): fast-path bootstrap estimates without per-replication plm/vcov

### DIFF
--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -92,33 +92,68 @@ prepare_linear_data <- function(df, spec) {
   )
 }
 
-#' @title Cluster bootstrap sample
-#' @description Resample the data by clusters.
-#' @param df *[data.frame]* Data to resample.
-#' @param cluster_column *[character]* Column name holding the cluster ids.
-#' @param cluster_splits *[list, optional]* Precomputed row indices split by
-#'   cluster, as returned by `split(seq_len(nrow(df)), df[[cluster_column]])`.
-#'   Pass this when resampling repeatedly so the split is not recomputed.
-#' @return A resampled data frame with replacement at the cluster level.
-resample_by_cluster <- function(df, cluster_column, cluster_splits = NULL) {
+#' @title Draw bootstrap row indices
+#' @description Resample row indices with replacement at the cluster level, or
+#'   plain rows when no cluster split is available.
+#' @param n_rows *[integer]* Number of rows in the data being resampled.
+#' @param cluster_splits *[list, optional]* Row indices split by cluster, as
+#'   returned by `split(seq_len(n_rows), cluster)`. `NULL` resamples rows.
+#' @return An integer vector of resampled row indices.
+resample_cluster_rows <- function(n_rows, cluster_splits = NULL) {
   if (is.null(cluster_splits)) {
-    if (is.null(cluster_column) || !cluster_column %in% colnames(df)) {
-      rows <- sample.int(nrow(df), nrow(df), replace = TRUE)
-      return(df[rows, , drop = FALSE])
-    }
-    cluster_splits <- split(seq_len(nrow(df)), df[[cluster_column]])
+    return(sample.int(n_rows, n_rows, replace = TRUE))
   }
-
   sampled_clusters <- sample(names(cluster_splits), length(cluster_splits), replace = TRUE)
-  sampled_indices <- unlist(cluster_splits[sampled_clusters], use.names = FALSE)
-  df[sampled_indices, , drop = FALSE]
+  unlist(cluster_splits[sampled_clusters], use.names = FALSE)
+}
+
+# Fast-path bootstrap estimators ---------------------------------------------
+#
+# The bootstrap only needs point estimates per replication, so specs may
+# provide a `boot_estimate(data, rows)` function that computes them directly
+# on the resampled rows, skipping model-object construction and vcov work.
+# Each fast path must reproduce the estimates of the corresponding
+# `spec$fit` + `spec$tidy` refit on `data[rows, ]` to near machine precision;
+# this is asserted in tests. `data` is the prepared frame from
+# `prepare_linear_data()` (finite columns, factor cluster ids).
+
+boot_estimate_ols <- function(data, rows) {
+  fit <- stats::lm.fit(cbind(1, data$se[rows]), data$effect[rows])
+  c(effect = fit$coefficients[[1L]], publication_bias = fit$coefficients[[2L]])
+}
+
+make_boot_estimate_weighted_ols <- function(weight_column) {
+  force(weight_column)
+  function(data, rows) {
+    weights <- data[[weight_column]][rows]^2
+    fit <- stats::lm.wfit(cbind(1, data$se[rows]), data$effect[rows], weights)
+    c(effect = fit$coefficients[[1L]], publication_bias = fit$coefficients[[2L]])
+  }
+}
+
+# Within (fixed effects) estimator. Duplicated resampled clusters keep their
+# original id, so they merge into one group during demeaning, exactly as plm
+# treats the resampled frame. The overall intercept is what
+# plm::within_intercept() returns: mean(y) - slope * mean(x).
+#
+# Random effects has no fast path: Swamy-Arora variance components must be
+# recomputed per resample, so it stays on the `fit` + `boot_coefs` fallback.
+boot_estimate_within <- function(data, rows) {
+  y <- data$effect[rows]
+  x <- data$se[rows]
+  group <- data$study_id[rows]
+  y_demeaned <- y - stats::ave(y, group)
+  x_demeaned <- x - stats::ave(x, group)
+  slope <- stats::.lm.fit(cbind(x_demeaned), y_demeaned)$coefficients[[1L]]
+  c(effect = mean(y) - slope * mean(x), publication_bias = slope)
 }
 
 #' @title Compute bootstrap confidence intervals
-#' @description Only point estimates are needed per replication, so the spec's
-#'   cheap `boot_coefs` extractor is used instead of the full `tidy` path, and
-#'   the data is trimmed to the columns the fit actually touches before
-#'   resampling.
+#' @description Only point estimates are needed per replication. Specs with a
+#'   `boot_estimate` fast path compute them directly on the resampled rows;
+#'   the rest refit via `spec$fit` and extract coefficients with the cheap
+#'   `boot_coefs` extractor instead of the full `tidy` path. The data is
+#'   trimmed to the columns the fit actually touches before resampling.
 #' @param spec *[list]* Linear model specification.
 #' @param data *[data.frame]* Prepared dataset.
 #' @param replications *[integer]* Number of bootstrap replications.
@@ -142,15 +177,23 @@ bootstrap_confidence <- function(spec, data, replications, conf_level) {
   cluster_splits <- if (!is.null(cluster_column) && cluster_column %in% colnames(data)) {
     split(seq_len(nrow(data)), data[[cluster_column]])
   }
+  boot_estimate <- spec$boot_estimate
 
   for (i in seq_len(replications)) {
-    boot_data <- resample_by_cluster(data, cluster_column, cluster_splits)
-    fit <- tryCatch(spec$fit(boot_data), error = function(e) NULL)
-    if (is.null(fit)) next
-    coefs <- tryCatch(spec$boot_coefs(fit), error = function(e) NULL)
-    if (is.null(coefs)) next
-    coefs <- coefs[intersect(names(coefs), spec$terms)]
-    samples[i, names(coefs)] <- coefs
+    rows <- resample_cluster_rows(nrow(data), cluster_splits)
+    if (!is.null(boot_estimate)) {
+      estimates <- tryCatch(boot_estimate(data, rows), error = function(e) NULL)
+      if (is.null(estimates)) next
+      samples[i, names(estimates)] <- estimates
+    } else {
+      boot_data <- data[rows, , drop = FALSE]
+      fit <- tryCatch(spec$fit(boot_data), error = function(e) NULL)
+      if (is.null(fit)) next
+      coefs <- tryCatch(spec$boot_coefs(fit), error = function(e) NULL)
+      if (is.null(coefs)) next
+      coefs <- coefs[intersect(names(coefs), spec$terms)]
+      samples[i, names(coefs)] <- coefs
+    }
   }
 
   ci <- matrix(NA_real_, nrow = length(spec$terms), ncol = 2, dimnames = list(spec$terms, c("lower", "upper")))
@@ -311,6 +354,7 @@ linear_model_specs <- function() {
       fit = function(df) stats::lm(effect ~ se, data = df),
       tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
       boot_coefs = boot_coefs_intercept_slope,
+      boot_estimate = boot_estimate_ols,
       supports_bootstrap = TRUE
     ),
     list(
@@ -324,6 +368,7 @@ linear_model_specs <- function() {
       fit = function(df) plm::plm(effect ~ se, data = df, model = "within", index = "study_id"),
       tidy = tidy_plm_within,
       boot_coefs = boot_coefs_within,
+      boot_estimate = boot_estimate_within,
       supports_bootstrap = TRUE
     ),
     list(
@@ -363,6 +408,7 @@ linear_model_specs <- function() {
       fit = function(df) stats::lm(effect ~ se, data = df, weights = (df$study_size^2)),
       tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
       boot_coefs = boot_coefs_intercept_slope,
+      boot_estimate = make_boot_estimate_weighted_ols("study_size"),
       supports_bootstrap = TRUE
     ),
     list(
@@ -376,6 +422,7 @@ linear_model_specs <- function() {
       fit = function(df) stats::lm(effect ~ se, data = df, weights = (df$precision^2)),
       tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
       boot_coefs = boot_coefs_intercept_slope,
+      boot_estimate = make_boot_estimate_weighted_ols("precision"),
       supports_bootstrap = TRUE
     )
   )
@@ -553,7 +600,9 @@ build_summary_table <- function(coefficients, digits) {
 }
 
 box::export(
-  run_linear_models
+  run_linear_models,
+  linear_model_specs,
+  resample_cluster_rows
 )
 
 # nocov end -----------------------------------------------------------------

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -12,7 +12,11 @@ box::use(
 )
 
 box::use(
-  artma / econometric / linear[run_linear_models],
+  artma / econometric / linear[
+    linear_model_specs,
+    resample_cluster_rows,
+    run_linear_models
+  ],
   artma / methods / linear_tests[linear_tests]
 )
 
@@ -160,6 +164,94 @@ test_that("bootstrap CIs are deterministic and seed-identical to the tidy-path i
   )
 
   expect_equal(ci, expected, tolerance = 1e-8, ignore_attr = TRUE)
+})
+
+test_that("bootstrap fast paths match slow-path refits on resampled data", {
+  skip_if_not_installed("plm")
+
+  set.seed(42)
+  n_studies <- 12L
+  per_study <- 5L
+  study_ids <- rep(paste0("S", seq_len(n_studies)), each = per_study)
+  se_vals <- runif(n_studies * per_study, min = 0.05, max = 0.15)
+  df <- data.frame(
+    study_id = droplevels(factor(study_ids)),
+    effect = rnorm(n_studies * per_study, mean = 0.2, sd = 0.05),
+    se = se_vals,
+    study_size = sample(20:80, n_studies * per_study, replace = TRUE),
+    precision = 1 / se_vals
+  )
+  cluster_splits <- split(seq_len(nrow(df)), df$study_id)
+
+  specs <- linear_model_specs()
+  names(specs) <- vapply(specs, function(spec) spec$name, character(1))
+  fast_path_specs <- c("ols", "fe", "ols_study_weighted", "ols_precision_weighted")
+  compared <- stats::setNames(integer(length(fast_path_specs)), fast_path_specs)
+
+  set.seed(1234)
+  for (replication in seq_len(5L)) {
+    rows <- resample_cluster_rows(nrow(df), cluster_splits)
+    boot_data <- df[rows, , drop = FALSE]
+
+    for (spec_name in fast_path_specs) {
+      spec <- specs[[spec_name]]
+      fast <- tryCatch(spec$boot_estimate(df, rows), error = function(e) NULL)
+      slow_model <- tryCatch(spec$fit(boot_data), error = function(e) NULL)
+
+      if (is.null(slow_model)) {
+        # A degenerate resample (e.g. too few distinct clusters) must fail
+        # identically on both paths.
+        expect_true(is.null(fast), info = paste(spec_name, "replication", replication))
+        next
+      }
+
+      slow_tidy <- spec$tidy(slow_model, boot_data)
+      slow <- stats::setNames(slow_tidy$estimate, slow_tidy$term)
+
+      expect_equal(
+        fast[c("effect", "publication_bias")],
+        slow[c("effect", "publication_bias")],
+        tolerance = 1e-12,
+        info = paste(spec_name, "replication", replication)
+      )
+      compared[spec_name] <- compared[spec_name] + 1L
+    }
+  }
+
+  expect_true(all(compared > 0L))
+})
+
+test_that("within fast path merges duplicated resampled clusters like plm", {
+  skip_if_not_installed("plm")
+
+  df <- make_demo_data()
+  df$study_id <- droplevels(factor(df$study_id))
+  cluster_splits <- split(seq_len(nrow(df)), df$study_id)
+
+  specs <- linear_model_specs()
+  names(specs) <- vapply(specs, function(spec) spec$name, character(1))
+  fe_spec <- specs[["fe"]]
+
+  # Force duplicated clusters so the merge semantics are actually exercised.
+  rows <- unlist(
+    cluster_splits[c("S1", "S1", "S2", "S3", "S3", "S3")],
+    use.names = FALSE
+  )
+  boot_data <- df[rows, , drop = FALSE]
+
+  fast <- fe_spec$boot_estimate(df, rows)
+  model <- plm::plm(effect ~ se, data = boot_data, model = "within", index = "study_id")
+
+  expect_equal(
+    fast[["publication_bias"]],
+    unname(stats::coef(model)[["se"]]),
+    tolerance = 1e-12
+  )
+  expect_equal(
+    fast[["effect"]],
+    unname(plm::within_intercept(model)[[1L]]),
+    tolerance = 1e-12
+  )
 })
 
 test_that("panel models are skipped with a clear message when plm is unavailable", {


### PR DESCRIPTION
## Summary

Profiling the linear-tests bootstrap (3000 rows, 200 studies) showed `bootstrap_confidence` spending ~3.8s in `spec$fit` across replications, dominated by `plm::plm` rebuilding panel structures (`model.matrix.pdata.frame`, `ercomp`) on every call for a bivariate `effect ~ se` regression.

Master already skips the per-replication vcov via the `boot_coefs` extractors (61bab94); this PR removes the per-replication model fit itself for the specs where a direct least-squares computation can match it exactly. Specs may now provide a `boot_estimate(data, rows)` fast path computed straight on resampled row indices, with no data-frame subsetting and no model objects; specs without one keep the `fit` + `boot_coefs` fallback. The main reported fits are untouched and still use `stats::lm` / `plm::plm` with clustered vcov.

### What was fast-pathed

- **OLS**: `stats::lm.fit` on a prebuilt `cbind(1, se)` matrix. Bit-for-bit identical to the `stats::lm` refit (same underlying `C_Cdqrls`).
- **Weighted OLS** (study- and precision-weighted): `stats::lm.wfit` with the squared weight column. Bit-for-bit identical.
- **Fixed effects ("within")**: demean `effect` and `se` within each resampled cluster, slope via `.lm.fit` on the demeaned column, overall intercept as `mean(effect) - slope * mean(se)` (what `plm::within_intercept` returns). Duplicated resampled cluster ids keep their original id and therefore merge into one group during demeaning, matching how plm treats the resampled frame; a dedicated test compares against an actual plm fit on a frame with forced duplicate clusters. Max observed deviation vs the plm refit: 5e-16.
- **Random effects**: not fast-pathed. Swamy-Arora variance components must be recomputed per resample and replicating `ercomp` exactly was not worth the verification risk; RE stays on the `plm::plm` + `boot_coefs` fallback that master already optimized.

### Measured per-replication cost (200 studies x 15 rows)

| Spec | fit + tidy | fast path |
|------|-----------|-----------|
| FE | 21.9 ms | 1.1 ms |
| OLS | 1.5 ms | 0.13 ms |

### Correctness

- Master's golden test (seed-identical bootstrap CIs vs the pre-optimization tidy-path implementation, tolerance 1e-8) passes unchanged through the fast paths; the resampling RNG stream is preserved exactly.
- New testthat test resamples with a fixed seed and compares fast-path estimates against `spec$fit` + `spec$tidy` refits on the same resampled frame for 5 replications across all fast-pathed specs at tolerance 1e-12, asserting that degenerate resamples fail identically on both paths.
- A second test forces duplicated clusters and checks the FE slope and intercept against `plm::plm` / `plm::within_intercept` directly.

`make lint` clean for the changed files; `make test-filter FILTER=linear`: 116 pass, 0 fail.
