### PR TITLE
perf(linear): fast-path random effects bootstrap via Swamy-Arora replication

### DIFF
--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -135,9 +135,6 @@ make_boot_estimate_weighted_ols <- function(weight_column) {
 # original id, so they merge into one group during demeaning, exactly as plm
 # treats the resampled frame. The overall intercept is what
 # plm::within_intercept() returns: mean(y) - slope * mean(x).
-#
-# Random effects has no fast path: Swamy-Arora variance components must be
-# recomputed per resample, so it stays on the `fit` + `boot_coefs` fallback.
 boot_estimate_within <- function(data, rows) {
   y <- data$effect[rows]
   x <- data$se[rows]
@@ -146,6 +143,77 @@ boot_estimate_within <- function(data, rows) {
   x_demeaned <- x - stats::ave(x, group)
   slope <- stats::.lm.fit(cbind(x_demeaned), y_demeaned)$coefficients[[1L]]
   c(effect = mean(y) - slope * mean(x), publication_bias = slope)
+}
+
+# Random effects estimator: feasible GLS via the theta (quasi-demeaning)
+# transformation with Swamy-Arora variance components, replicating
+# plm::plm(model = "random") exactly. With one regressor plus intercept,
+# plm's ercomp (method "swar", effect "individual") reduces to:
+#   sigma_nu^2  = within SSR / (O - N - 1)
+#   sigma_eta^2 = (sum_i T_i e_Bi^2 - (N - 2) sigma_nu^2) / (O - tr(A^-1 B))
+# where O is the observation count, N the group count, e_Bi the residuals of
+# the T_i-weighted between regression, A = sum_i T_i m_i m_i' and
+# B = sum_i T_i^2 m_i m_i' with m_i = (1, xbar_i). plm's balanced-panel
+# branch (dfcor = c(2, 2)) is the algebraic special case of these formulas,
+# so no separate branch is needed. Negative components clamp to zero, then
+# theta_i = 1 - sqrt(sigma_nu^2 / (T_i sigma_eta^2 + sigma_nu^2)) and OLS on
+# the quasi-demeaned data yields the GLS estimates.
+#
+# The guards mirror the conditions under which plm errors, so degenerate
+# resamples fail identically on both paths: plm's swar_Between_check rejects
+# fewer than three distinct groups, and its within fit rejects a regressor
+# with no within-group variation ("empty model").
+boot_estimate_re <- function(data, rows) {
+  y <- data$effect[rows]
+  x <- data$se[rows]
+  group <- droplevels(data$study_id[rows])
+
+  n_obs <- length(y)
+  n_groups <- nlevels(group)
+  if (n_groups < 3L) {
+    cli::cli_abort("Swamy-Arora needs at least three distinct clusters")
+  }
+  if (n_obs - n_groups < 2L) {
+    cli::cli_abort("Not enough within-group observations for Swamy-Arora")
+  }
+
+  y_mean <- stats::ave(y, group)
+  x_mean <- stats::ave(x, group)
+  y_demeaned <- y - y_mean
+  x_demeaned <- x - x_mean
+  if (sum(x_demeaned^2) == 0) {
+    cli::cli_abort("No within-group variation in se")
+  }
+
+  within_slope <- stats::.lm.fit(cbind(x_demeaned), y_demeaned)$coefficients[[1L]]
+  within_ssr <- sum((y_demeaned - within_slope * x_demeaned)^2)
+  idios_var <- within_ssr / (n_obs - n_groups - 1)
+
+  group_codes <- as.integer(group)
+  sizes_by_obs <- tabulate(group_codes, nbins = n_groups)[group_codes]
+  first_in_group <- !duplicated(group_codes)
+  group_sizes <- sizes_by_obs[first_in_group]
+  group_x <- x_mean[first_in_group]
+  group_y <- y_mean[first_in_group]
+
+  between_fit <- stats::lm.wfit(cbind(1, group_x), group_y, group_sizes)
+  between_quad <- sum(group_sizes * between_fit$residuals^2)
+
+  m <- cbind(1, group_x)
+  a_mat <- crossprod(m * sqrt(group_sizes))
+  b_mat <- crossprod(m * group_sizes)
+  id_eta_weight <- n_obs - sum(diag(solve(a_mat, b_mat)))
+  id_var <- (between_quad - (n_groups - 2) * idios_var) / id_eta_weight
+
+  sigma2 <- c(idios_var, id_var)
+  sigma2[sigma2 < 0] <- 0
+
+  theta <- 1 - sqrt(sigma2[[1L]] / (sizes_by_obs * sigma2[[2L]] + sigma2[[1L]]))
+  fit <- stats::lm.fit(
+    cbind(1 - theta, x - theta * x_mean),
+    y - theta * y_mean
+  )
+  c(effect = fit$coefficients[[1L]], publication_bias = fit$coefficients[[2L]])
 }
 
 #' @title Compute bootstrap confidence intervals
@@ -395,6 +463,7 @@ linear_model_specs <- function() {
       fit = function(df) plm::plm(effect ~ se, data = df, model = "random", index = "study_id"),
       tidy = tidy_plm_generic,
       boot_coefs = boot_coefs_intercept_slope,
+      boot_estimate = boot_estimate_re,
       supports_bootstrap = TRUE
     ),
     list(

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -185,7 +185,7 @@ test_that("bootstrap fast paths match slow-path refits on resampled data", {
 
   specs <- linear_model_specs()
   names(specs) <- vapply(specs, function(spec) spec$name, character(1))
-  fast_path_specs <- c("ols", "fe", "ols_study_weighted", "ols_precision_weighted")
+  fast_path_specs <- c("ols", "fe", "re", "ols_study_weighted", "ols_precision_weighted")
   compared <- stats::setNames(integer(length(fast_path_specs)), fast_path_specs)
 
   set.seed(1234)
@@ -252,6 +252,134 @@ test_that("within fast path merges duplicated resampled clusters like plm", {
     unname(plm::within_intercept(model)[[1L]]),
     tolerance = 1e-12
   )
+})
+
+test_that("random effects fast path matches plm on duplicated resampled clusters", {
+  skip_if_not_installed("plm")
+
+  df <- make_demo_data()
+  df$study_id <- droplevels(factor(df$study_id))
+  cluster_splits <- split(seq_len(nrow(df)), df$study_id)
+
+  specs <- linear_model_specs()
+  names(specs) <- vapply(specs, function(spec) spec$name, character(1))
+  re_spec <- specs[["re"]]
+
+  # Force duplicated clusters so the merge semantics are actually exercised.
+  rows <- unlist(
+    cluster_splits[c("S1", "S1", "S2", "S3", "S3", "S3", "S5")],
+    use.names = FALSE
+  )
+  boot_data <- df[rows, , drop = FALSE]
+
+  fast <- re_spec$boot_estimate(df, rows)
+  model <- plm::plm(effect ~ se, data = boot_data, model = "random", index = "study_id")
+
+  expect_equal(
+    fast[["effect"]],
+    unname(stats::coef(model)[["(Intercept)"]]),
+    tolerance = 1e-12
+  )
+  expect_equal(
+    fast[["publication_bias"]],
+    unname(stats::coef(model)[["se"]]),
+    tolerance = 1e-12
+  )
+})
+
+test_that("random effects fast path matches plm on unbalanced clusters", {
+  skip_if_not_installed("plm")
+
+  set.seed(7)
+  sizes <- c(2L, 3L, 5L, 8L, 13L, 21L, 4L, 30L, 2L, 9L)
+  study_ids <- rep(paste0("U", seq_along(sizes)), times = sizes)
+  se_vals <- runif(sum(sizes), min = 0.05, max = 0.15)
+  df <- data.frame(
+    study_id = droplevels(factor(study_ids)),
+    effect = rnorm(sum(sizes), mean = 0.2, sd = 0.05),
+    se = se_vals
+  )
+  cluster_splits <- split(seq_len(nrow(df)), df$study_id)
+
+  specs <- linear_model_specs()
+  names(specs) <- vapply(specs, function(spec) spec$name, character(1))
+  re_spec <- specs[["re"]]
+
+  set.seed(99)
+  for (replication in seq_len(5L)) {
+    rows <- resample_cluster_rows(nrow(df), cluster_splits)
+    boot_data <- df[rows, , drop = FALSE]
+
+    fast <- tryCatch(re_spec$boot_estimate(df, rows), error = function(e) NULL)
+    model <- tryCatch(
+      plm::plm(effect ~ se, data = boot_data, model = "random", index = "study_id"),
+      error = function(e) NULL
+    )
+
+    if (is.null(model)) {
+      expect_true(is.null(fast), info = paste("replication", replication))
+      next
+    }
+
+    expect_equal(
+      fast[c("effect", "publication_bias")],
+      stats::setNames(
+        unname(stats::coef(model)[c("(Intercept)", "se")]),
+        c("effect", "publication_bias")
+      ),
+      tolerance = 1e-12,
+      info = paste("replication", replication)
+    )
+  }
+})
+
+test_that("random effects fast path fails on degenerate resamples exactly like plm", {
+  skip_if_not_installed("plm")
+
+  df <- make_demo_data()
+  df$study_id <- droplevels(factor(df$study_id))
+  cluster_splits <- split(seq_len(nrow(df)), df$study_id)
+
+  specs <- linear_model_specs()
+  names(specs) <- vapply(specs, function(spec) spec$name, character(1))
+  re_spec <- specs[["re"]]
+
+  degenerate_draws <- list(
+    single_cluster = c("S2", "S2", "S2"),
+    two_clusters = c("S2", "S5")
+  )
+
+  for (case in names(degenerate_draws)) {
+    rows <- unlist(cluster_splits[degenerate_draws[[case]]], use.names = FALSE)
+    boot_data <- df[rows, , drop = FALSE]
+
+    fast <- tryCatch(re_spec$boot_estimate(df, rows), error = function(e) NULL)
+    # plm warns about a perfect between fit before erroring on these draws.
+    model <- suppressWarnings(tryCatch(
+      plm::plm(effect ~ se, data = boot_data, model = "random", index = "study_id"),
+      error = function(e) NULL
+    ))
+
+    expect_true(is.null(model), info = case)
+    expect_true(is.null(fast), info = case)
+  }
+
+  # All-singleton clusters: plm rejects the within model as empty.
+  singleton_df <- data.frame(
+    study_id = droplevels(factor(paste0("P", 1:8))),
+    effect = rnorm(8, mean = 0.2, sd = 0.05),
+    se = runif(8, min = 0.05, max = 0.15)
+  )
+  rows <- seq_len(nrow(singleton_df))
+
+  fast <- tryCatch(re_spec$boot_estimate(singleton_df, rows), error = function(e) NULL)
+  model <- tryCatch(
+    plm::plm(effect ~ se, data = singleton_df, model = "random", index = "study_id"),
+    error = function(e) NULL
+  )
+
+  expect_true(is.null(model))
+  expect_true(is.null(fast))
 })
 
 test_that("panel models are skipped with a clear message when plm is unavailable", {


### PR DESCRIPTION
## Summary

Follow-up to #285, which added `boot_estimate(data, rows)` fast paths for the OLS, weighted OLS, and FE specs but left Random Effects refitting `plm::plm(model = "random")` in every bootstrap replication (~36 ms per rep). This PR gives RE the same treatment by replicating plm's Swamy-Arora variance components exactly.

## How it works

`boot_estimate_re` performs feasible GLS via the theta (quasi-demeaning) transformation. For the intercept plus one regressor case, plm's `ercomp` (method `swar`, effect `individual`, unbalanced `dfcor = c(3, 3)`) reduces to:

- idiosyncratic variance: within SSR / (O - N - 1)
- individual variance: (sum_i T_i e_Bi^2 - (N - 2) sigma_nu^2) / (O - tr(A^-1 B)), where e_Bi are residuals of the T_i-weighted between regression, A = sum_i T_i m_i m_i', B = sum_i T_i^2 m_i m_i', m_i = (1, xbar_i)

plm's balanced-panel branch (`dfcor = c(2, 2)`) is the algebraic special case of the unbalanced formulas (tr(A^-1 B) = 2T there), so a single code path covers both. Negative components clamp to zero as in plm, then per-group theta and an OLS fit on the quasi-demeaned data yield the GLS estimates.

Resampled duplicated cluster ids merge into one group (established in #285), which the per-replication group statistics handle naturally: merged groups keep their means and scale their within cross-products.

Degenerate resamples fail identically on both paths. The guards mirror plm's own failure conditions: fewer than three distinct clusters (plm's `swar_Between_check`), too few within-group observations (singular `ercomp` system), and no within-group variation in `se` (plm's "empty model").

## Correctness

Tested against `plm::plm(model = "random")` refits on the same resampled frames at tolerance 1e-12 (observed differences are ~1e-15):

- seeded cluster resamples on balanced data (shared fast-path test, now including `re`)
- forced duplicate clusters
- strongly unbalanced cluster sizes (2 to 30 per cluster), plus duplicates
- degenerate draws (one cluster, two clusters, all-singleton groups): both paths error

The seed-identical bootstrap CI regression test with reference values from the pre-optimization implementation still passes unchanged.

## Benchmark

`linear_tests` end-to-end on `create_mock_df(nrow = 3000L, n_studies = 200L, seed = 42L)` with 100 bootstrap replications, same machine, warm cache disabled:

| | elapsed |
|---|---|
| before (master, #285) | 3.22 s |
| after | 0.42 s |

(Reference figures from the task were ~5.2 s before and ~1.5 s expected after on a slower machine; the RE refits dominated the remaining runtime and are now gone.)

## Checks

- `styler` clean, `make lint` clean
- `make test-filter FILTER=linear`: 134 pass
- `make test`: 1650 pass, 0 fail