### PR TITLE
fix(cache): record base-graphics plots so cached reruns restore them

### DIFF
--- a/inst/artma/visualization/export.R
+++ b/inst/artma/visualization/export.R
@@ -77,7 +77,10 @@ build_export_filename <- function(base_name, factor_by, index = NULL, extension 
 #' @return NULL (invisibly). Called for its side effect of opening a graphics device.
 #' @keywords internal
 open_png_device <- function(path, width, height, units = "px", res = 90) {
-  box::use(artma / libs / core / validation[validate])
+  box::use(
+    artma / libs / core / validation[validate],
+    artma / libs / infrastructure / output_files[record_output_file]
+  )
 
   validate(
     is.character(path),
@@ -92,6 +95,11 @@ open_png_device <- function(path, width, height, units = "px", res = 90) {
   } else {
     grDevices::png(filename = path, width = width, height = height, units = units, res = res)
   }
+
+  # Base-graphics plots (BMA correlation and model-size charts, the non-linear
+  # diagnostics) never pass through `save_plot()`, so record them here instead.
+  # Without this a cached rerun cannot tell that these files went missing.
+  record_output_file(path)
 
   invisible(NULL)
 }

--- a/tests/testthat/test-cache-signature-components.R
+++ b/tests/testthat/test-cache-signature-components.R
@@ -218,6 +218,33 @@ test_that("a cache hit whose recorded plot file vanished recomputes", {
   expect_true(file.exists(plot_path))
 })
 
+test_that("base-graphics plots are recorded too, not just ggplot exports", {
+  box::use(
+    artma / visualization / export[open_png_device],
+    artma / libs / infrastructure / output_files[
+      begin_output_file_capture, end_output_file_capture
+    ]
+  )
+
+  # BMA and the non-linear diagnostics write PNGs through a graphics device
+  # rather than save_plot(). A real run showed those files staying missing
+  # after a cache hit because nothing recorded them.
+  plot_path <- file.path(withr::local_tempdir(), "device_plot.png")
+
+  capture_id <- begin_output_file_capture()
+  open_png_device(plot_path, width = 800, height = 600)
+  graphics::plot(1:3)
+  grDevices::dev.off()
+  recorded <- end_output_file_capture(capture_id)
+
+  expect_equal(length(recorded), 1L)
+  expect_true(file.exists(recorded))
+  expect_identical(
+    normalizePath(recorded, mustWork = FALSE),
+    normalizePath(plot_path, mustWork = FALSE)
+  )
+})
+
 test_that("use_cache is honoured at call time, not at wrap time", {
   box::use(artma / libs / infrastructure / cache[cache_cli_runner])
 


### PR DESCRIPTION
Follow-up to #290, found by running the default-on cache against real mock data through `artma::artma()`.

## The bug

#290 records exported plot files so a cache hit whose graphics have gone missing recomputes instead of reporting success with an empty results directory. It hooked `save_plot()` and `save_plot_html()`, which covers the ggplot exports.

It missed the base-graphics path: `bma` (correlation and model-size charts) and `nonlinear_tests` write PNGs through `open_png_device()` + `grDevices::dev.off()`, never touching `save_plot()`. Those files were recorded as `files = 0` on the artifact, so the replay guard had nothing to check.

Observed on a real run: after deleting all four exported plots, `funnel_plot` and `best_practice_estimate` recomputed and restored theirs, while `bma`'s two PNGs stayed missing and the run still reported success. That is exactly the regression #290 set out to prevent, just on the path it did not instrument.

## The fix

`record_output_file()` moves to `open_png_device()`, the single choke point for the device-based path. Same run after the fix: all four plots come back (the deleting run takes 3.1s recomputing `bma` and `best_practice_estimate`, against 1.3s fully warm).

Test added: opening a device, drawing, and closing it records exactly one existing file.

## Cache behaviour on a real run, for the record

Sequential run of `effect_summary_stats`, `funnel_plot`, `linear_tests`, `bma`, `best_practice_estimate` over 1000 mock observations:

- cold: 3.3s
- fully warm: 0.8s
- artifact count stops growing after the second run and every method hits from then on

Two things I noticed and did not fix here, worth separate issues:

1. The first rerun after creating an options file always misses. The cold run persists computed columns back into the options file, so the second run's signature differs from the first; from the third run on it is stable. Costs one extra recomputation per new options file, no correctness impact.
2. Only `prepare_data`'s "Using cached results" notice reaches the console. Method-level hit notices do not surface, which makes a warm run look like it recomputed. Suspect the per-method CLI capture/replay layer added with parallel execution swallows them.
