### PR TITLE
feat(cache): harden cache signature and enable caching by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,11 @@ This keeps the package functional when a user's options file predates newly adde
 
 ### Caching
 
-`cache_cli()` (`inst/artma/libs/infrastructure/cache.R`) memoises a function on disk via `memoise` while preserving its CLI output; `cache_cli_runner()` layers stage naming and cache signatures on top. Control behavior with the `invalidate_fun` and `max_age` arguments, or disable caching globally with `options(artma.cache.use_cache = FALSE)`.
+`cache_cli()` (`inst/artma/libs/infrastructure/cache.R`) memoises a function on disk via `memoise` while preserving its CLI output; `cache_cli_runner()` layers stage naming and cache signatures on top. Caching is on by default. Control behavior with the `invalidate_fun` and `max_age` arguments, or disable it globally with `options(artma.cache.use_cache = FALSE)` (read on every call, so it takes effect immediately).
+
+The cache key must cover every input. `memoise` hashes the call arguments (the data frame, any `<dependency>_result`); `build_data_cache_signature()` (`inst/artma/data/cache_signatures.R`) adds the data source path and mtime, the user-authored data config, the whole user-authored `artma.*` option group, the package version, and `package_source_fingerprint()` (a hash of every R file under `inst/artma`). `register_runtime_method()` appends the method's own source hash. When adding a cached workflow, route new inputs through the signature rather than relying on the argument hash alone.
+
+Graphics are written during method execution, so they are not replayed by a cache hit. Writers call `record_output_file()` (`inst/artma/libs/infrastructure/output_files.R`); `cache_cli()` stores the recorded paths on the artifact and reruns the implementation when any of them have since disappeared. Any new file-writing side effect in a cached path needs the same call.
 
 ### Data Pipeline
 

--- a/README-dev.md
+++ b/README-dev.md
@@ -314,16 +314,42 @@ artifact$meta  # timestamp, extra keys, and cache settings
 
 ## Invalidation and configuration
 
-Several mechanisms keep cached artefacts fresh:
+Caching is on by default (`artma.cache.use_cache`), so the cache key has to be
+exhaustive. `memoise` hashes the arguments of the memoised call, which covers
+the data frame and any upstream `<dependency>_result` the orchestrator injects.
+Everything else reaches the key through the `cache_signature` that
+`build_data_cache_signature()` builds:
+
+- the data source path and its modification time;
+- the user-authored data config entries;
+- the whole user-authored `artma.*` option group, not a per-method subset, so
+  an option read indirectly through a shared helper cannot be missed;
+- the installed package version;
+- `package_source_fingerprint()`, a hash of every R file under `inst/artma`.
+
+`register_runtime_method()` appends `method_source_hash(stage)` on top, so
+editing one method file invalidates that method alone. Fingerprints are
+memoised per session, which matches when a source edit actually takes effect
+(`box` caches loaded modules for the session too).
+
+Several further mechanisms keep cached artefacts fresh:
 
 - `invalidate_fun` (optional) receives the call arguments and should return
   `TRUE` when the cache must be bypassed (e.g. negative inputs). When triggered
   the memoised store is cleared before recomputing so subsequent calls rebuild
   fresh artefacts.
 - `max_age` enforces a time-to-live in seconds. Set it explicitly when
-  wrapping a function or globally via the `artma.cache.max_age` option.
+  wrapping a function or globally via the `artma.cache.max_age` option. It is a
+  backstop for inputs that change without the signature noticing, such as a
+  data file edited in place with its modification time preserved.
+- Output files recorded during a cold run (graphics, via `save_plot()` and
+  `record_output_file()`) are re-checked on every hit. If one has gone missing,
+  the artefact is dropped and the implementation reruns, so a cache hit never
+  reports success with its plots absent.
 - Disable caching entirely with `options(artma.cache.use_cache = FALSE)` when
-  debugging or benchmarking; the original function is returned untouched.
+  debugging or benchmarking. The option is read on every call, so toggling it
+  mid-session takes effect immediately.
+- Wipe the on-disk cache with `make clear-cache`.
 
 Combine `invalidate_fun`, `max_age`, and `extra_keys` to model domain-specific
 refresh rules without manually clearing the cache.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A call to `artma()` orchestrates four steps:
 
 Runs are fault tolerant. A method that errors is skipped with a warning while the rest continue, and results from successful methods are still exported. Failed method names and their error messages are attached to the returned list as the `failed_methods` attribute. Methods whose required columns are missing from your data, or whose optional packages aren't installed, are skipped with an explanation rather than aborting the run.
 
-Expensive computations are cached on disk between runs. Disable this with `options(artma.cache.use_cache = FALSE)` if you need fresh results every time.
+Expensive computations are cached on disk between runs, so rerunning an analysis with unchanged inputs is near-instant. A cached result is reused only when the data, the upstream method results, every user-authored `artma.*` option, the data source and its modification time, and the package source code all match the run that produced it; a method whose exported plot files have since been removed is rerun so the files come back. Disable caching with `options(artma.cache.use_cache = FALSE)`, and clear it with `make clear-cache`.
 
 # Available methods
 

