### PR TITLE
feat(linear): precheck panel specs and skip with plain-language reasons

### DIFF
--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -410,6 +410,56 @@ boot_coefs_within <- function(model) {
   )
 }
 
+# Spec prechecks -------------------------------------------------------------
+#
+# Each panel spec carries a `precheck(prepared)` function evaluated after
+# `prepare_linear_data()`. It returns NULL when the prepared data can support
+# the estimator, or a plain-language skip reason. This turns raw plm errors
+# (e.g. "empty model", "model not estimable") into actionable messages; the
+# tryCatch around `spec$fit` remains as a fallback for anything missed here.
+
+has_within_cluster_variation <- function(data, value_column, cluster_column) {
+  groups <- split(data[[value_column]], data[[cluster_column]])
+  any(vapply(groups, function(x) length(unique(x)) > 1L, logical(1)))
+}
+
+precheck_fe <- function(prepared) {
+  if (!has_within_cluster_variation(prepared$data, "se", "study_id")) {
+    return(cli::format_inline(
+      "Cannot fit {.emph Fixed Effects}: {.field se} does not vary within any {.field study_id} cluster"
+    ))
+  }
+  NULL
+}
+
+precheck_be <- function(prepared) {
+  if (prepared$n_clusters < 3L) {
+    return(cli::format_inline(
+      "Not enough clusters to fit {.emph Between Effects}: at least 3 distinct {.field study_id} values are needed, found {prepared$n_clusters}"
+    ))
+  }
+  NULL
+}
+
+precheck_re <- function(prepared) {
+  if (prepared$n_clusters < 3L) {
+    return(cli::format_inline(
+      "Not enough clusters to fit {.emph Random Effects}: at least 3 distinct {.field study_id} values are needed, found {prepared$n_clusters}"
+    ))
+  }
+  if (prepared$n_obs <= prepared$n_clusters + 1L) {
+    return(cli::format_inline(
+      "Not enough observations to fit {.emph Random Effects}: more than {prepared$n_clusters + 1L} rows are needed with {prepared$n_clusters} {.field study_id} clusters, found {prepared$n_obs}"
+    ))
+  }
+  if (!has_within_cluster_variation(prepared$data, "se", "study_id")) {
+    return(cli::format_inline(
+      "Cannot fit {.emph Random Effects}: {.field se} does not vary within any {.field study_id} cluster"
+    ))
+  }
+  NULL
+}
+
 linear_model_specs <- function() {
   list(
     list(
@@ -433,6 +483,7 @@ linear_model_specs <- function() {
       cluster_column = "study_id",
       terms = c("effect", "publication_bias"),
       required_packages = "plm",
+      precheck = precheck_fe,
       fit = function(df) plm::plm(effect ~ se, data = df, model = "within", index = "study_id"),
       tidy = tidy_plm_within,
       boot_coefs = boot_coefs_within,
@@ -447,6 +498,7 @@ linear_model_specs <- function() {
       cluster_column = "study_id",
       terms = c("effect", "publication_bias"),
       required_packages = "plm",
+      precheck = precheck_be,
       fit = function(df) plm::plm(effect ~ se, data = df, model = "between", index = "study_id"),
       tidy = tidy_plm_generic,
       boot_coefs = boot_coefs_intercept_slope,
@@ -460,6 +512,7 @@ linear_model_specs <- function() {
       cluster_column = "study_id",
       terms = c("effect", "publication_bias"),
       required_packages = "plm",
+      precheck = precheck_re,
       fit = function(df) plm::plm(effect ~ se, data = df, model = "random", index = "study_id"),
       tidy = tidy_plm_generic,
       boot_coefs = boot_coefs_intercept_slope,
@@ -531,6 +584,14 @@ run_linear_models <- function(df, options, is_pkg_available = NULL) {
     if (prepared$skipped) {
       skipped[[spec$name]] <- list(label = spec$label, reason = prepared$reason)
       next
+    }
+
+    if (!is.null(spec$precheck)) {
+      precheck_reason <- spec$precheck(prepared)
+      if (!is.null(precheck_reason)) {
+        skipped[[spec$name]] <- list(label = spec$label, reason = precheck_reason)
+        next
+      }
     }
 
     model <- tryCatch(spec$fit(prepared$data), error = function(e) {

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -382,6 +382,92 @@ test_that("random effects fast path fails on degenerate resamples exactly like p
   expect_true(is.null(fast))
 })
 
+test_that("two-cluster data skips RE and BE with a plain-language reason", {
+  skip_if_not_installed("plm")
+
+  set.seed(7)
+  df <- make_demo_data()
+  df <- df[df$study_id %in% c("S1", "S2"), , drop = FALSE]
+
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
+  )
+
+  expect_true(all(c("re", "be") %in% names(res$skipped)))
+  expect_true(grepl("Not enough clusters to fit", res$skipped$re$reason))
+  expect_true(grepl("Random Effects", res$skipped$re$reason))
+  expect_true(grepl("found 2", res$skipped$re$reason))
+  expect_true(grepl("Not enough clusters to fit", res$skipped$be$reason))
+  expect_true(grepl("Between Effects", res$skipped$be$reason))
+  expect_false(grepl("not estimable", res$skipped$re$reason))
+
+  expect_true(all(c("ols", "fe") %in% res$coefficients$model))
+})
+
+test_that("singleton-cluster data skips FE and RE with a plain-language reason", {
+  skip_if_not_installed("plm")
+
+  set.seed(7)
+  n_studies <- 6L
+  se_vals <- runif(n_studies, min = 0.05, max = 0.15)
+  df <- data.frame(
+    study_id = paste0("S", seq_len(n_studies)),
+    effect = rnorm(n_studies, mean = 0.2, sd = 0.05),
+    se = se_vals,
+    study_size = sample(20:80, n_studies, replace = TRUE),
+    precision = 1 / se_vals,
+    check.names = FALSE
+  )
+
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
+  )
+
+  expect_true(all(c("fe", "re") %in% names(res$skipped)))
+  expect_true(grepl("does not vary within any", res$skipped$fe$reason))
+  expect_true(grepl("Fixed Effects", res$skipped$fe$reason))
+  expect_true(grepl("Not enough observations to fit", res$skipped$re$reason))
+  expect_true(grepl("Random Effects", res$skipped$re$reason))
+  expect_false(grepl("empty model", res$skipped$fe$reason))
+
+  expect_true(all(c("ols", "be") %in% res$coefficients$model))
+})
+
+test_that("constant within-cluster se skips FE and RE even with many clusters", {
+  skip_if_not_installed("plm")
+
+  df <- make_demo_data()
+  df$se <- stats::ave(df$se, df$study_id)
+
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
+  )
+
+  expect_true(all(c("fe", "re") %in% names(res$skipped)))
+  expect_true(grepl("does not vary within any", res$skipped$fe$reason))
+  expect_true(grepl("does not vary within any", res$skipped$re$reason))
+
+  expect_true(all(c("ols", "be") %in% res$coefficients$model))
+})
+
 test_that("panel models are skipped with a clear message when plm is unavailable", {
   df <- make_demo_data()
 


### PR DESCRIPTION
## Summary

Users running the linear tests on data that cannot support a panel spec previously saw raw plm errors as skip reasons, e.g. "model not estimable: 2 coefficient(s) (incl. intercept) to be estimated but only 2 individual(s) in data..." or "empty model".

This adds per-spec precondition checks in inst/artma/econometric/linear.R, evaluated after prepare_linear_data and before the plm fit:

- **FE**: requires within-cluster variation in se
- **BE**: requires at least 3 distinct study_id clusters
- **RE (Swamy-Arora)**: requires at least 3 clusters, more than n_clusters + 1 observations, and within-cluster se variation

Each failed precheck skips the spec with a cli-formatted plain-language reason in the style of the existing "Not enough observations to fit ..." messages. The tryCatch around spec$fit stays as a fallback for anything the prechecks miss.

The preconditions match those established in #291.

## Tests

New cases in tests/testthat/test-linear-tests.R:

- two-cluster data skips RE and BE with the friendly cluster-count message while OLS and FE still fit
- singleton-cluster data skips FE (no within-cluster se variation) and RE (too few observations) while OLS and BE still fit
- constant within-cluster se skips FE and RE even with many clusters

`make test-filter FILTER=linear` passes (135 tests), `make lint` clean, styled under a UTF-8 locale.