### PR TITLE
feat(robma): enable parallel MCMC chains when cores allow

### DIFF
--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -35,7 +35,7 @@ robma <- function(df) {
   samples <- opt$samples %||% 5000L
   burnin <- opt$burnin %||% 2000L
   adapt <- opt$adapt %||% 500L
-  parallel <- opt$parallel %||% FALSE
+  parallel <- resolve_parallel(opt$parallel, chains)
   autofit <- opt$autofit %||% TRUE
   seed <- opt$seed %||% NA_integer_
   measure <- opt$measure %||% "SMD"
@@ -139,6 +139,32 @@ robma <- function(df) {
     ),
     meta = list(model = fit, n_obs = nrow(fit_data))
   )
+}
+
+#' @title Resolve the RoBMA parallel sampling flag
+#' @description
+#' RoBMA spawns one worker per chain when `parallel = TRUE`, so parallel
+#' sampling only pays off when the machine has a spare core on top of the
+#' chains. Auto-detect that when the user left the option unset (`NA`); an
+#' explicit `TRUE`/`FALSE` in the options file always wins.
+#' @param setting *\[logical, optional\]* The `parallel` option value.
+#' @param chains *\[numeric\]* Number of MCMC chains to be fitted.
+#' @return *\[logical\]* Whether to sample the chains in parallel.
+resolve_parallel <- function(setting, chains) {
+  if (!is.null(setting) && !is.na(setting)) {
+    return(isTRUE(setting))
+  }
+
+  if (tolower(Sys.getenv("_R_CHECK_LIMIT_CORES_", "")) %in% c("true", "warn")) {
+    return(FALSE)
+  }
+
+  cores <- parallel::detectCores()
+  if (is.na(cores)) {
+    cores <- 1L
+  }
+
+  cores > chains
 }
 
 #' @title Empty RoBMA estimates table

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -525,9 +525,15 @@ methods:
 
     parallel:
       type: "logical"
-      default: false
+      allow_na: true
+      default: .na
       help: |
-        If `TRUE`, fit the models of the RoBMA ensemble in parallel.
+        If `TRUE`, sample the MCMC chains of each RoBMA model in parallel,
+        which is close to a `chains`-fold speed-up on a multi-core machine.
+        RoBMA starts one worker per chain, so leave the option unset (NA) to
+        enable parallel sampling only when the machine has more cores than
+        `chains`, and fall back to sequential sampling otherwise. Setting the
+        option explicitly overrides the auto-detection.
 
     autofit:
       type: "logical"


### PR DESCRIPTION
## What

RoBMA MCMC is the slowest part of a full run, and `parallel` was hard-defaulted to `FALSE`. It now auto-enables when the machine has cores to spare.

- `inst/artma/methods/robma.R`: `parallel <- resolve_parallel(opt$parallel, chains)`. The new helper returns the user's value whenever the option is set explicitly (`TRUE`/`FALSE`), and otherwise auto-detects: `parallel::detectCores() > chains`, with `NA` from `detectCores()` treated as 1 core.
- `inst/artma/options/templates/options_template.yaml`: the `methods.robma.parallel` node becomes `allow_na: true` / `default: .na`, with help text explaining that NA means auto-detect.

## Why NA rather than a plain `true` default

The requirement was that an explicit user setting always wins. With a plain logical default the method cannot tell "user wrote `true`" from "template default", so a guard in the code would silently override a deliberate `parallel: true` on a small machine. `.na` as the template default gives a real third state: unset means auto, and `TRUE`/`FALSE` are passed through untouched. The options system already supports `allow_na` for defaults (`inst/artma/options/template.R`), and `is.logical(NA)` keeps the existing validation happy.

`resolve_parallel()` also forces sequential sampling under `_R_CHECK_LIMIT_CORES_`, matching the existing precedent in `inst/artma/calc/methods/elliott.R`.

## Behaviour on fewer cores than chains

`BayesTools::JAGS_fit()` (which RoBMA calls) does `parallel::makePSOCKcluster(cores)` with `cores = chains` and dispatches via runjags `"rjparallel"`. Oversubscribing works, it just spawns more workers than cores and loses the speed-up to context switching plus cluster startup. So `parallel = TRUE` on a single-core machine degrades rather than fails, but the auto-detection avoids paying that cost.

## Seed and reproducibility

Verified in the source and empirically: `JAGS_fit()` builds per-chain inits with `JAGS_get_inits(prior_list, chains = chains, seed = seed)` *before* branching on `parallel`, and calls `set.seed(seed)` in both paths. The per-chain RNG seeds are therefore identical whether chains run in parallel or sequentially. RoBMA's autofit extension likewise derives `seed + i` per chain. A run with `seed = 1` gave bit-identical model-averaged estimates both ways (`all.equal` TRUE, see below).

## Smoke run

RoBMA 4.0.0 with JAGS installed locally; mock data from `create_mock_df(nrow = 60, seed = 42)`, 8 cores, 3 chains, 5000 samples / 2000 burn-in / 500 adapt, `autofit = FALSE`, `seed = 1`:

| mode | wall time |
|---|---|
| sequential | 5.61 s |
| parallel | 3.98 s |

Estimates identical between the two (`mu` 0.003, `tau` 0.417 in both). The 1.4x here understates the real-world gain: mock data is tiny, so PSOCK cluster startup is a large share of the total. On a real fit, where each chain runs for minutes, the fixed startup cost is negligible and the speed-up approaches chains-fold.

## Checks

`make lint` clean for the touched files, `make test` passes (0 failures, 1606 assertions).