--- a/inst/artma/data/cache_signatures.R
+++ b/inst/artma/data/cache_signatures.R
@@ -1,5 +1,6 @@
 box::use(
-  artma / options / index[get_option_group]
+  artma / options / index[get_option_group],
+  artma / libs / infrastructure / source_fingerprint[package_source_fingerprint]
 )
 
 # Option keys under the "artma." prefix that the data pipeline itself writes
@@ -89,10 +90,21 @@ user_authored_config_entries <- function(config) {
 #' Construct a deterministic list of the user-controlled inputs that influence
 #' data preparation: the configured data source (normalized path plus file
 #' modification time), the user-authored part of the data config, the
-#' remaining user-authored `artma.*` options, and the installed package
-#' version. The list is forwarded to `cache_cli()` wrappers as the
-#' `cache_signature` argument and `memoise` hashes it as part of the cache
-#' key, so no explicit hashing happens here.
+#' remaining user-authored `artma.*` options, the installed package version,
+#' and a fingerprint of the package's own source tree. The list is forwarded to
+#' `cache_cli()` wrappers as the `cache_signature` argument and `memoise`
+#' hashes it as part of the cache key, so no explicit hashing happens here.
+#'
+#' The `artma.*` options are taken as a whole group rather than as a
+#' per-consumer subset, so an option a workflow reads indirectly (through a
+#' shared formatter or calculation helper) cannot be missed. That is coarser
+#' than necessary, which is the safe direction: a needless recomputation costs
+#' time, a stale hit costs correctness.
+#'
+#' The source fingerprint covers every R file under the package's module root,
+#' so editing a method (or anything it calls) invalidates the caches built from
+#' it. Callers that key on a single method add its own source hash on top; see
+#' `register_runtime_method()`.
 #'
 #' Options that the pipeline itself writes while running (computed column
 #' entries in `data.columns`, the `data.expected_schema_columns` baseline, and
@@ -129,7 +141,8 @@ build_data_cache_signature <- function() {
     source_mtime = source_mtime,
     data_config = data_config,
     artma_options = artma_options,
-    package_version = as.character(utils::packageVersion("artma"))
+    package_version = as.character(utils::packageVersion("artma")),
+    source_fingerprint = package_source_fingerprint()
   )
 }
 

--- a/inst/artma/libs/infrastructure/cache.R
+++ b/inst/artma/libs/infrastructure/cache.R
@@ -5,6 +5,24 @@
 # injection on top so callers stay free of caching boilerplate. On a cache
 # hit a single notice is printed; the wrapped function's own CLI output is
 # not replayed.
+#
+# What ends up in a cache key
+# ---------------------------
+# `memoise` hashes the arguments of the memoised call, so the key covers:
+#
+# * every argument the caller passes, including the data frame and any
+#   upstream `<dependency>_result` the orchestrator injects;
+# * the `cache_signature` that `cache_cli_runner()` builds via `key_builder`,
+#   which for runtime methods carries the stage label, the user-authored
+#   `artma.*` options, the data source path and mtime, the package version,
+#   the package source fingerprint, and the method's own source hash.
+#
+# `memoise` also folds in the memoised function's body, but that body is the
+# fixed `worker` closure below and is identical for every stage, so stage
+# isolation comes from the signature rather than from `memoise`.
+#
+# Beyond the key, a cached artifact is rejected when it has outlived `max_age`
+# or when the output files it recorded on the cold run are no longer on disk.
 
 #' @title Construct a cached artifact
 #' @description Bundle a computed value with the metadata required to reason
@@ -104,6 +122,21 @@ artifact_expired <- function(art, max_age) {
   !is.na(age) && age > max_age
 }
 
+#' @title Test whether a cached artifact's output files are gone
+#' @description Report whether any file the artifact recorded when it was
+#'   produced has since disappeared. Runtime methods write graphics during
+#'   execution, so replaying only the returned value would leave a run claiming
+#'   success with its plots missing.
+#' @param art *\[cached_artifact\]* The artifact to test.
+#' @return *\[logical\]* `TRUE` when a recorded output file is missing.
+#' @keywords internal
+artifact_files_missing <- function(art) {
+  box::use(
+    artma / libs / infrastructure / output_files[recorded_output_files_missing]
+  )
+  recorded_output_files_missing(art$meta$output_files)
+}
+
 #' @title Announce a cache hit
 #' @description Print a single short notice when cached results are reused,
 #'   respecting the configured verbosity level.
@@ -139,12 +172,13 @@ notify_cache_hit <- function(extra_keys) {
 #' @param max_age *\[numeric\]* Maximum age of cached artifacts in seconds. Use
 #'   `Inf` to disable time-based invalidation. When `NULL` (the default) the
 #'   value is sourced from the `artma.cache.max_age` option, falling back to
-#'   3600 seconds (1 hour). The fallback is deliberately finite: cache keys
-#'   include the package version but not the source code, so two development
-#'   builds sharing a version would otherwise serve each other's stale
-#'   artifacts indefinitely.
-#' @return *\[function\]* The wrapped function. When caching is disabled via the
-#'   `artma.cache.use_cache` option, `fun` is returned unchanged.
+#'   3600 seconds (1 hour). Time-based invalidation is a backstop rather than
+#'   the primary guard: cache keys cover the inputs, the options, and the
+#'   package source, so the TTL only catches inputs that changed without the
+#'   signature noticing (an edited data file whose mtime was preserved, say).
+#' @return *\[function\]* The wrapped function. It consults
+#'   `artma.cache.use_cache` on every call, so disabling caching mid-session
+#'   takes effect immediately and calls through to `fun` unchanged.
 #' @examples
 #' \dontrun{
 #' .run_models_impl <- function(df, formula, seed = 123) {
@@ -162,43 +196,75 @@ cache_cli <- function(fun,
                       cache = NULL,
                       invalidate_fun = NULL,
                       max_age = NULL) {
+  box::use(
+    artma / libs / infrastructure / output_files[
+      begin_output_file_capture, end_output_file_capture
+    ]
+  )
+
   base::force(fun) # lock the original function inside the closure
 
-  max_age <- resolve_max_age(max_age)
-
-  if (!getOption("artma.cache.use_cache", TRUE)) {
-    return(fun)
-  }
-
-  if (is.null(cache)) {
-    cache <- default_cache()
-  }
+  requested_max_age <- max_age
+  supplied_cache <- cache
 
   # Tracks whether the worker actually ran, so the wrapper can tell a genuine
-  # cache hit (worker skipped by memoise) from a cold computation.
+  # cache hit (worker skipped by memoise) from a cold computation. It also
+  # carries the TTL in force for the current call into the worker.
   worker_state <- new.env(parent = emptyenv())
+  worker_state$max_age <- resolve_max_age(requested_max_age)
 
   worker <- function(...) {
     worker_state$executed <- TRUE
+
+    # Bracket the run so any file the implementation writes (graphics, in
+    # practice) is recorded on the artifact and can be re-checked on a hit.
+    capture_id <- begin_output_file_capture()
+    on.exit(end_output_file_capture(capture_id), add = TRUE)
     value <- fun(...)
+    output_files <- end_output_file_capture(capture_id)
+
     meta <- list(
       timestamp = Sys.time(),
       extra = extra_keys,
-      cache = list(max_age = max_age)
+      output_files = output_files,
+      cache = list(max_age = worker_state$max_age)
     )
     new_artifact(value, meta)
   }
 
-  worker_memoised <- memoise::memoise(worker, cache = cache)
-  drop_worker_cache <- memoise::drop_cache(worker_memoised)
+  # The memoised layer is built on first use rather than at wrap time: runtime
+  # methods are wrapped when their module loads, which is well before the
+  # options file has settled, and building it lazily also keeps the cache
+  # directory from being created for sessions that never cache anything.
+  memo_state <- new.env(parent = emptyenv())
+
+  resolve_memoised <- function() {
+    if (is.null(memo_state$memoised)) {
+      resolved_cache <- if (is.null(supplied_cache)) default_cache() else supplied_cache
+      memo_state$memoised <- memoise::memoise(worker, cache = resolved_cache)
+      memo_state$drop <- memoise::drop_cache(memo_state$memoised)
+    }
+    memo_state
+  }
 
   function(...) {
     dots <- rlang::list2(...)
+
+    # Read at call time so toggling `artma.cache.use_cache` takes effect
+    # immediately, rather than being frozen at module load.
+    if (!getOption("artma.cache.use_cache", TRUE)) {
+      return(rlang::exec(fun, !!!dots))
+    }
+
+    max_age <- resolve_max_age(requested_max_age)
+    worker_state$max_age <- max_age
     worker_state$executed <- FALSE
+
+    memo <- resolve_memoised()
 
     if (is.function(invalidate_fun) && should_invalidate(invalidate_fun, dots)) {
       tryCatch(
-        memoise::forget(worker_memoised),
+        memoise::forget(memo$memoised),
         error = function(err) {
           cli::cli_warn(
             sprintf("cache invalidator failed to reset memoised state: %s", conditionMessage(err))
@@ -207,12 +273,15 @@ cache_cli <- function(fun,
       )
     }
 
-    art <- rlang::exec(worker_memoised, !!!dots)
+    art <- rlang::exec(memo$memoised, !!!dots)
     cache_hit <- !isTRUE(worker_state$executed)
 
-    if (cache_hit && is.finite(max_age) && artifact_expired(art, max_age)) {
+    stale <- cache_hit &&
+      ((is.finite(max_age) && artifact_expired(art, max_age)) || artifact_files_missing(art))
+
+    if (stale) {
       tryCatch(
-        rlang::exec(drop_worker_cache, !!!dots),
+        rlang::exec(memo$drop, !!!dots),
         error = function(err) {
           cli::cli_warn(
             sprintf("Failed to evict stale cache entry: %s", conditionMessage(err))
@@ -220,7 +289,7 @@ cache_cli <- function(fun,
         }
       )
       worker_state$executed <- FALSE
-      art <- rlang::exec(worker_memoised, !!!dots)
+      art <- rlang::exec(memo$memoised, !!!dots)
       cache_hit <- !isTRUE(worker_state$executed)
     }
 

--- a/inst/artma/libs/infrastructure/output_files.R
+++ b/inst/artma/libs/infrastructure/output_files.R
@@ -1,0 +1,85 @@
+# Recording of files written to disk while a cached workflow runs.
+#
+# Runtime methods write their graphics during execution, not from the value
+# they return, so a cache hit skips those writes. That is fine as long as the
+# files are still where the previous run left them; it is a silent regression
+# when they are not (the results directory was cleared, the graphics were moved
+# away, an export failed halfway).
+#
+# Writers call `record_output_file()`; `cache_cli()` brackets each cold run with
+# `begin_output_file_capture()` / `end_output_file_capture()` and stores the
+# recorded paths in the cached artifact. On a hit it re-checks them and falls
+# back to recomputation when any have gone missing.
+
+.capture <- new.env(parent = emptyenv())
+.capture$frames <- list()
+
+#' @title Record a file written by the current workflow
+#' @description Note a path as an output of every capture currently in
+#'   progress. A no-op when nothing is capturing, so writers can call it
+#'   unconditionally.
+#' @param path *\[character\]* Path of the file that was written.
+#' @return `NULL`, invisibly.
+record_output_file <- function(path) {
+  if (length(.capture$frames) == 0L) {
+    return(invisible(NULL))
+  }
+  if (!is.character(path) || length(path) != 1L || is.na(path) || !nzchar(path)) {
+    return(invisible(NULL))
+  }
+
+  normalized <- tryCatch(
+    normalizePath(path, mustWork = FALSE),
+    error = function(err) path
+  )
+
+  .capture$frames <- lapply(.capture$frames, function(frame) c(frame, normalized))
+  invisible(NULL)
+}
+
+#' @title Start recording output files
+#' @description Open a capture frame. Frames nest: a recorded path is added to
+#'   every open frame, so an outer cached stage sees the files written by the
+#'   cached stages it calls.
+#' @return *\[integer\]* The identifier of the frame that was opened.
+begin_output_file_capture <- function() {
+  .capture$frames <- c(.capture$frames, list(character()))
+  length(.capture$frames)
+}
+
+#' @title Stop recording output files
+#' @description Close the capture frame opened by `begin_output_file_capture()`
+#'   and return the paths recorded while it was open. Closing a frame also
+#'   closes any frames opened after it, which keeps the stack consistent when a
+#'   nested workflow aborts. Closing an already-closed frame is a no-op.
+#' @param id *\[integer\]* The frame identifier to close.
+#' @return *\[character\]* The unique paths recorded while the frame was open.
+end_output_file_capture <- function(id) {
+  if (!is.numeric(id) || length(id) != 1L || is.na(id) || id > length(.capture$frames)) {
+    return(character())
+  }
+
+  files <- .capture$frames[[id]]
+  .capture$frames <- .capture$frames[seq_len(id - 1L)]
+  unique(files)
+}
+
+#' @title Test whether recorded output files are still on disk
+#' @description Report whether any of the paths a cached run recorded have since
+#'   disappeared. An empty or absent record means nothing to verify, which
+#'   counts as intact.
+#' @param files *\[character\]* Paths recorded on a previous run.
+#' @return *\[logical\]* `TRUE` when at least one recorded file is missing.
+recorded_output_files_missing <- function(files) {
+  if (!is.character(files) || length(files) == 0L) {
+    return(FALSE)
+  }
+  any(!file.exists(files))
+}
+
+box::export(
+  begin_output_file_capture,
+  end_output_file_capture,
+  record_output_file,
+  recorded_output_files_missing
+)

--- a/inst/artma/libs/infrastructure/source_fingerprint.R
+++ b/inst/artma/libs/infrastructure/source_fingerprint.R
@@ -1,0 +1,119 @@
+# Source-code fingerprints for cache keys.
+#
+# The on-disk cache keys on the user's inputs (data, options, upstream
+# results). None of that changes when the package's own code changes, so a
+# cached artifact would survive an edit to the very function that produced it.
+# These helpers close that gap by folding a hash of the package source into the
+# cache signature.
+#
+# Fingerprints are computed once per session and memoised in `.state`. Session
+# scope is the right granularity: `box` caches loaded modules for the lifetime
+# of the session, so an edit made mid-session does not take effect until the
+# modules are reloaded, which resets this env too.
+
+box::use(
+  artma / paths[PATHS]
+)
+
+.state <- new.env(parent = emptyenv())
+
+#' @title Hash a set of source files
+#' @description Hash file contents together with their paths relative to
+#'   `root`, so both edits and renames change the result. Files are sorted by
+#'   path to keep the hash independent of the filesystem's listing order.
+#' @param files *\[character\]* Absolute paths of the files to hash.
+#' @param root *\[character\]* Directory the paths are made relative to.
+#' @return *\[character\]* A single hash, or `NA_character_` when `files` is
+#'   empty.
+#' @keywords internal
+hash_source_files <- function(files, root) {
+  if (length(files) == 0L) {
+    return(NA_character_)
+  }
+
+  files <- sort(files, method = "radix")
+
+  entries <- lapply(files, function(path) {
+    contents <- tryCatch(
+      paste(readLines(path, warn = FALSE), collapse = "\n"),
+      error = function(err) NA_character_
+    )
+    list(path = substring(path, nchar(root) + 2L), contents = contents)
+  })
+
+  rlang::hash(entries)
+}
+
+#' @title Fingerprint the package source tree
+#' @description Hash every R source file under the package's module root. Any
+#'   change to the package's own code (a method, a shared calculation helper, an
+#'   output formatter) changes the fingerprint and therefore every cache key
+#'   built from it.
+#' @param root *\[character, optional\]* Module root to fingerprint. Defaults to
+#'   `PATHS$PROJECT_ROOT`.
+#' @return *\[character\]* A single hash, or `NA_character_` when the root does
+#'   not exist.
+package_source_fingerprint <- function(root = PATHS$PROJECT_ROOT) {
+  cache_key <- paste0("tree:", root)
+  cached <- .state[[cache_key]]
+  if (!is.null(cached)) {
+    return(cached)
+  }
+
+  if (!dir.exists(root)) {
+    fingerprint <- NA_character_
+  } else {
+    files <- list.files(root, pattern = "\\.[Rr]$", recursive = TRUE, full.names = TRUE)
+    fingerprint <- hash_source_files(files, root)
+  }
+
+  .state[[cache_key]] <- fingerprint
+  fingerprint
+}
+
+#' @title Hash a single runtime method's source file
+#' @description Hash the source file backing a runtime method, identified by its
+#'   stage (method files are named `<stage>.R`). Editing the method changes the
+#'   hash and invalidates only that method's cache, whereas
+#'   `package_source_fingerprint()` invalidates everything. Both feed the
+#'   signature: the per-method hash keeps the common case precise, the tree
+#'   fingerprint covers the shared code a method calls into.
+#' @param stage *\[character\]* The method's stage label.
+#' @param methods_dir *\[character, optional\]* Directory holding the method
+#'   files. Defaults to `PATHS$DIR_METHODS`.
+#' @return *\[character\]* A single hash, or `NA_character_` when no matching
+#'   file exists.
+method_source_hash <- function(stage, methods_dir = PATHS$DIR_METHODS) {
+  if (!is.character(stage) || length(stage) != 1L || is.na(stage)) {
+    return(NA_character_)
+  }
+
+  cache_key <- paste0("method:", methods_dir, ":", stage)
+  cached <- .state[[cache_key]]
+  if (!is.null(cached)) {
+    return(cached)
+  }
+
+  path <- file.path(methods_dir, paste0(stage, ".R"))
+  hash <- if (file.exists(path)) hash_source_files(path, methods_dir) else NA_character_
+
+  .state[[cache_key]] <- hash
+  hash
+}
+
+#' @title Forget memoised source fingerprints
+#' @description Drop the session-scoped fingerprint cache. Used by tests that
+#'   edit source files and need the next fingerprint to reflect the change.
+#' @return `NULL`, invisibly.
+#' @keywords internal
+forget_source_fingerprints <- function() {
+  rm(list = ls(envir = .state, all.names = TRUE), envir = .state)
+  invisible(NULL)
+}
+
+box::export(
+  forget_source_fingerprints,
+  hash_source_files,
+  method_source_hash,
+  package_source_fingerprint
+)

--- a/inst/artma/modules/runtime_methods.R
+++ b/inst/artma/modules/runtime_methods.R
@@ -82,7 +82,9 @@ METHOD_META_ATTR <- "artma_method_meta"
 #' @param label *\[character, optional\]* Human-readable display label. Defaults
 #'   to `stage`.
 #' @param key_builder *\[function, optional\]* Cache signature builder. Defaults
-#'   to the standard data cache signature.
+#'   to the standard data cache signature. Whatever it returns, the method's own
+#'   source hash is appended, so editing a method file invalidates that method's
+#'   cache without disturbing the others.
 #' @param ... *\[any\]* Extra arguments forwarded to `cache_cli_runner`.
 #' @return *\[function\]* The cached `run` wrapper, carrying the method metadata
 #'   in its `artma_method_meta` attribute.
@@ -95,14 +97,27 @@ register_runtime_method <- function(impl, stage,
                                     key_builder = NULL, ...) {
   box::use(
     artma / libs / infrastructure / cache[cache_cli_runner],
+    artma / libs / infrastructure / source_fingerprint[method_source_hash],
     artma / data / cache_signatures[build_data_cache_signature]
   )
 
-  if (is.null(key_builder)) {
-    key_builder <- function(...) build_data_cache_signature()
+  base_key_builder <- key_builder
+  if (is.null(base_key_builder)) {
+    base_key_builder <- function(...) build_data_cache_signature()
   }
 
-  run <- cache_cli_runner(impl, stage = stage, key_builder = key_builder, ...)
+  # The data frame and any upstream `<dependency>_result` reach the cache key
+  # as ordinary call arguments, which `memoise` hashes; the signature adds the
+  # inputs that are not arguments (options, data source, package source).
+  signature_builder <- function(...) {
+    signature <- base_key_builder(...)
+    if (!is.list(signature)) {
+      signature <- list(value = signature)
+    }
+    c(signature, list(method_source = method_source_hash(stage)))
+  }
+
+  run <- cache_cli_runner(impl, stage = stage, key_builder = signature_builder, ...)
 
   attr(run, METHOD_META_ATTR) <- list(
     stage = stage,

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -967,10 +967,22 @@ verbose:
 cache:
   use_cache:
     type: "logical"
-    default: false
+    default: true
     help: |
-      If `TRUE`, use caching to speed up the package.
-      If `FALSE`, do not use caching.
+      If `TRUE` (the default), reuse results from previous runs so that
+      rerunning an analysis with unchanged inputs is near-instant.
+      If `FALSE`, recompute everything on every run.
+
+      A cached result is reused only when all of the following match the run
+      that produced it:
+        {cli::symbol$bullet} the data frame handed to the method, and the results of the methods it depends on
+        {cli::symbol$bullet} the data source path and its modification time
+        {cli::symbol$bullet} every user-authored {.code artma.*} option and data config entry
+        {cli::symbol$bullet} the {.emph artma} version and the package source code
+      Cached graphics are also checked: if a plot file a run produced is no
+      longer on disk, the method is rerun so the file is written again.
+
+      Clear the cache at any time with {.code make clear-cache}.
 
   max_age:
     type: "integer"
@@ -979,6 +991,9 @@ cache:
       Maximum age of cached artifacts in seconds.
       Defaults to 3600 seconds (1 hour).
       Cached entries older than this are recomputed on access.
+      This is a backstop for inputs that change without the cache key
+      noticing (for example a data file edited in place with its modification
+      time preserved). Set it to a larger value to keep results longer.
 
 temp:
   # A set of options that are only set at runtime but never stored in the options file.

--- a/inst/artma/visualization/export.R
+++ b/inst/artma/visualization/export.R
@@ -78,7 +78,8 @@ build_export_filename <- function(base_name, factor_by, index = NULL, extension 
 save_plot <- function(plot, path, width = 800, height = 1100, scale = 1, units = "px", dpi = 150) {
   box::use(
     artma / libs / core / validation[validate],
-    artma / libs / core / utils[get_verbosity]
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / infrastructure / output_files[record_output_file]
   )
 
   validate(
@@ -104,6 +105,11 @@ save_plot <- function(plot, path, width = 800, height = 1100, scale = 1, units =
     units = units,
     dpi = dpi
   )
+
+  # Graphics are a side effect of the method run, not part of its return value,
+  # so record them: a cache hit that replays the value must not leave the
+  # results directory without its plots.
+  record_output_file(path)
 
   if (get_verbosity() >= 4) {
     cli::cli_alert_success("Exported plot to {.file {path}}")
@@ -134,7 +140,8 @@ save_plot <- function(plot, path, width = 800, height = 1100, scale = 1, units =
 save_plot_html <- function(plot, path) {
   box::use(
     artma / libs / core / validation[validate],
-    artma / libs / core / utils[get_verbosity]
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / infrastructure / output_files[record_output_file]
   )
 
   validate(ggplot2::is_ggplot(plot), is.character(path))
@@ -157,6 +164,8 @@ save_plot_html <- function(plot, path) {
 
   widget <- plotly::ggplotly(plot)
   htmlwidgets::saveWidget(widget, file = path, selfcontained = TRUE)
+
+  record_output_file(path)
 
   if (get_verbosity() >= 4) {
     cli::cli_alert_success("Exported interactive plot to {.file {path}}")

--- a/tests/testthat/test-cache-signature-components.R
+++ b/tests/testthat/test-cache-signature-components.R
@@ -1,0 +1,255 @@
+box::use(
+  testthat[test_that, expect_equal, expect_false, expect_true, expect_identical],
+  testing / fixtures / index[FIXTURES]
+)
+
+# Caching is on by default, so every component of the cache signature needs a
+# test that proves a change to it produces a miss. A stale hit is a correctness
+# bug, not a performance one.
+
+cache_test_options <- function() {
+  list(
+    "artma.cache.use_cache" = TRUE,
+    "artma.cache.max_age" = 3600,
+    "artma.verbose" = 1
+  )
+}
+
+# A registered method whose runs are counted and whose received cache signature
+# is recorded, wired to an isolated in-memory cache.
+make_counted_method <- function(stage = "cache_signature_demo") {
+  box::use(artma / modules / runtime_methods[register_runtime_method])
+
+  state <- new.env(parent = emptyenv())
+  state$runs <- 0L
+  state$signature <- NULL
+
+  impl <- function(df, bma_result = NULL, cache_signature = NULL) {
+    state$runs <- state$runs + 1L
+    state$signature <- cache_signature
+    list(rows = nrow(df))
+  }
+
+  state$run <- register_runtime_method(
+    impl,
+    stage = stage,
+    cache = memoise::cache_memory()
+  )
+
+  state
+}
+
+test_that("identical inputs reuse the cached method result", {
+  FIXTURES$local_cli_silence()
+  withr::local_options(cache_test_options())
+
+  method <- make_counted_method()
+  df <- data.frame(effect = c(0.1, 0.2), se = c(0.01, 0.02))
+
+  testthat::capture_messages(first <- method$run(df = df))
+  testthat::capture_messages(second <- method$run(df = df))
+
+  expect_equal(method$runs, 1L)
+  expect_identical(first, second)
+})
+
+test_that("a changed data frame misses the cache", {
+  FIXTURES$local_cli_silence()
+  withr::local_options(cache_test_options())
+
+  method <- make_counted_method()
+
+  testthat::capture_messages(method$run(df = data.frame(effect = 0.1, se = 0.01)))
+  testthat::capture_messages(method$run(df = data.frame(effect = 0.9, se = 0.01)))
+
+  expect_equal(method$runs, 2L)
+})
+
+test_that("a changed artma option misses the cache", {
+  FIXTURES$local_cli_silence()
+  withr::local_options(cache_test_options())
+
+  method <- make_counted_method()
+  df <- data.frame(effect = 0.1, se = 0.01)
+
+  withr::with_options(
+    list("artma.output.number_of_decimals" = 3),
+    testthat::capture_messages(method$run(df = df))
+  )
+  expect_equal(method$runs, 1L)
+
+  # An option the method never reads directly still changes the key: the
+  # signature covers the whole artma.* group, deliberately erring towards
+  # recomputation.
+  withr::with_options(
+    list("artma.output.number_of_decimals" = 5),
+    testthat::capture_messages(method$run(df = df))
+  )
+  expect_equal(method$runs, 2L)
+})
+
+test_that("a changed upstream dependency result misses the cache", {
+  FIXTURES$local_cli_silence()
+  withr::local_options(cache_test_options())
+
+  method <- make_counted_method()
+  df <- data.frame(effect = 0.1, se = 0.01)
+
+  bma_first <- list(tables = list(coefficients = data.frame(term = "x", estimate = 1)))
+  bma_second <- list(tables = list(coefficients = data.frame(term = "x", estimate = 2)))
+
+  testthat::capture_messages(method$run(df = df, bma_result = bma_first))
+  expect_equal(method$runs, 1L)
+
+  testthat::capture_messages(method$run(df = df, bma_result = bma_first))
+  expect_equal(method$runs, 1L)
+
+  # A changed BMA result must not be served the estimate built on the old one.
+  testthat::capture_messages(method$run(df = df, bma_result = bma_second))
+  expect_equal(method$runs, 2L)
+})
+
+test_that("the method source hash is part of the cache signature", {
+  FIXTURES$local_cli_silence()
+  withr::local_options(cache_test_options())
+
+  df <- data.frame(effect = 0.1, se = 0.01)
+
+  # "bma" and "fma" name real method files, so their hashes are resolvable and
+  # must differ from one another.
+  bma_method <- make_counted_method(stage = "bma")
+  fma_method <- make_counted_method(stage = "fma")
+
+  testthat::capture_messages(bma_method$run(df = df))
+  testthat::capture_messages(fma_method$run(df = df))
+
+  expect_true(is.character(bma_method$signature$method_source))
+  expect_false(is.na(bma_method$signature$method_source))
+  expect_false(
+    identical(bma_method$signature$method_source, fma_method$signature$method_source)
+  )
+})
+
+test_that("method_source_hash tracks edits to the method file", {
+  box::use(
+    artma / libs / infrastructure / source_fingerprint[
+      forget_source_fingerprints, method_source_hash
+    ]
+  )
+
+  methods_dir <- withr::local_tempdir()
+  method_file <- file.path(methods_dir, "demo.R")
+
+  writeLines("demo <- function(df) nrow(df)", method_file)
+  before <- method_source_hash("demo", methods_dir = methods_dir)
+
+  writeLines("demo <- function(df) nrow(df) * 2L", method_file)
+  forget_source_fingerprints()
+  after <- method_source_hash("demo", methods_dir = methods_dir)
+
+  expect_false(identical(before, after))
+  expect_true(is.na(method_source_hash("no_such_method", methods_dir = methods_dir)))
+})
+
+test_that("package_source_fingerprint tracks edits anywhere in the source tree", {
+  box::use(
+    artma / libs / infrastructure / source_fingerprint[
+      forget_source_fingerprints, package_source_fingerprint
+    ]
+  )
+
+  root <- withr::local_tempdir()
+  dir.create(file.path(root, "libs"), recursive = TRUE)
+  writeLines("a <- 1", file.path(root, "top.R"))
+  writeLines("helper <- function() 1", file.path(root, "libs", "helper.R"))
+
+  before <- package_source_fingerprint(root)
+
+  # A shared helper a method calls into, not the method itself.
+  writeLines("helper <- function() 2", file.path(root, "libs", "helper.R"))
+  forget_source_fingerprints()
+  after <- package_source_fingerprint(root)
+
+  expect_false(identical(before, after))
+})
+
+test_that("a cache hit whose recorded plot file vanished recomputes", {
+  box::use(
+    artma / libs / infrastructure / cache[cache_cli_runner],
+    artma / libs / infrastructure / output_files[record_output_file]
+  )
+
+  FIXTURES$local_cli_silence()
+  withr::local_options(cache_test_options())
+
+  plot_dir <- withr::local_tempdir()
+  plot_path <- file.path(plot_dir, "demo_plot.png")
+
+  runs <- 0L
+  impl <- function(df) {
+    runs <<- runs + 1L
+    writeLines("plot", plot_path)
+    record_output_file(plot_path)
+    "done"
+  }
+
+  cached <- cache_cli_runner(
+    impl,
+    stage = "plot_replay",
+    key_builder = function(df) list(rows = nrow(df)),
+    cache = memoise::cache_memory()
+  )
+
+  df <- data.frame(x = 1)
+
+  testthat::capture_messages(cached(df))
+  expect_equal(runs, 1L)
+  expect_true(file.exists(plot_path))
+
+  # A plain hit: the file is still there, nothing to redo.
+  testthat::capture_messages(cached(df))
+  expect_equal(runs, 1L)
+
+  # The results directory was cleared between runs. Replaying the return value
+  # alone would report success with the plot missing.
+  file.remove(plot_path)
+  testthat::capture_messages(cached(df))
+  expect_equal(runs, 2L)
+  expect_true(file.exists(plot_path))
+})
+
+test_that("use_cache is honoured at call time, not at wrap time", {
+  box::use(artma / libs / infrastructure / cache[cache_cli_runner])
+
+  FIXTURES$local_cli_silence()
+
+  runs <- 0L
+  impl <- function(x) {
+    runs <<- runs + 1L
+    x
+  }
+
+  # Wrapped while caching is off, as happens when a method module loads before
+  # the options file is applied.
+  cached <- withr::with_options(
+    list("artma.cache.use_cache" = FALSE),
+    cache_cli_runner(
+      impl,
+      stage = "call_time_gate",
+      key_builder = function(x) list(value = x),
+      cache = memoise::cache_memory()
+    )
+  )
+
+  withr::with_options(list("artma.cache.use_cache" = FALSE), {
+    testthat::capture_messages(cached(1))
+    testthat::capture_messages(cached(1))
+  })
+  expect_equal(runs, 2L)
+
+  withr::with_options(list("artma.cache.use_cache" = TRUE), {
+    testthat::capture_messages(cached(1))
+    testthat::capture_messages(cached(1))
+  })
+  expect_equal(runs, 3L)
+})


### PR DESCRIPTION
Interactive meta-analysis is rerun-heavy, so `cache.use_cache` now defaults to `true`. The bulk of this PR is the work that had to come first: making invalidation trustworthy enough that a default-on cache cannot serve a stale result.

## Audit: what was already in the key

`memoise` hashes the arguments of the memoised call, so these were already covered:

- the prepared data frame (passed as `df`)
- upstream dependency results (the orchestrator passes them as `<dependency>_result`, so a changed BMA result already missed the `best_practice_estimate` cache)

`build_data_cache_signature()` covered the rest of the user-controlled inputs: data source path and mtime, user-authored data config, the whole user-authored `artma.*` option group (so `artma.methods.<name>.*`, `artma.output.*`, and `artma.calc.*` are all in), and the package version.

`memoise` also folds in the memoised function's body, but that body is the fixed `worker` closure in `cache.R` and is identical for every stage. Stage isolation comes from the `stage` entry in the signature, not from `memoise`.

## Gaps closed

**1. Source code was invisible to the key.** The implementation is captured in a closure, not in the hashed body, so editing a method left its cached results in place. Added `libs/infrastructure/source_fingerprint.R`:

- `package_source_fingerprint()` hashes every R file under `inst/artma`, folded into `build_data_cache_signature()`. This covers the shared code a method calls into (calc helpers, formatters), which a per-method hash alone would miss.
- `method_source_hash(stage)` hashes the single method file; `register_runtime_method()` appends it, so the common case of editing one method invalidates that method alone.

Both are memoised per session, which matches when a source edit actually takes effect (`box` caches loaded modules for the session too).

**2. Plot files were not replayed on a hit.** Methods write graphics during execution, so a cache hit skipped the writes. Because the output directory is stable across runs, files from the previous run usually survive, but a cleared results directory produced a run reporting success with its plots missing. Added `libs/infrastructure/output_files.R`: `save_plot()` and `save_plot_html()` call `record_output_file()`, `cache_cli()` brackets each cold run and stores the recorded paths on the artifact, and a hit whose recorded files have gone missing is dropped and recomputed. Verified end to end: deleting the exported PNG makes the next call rerun and rewrite it.

**3. `use_cache` was read at wrap time.** `cache_cli()` returned the unwrapped function if caching was off when the module loaded, which for runtime methods is before the options file has settled. It is now read on every call, so toggling the option mid-session takes effect immediately. The memoised layer is built lazily, which also stops the cache directory from being created for sessions that never cache.

## Behavioural notes

- `max_age` is unchanged (3600s default) and still enforced, but is now documented as a backstop for inputs that change without the signature noticing (a data file edited in place with its mtime preserved), rather than as the guard against stale dev builds.
- The signature deliberately keys on the whole `artma.*` group rather than a per-method subset. That over-invalidates, which is the safe direction: a needless recomputation costs time, a stale hit costs correctness.
- `make clear-cache` works unchanged.
- On a filesystem-cache hit the returned ggplot objects are deserialized copies, so `identical()` against the cold-run result is `FALSE` while `tables` and `meta` match exactly and the plots still build. That is pre-existing cache behaviour, not new here.

## Tests

New `tests/testthat/test-cache-signature-components.R`, one per signature component: same inputs hit; changed data misses; changed option misses; changed upstream `bma_result` misses; the method source hash is present and differs per method; `method_source_hash` and `package_source_fingerprint` both track file edits. Plus the plot-file replay path and the call-time `use_cache` gate.

`make test` passes (1627 tests, 0 failures), `make lint` is clean. `make test-e2e` fails to build locally for an unrelated reason (stale `src/*.o` against a mismatched R version); nothing in this change touches compiled code.
