### PR TITLE
fix(run): use a fork-safe graphics device so parallel runs can export plots

### DIFF
--- a/inst/artma/modules/method_execution.R
+++ b/inst/artma/modules/method_execution.R
@@ -15,7 +15,8 @@
 
 box::use(
   artma / libs / core / autonomy[get_autonomy_level, get_default_autonomy_level],
-  artma / libs / core / validation[assert]
+  artma / libs / core / validation[assert],
+  artma / visualization / fork_safety[graphics_survive_fork, with_forked_worker_flag]
 )
 
 #' @title Group methods into dependency layers
@@ -102,12 +103,16 @@ max_parallel_workers <- function() {
 #'   testing; defaults to `parallel::detectCores()`.
 #' @param max_workers *\[numeric, optional\]* Hard ceiling on the worker count.
 #'   Injectable for testing; defaults to `max_parallel_workers()`.
+#' @param graphics_fork_safe *\[logical, optional\]* Whether a forked worker can
+#'   write a plot on this platform. Injectable for testing; defaults to
+#'   `graphics_survive_fork()`.
 #' @return *\[integer\]* The number of workers, at least `1`.
 resolve_worker_count <- function(n_tasks,
                                  is_interactive = NULL,
                                  os_type = NULL,
                                  n_cores = NULL,
-                                 max_workers = NULL) {
+                                 max_workers = NULL,
+                                 graphics_fork_safe = NULL) {
   n_tasks <- as.integer(n_tasks)
   if (is.na(n_tasks) || n_tasks < 2L) {
     return(1L)
@@ -127,6 +132,14 @@ resolve_worker_count <- function(n_tasks,
   if (isTRUE(is_interactive) && !identical(autonomy_level, "autonomous")) {
     # Methods may still prompt at these autonomy levels, and a forked child
     # cannot read from the console.
+    return(1L)
+  }
+
+  # Exporting graphics means opening a raster device in the child. Where that
+  # would abort the worker and no fork-safe device exists, run sequentially
+  # rather than lose the methods that draw.
+  graphics_fork_safe <- graphics_fork_safe %||% graphics_survive_fork()
+  if (isTRUE(getOption("artma.visualization.export_graphics", TRUE)) && !isTRUE(graphics_fork_safe)) {
     return(1L)
   }
 
@@ -259,6 +272,37 @@ replay_captured_output <- function(output) {
   invisible(NULL)
 }
 
+#' @title Describe a forked worker that returned no usable outcome
+#' @description
+#' `parallel::mclapply()` signals a child that terminated abnormally either with
+#' a `try-error` or, when the child was killed outright, with `NULL`. The latter
+#' carries no message at all, so the reported failure would otherwise be an
+#' empty string. Turn both into a diagnostic that names the method and points at
+#' the sequential fallback, which reproduces the fault in the parent where the
+#' real error is visible.
+#' @param outcome *\[any\]* Whatever `mclapply()` returned for the method.
+#' @param method_name *\[character\]* The method that was being run.
+#' @return *\[character\]* A single-line description of the failure.
+#' @keywords internal
+describe_dead_worker <- function(outcome, method_name) {
+  detail <- trimws(paste(as.character(outcome), collapse = " "))
+
+  if (nzchar(detail)) {
+    return(sprintf(
+      "the forked worker running '%s' terminated abnormally: %s", method_name, detail
+    ))
+  }
+
+  sprintf(
+    paste0(
+      "the forked worker running '%s' died without reporting an error ",
+      "(the child process was killed, e.g. by a crash in compiled code or the OS). ",
+      "Re-run with options(artma.general.parallel = FALSE) to see the underlying failure."
+    ),
+    method_name
+  )
+}
+
 #' @title Run one layer of methods
 #' @description
 #' Execute every method in `method_names` through `run_one`, capturing output
@@ -293,23 +337,29 @@ execute_method_layer <- function(method_names, run_one, streams = list(), worker
   if (workers > 1L) {
     outcomes <- parallel::mclapply(
       method_names,
-      run_task,
+      function(method_name) with_forked_worker_flag(run_task(method_name)),
       mc.cores = workers,
       mc.preschedule = FALSE,
       mc.set.seed = TRUE
     )
-    # A worker that dies outright (rather than signalling an R error) comes
-    # back as a try-error; surface it through the same bookkeeping.
-    outcomes <- lapply(outcomes, function(outcome) {
-      if (inherits(outcome, "try-error") || !is.list(outcome)) {
-        return(list(
+    # A worker that dies outright rather than signalling an R error comes back
+    # as a try-error, or as NULL when the child was killed before it could
+    # answer at all. Neither carries a usable message, so describe what
+    # happened instead of reporting an empty failure.
+    outcomes <- Map(
+      function(outcome, method_name) {
+        if (is.list(outcome) && !inherits(outcome, "try-error")) {
+          return(outcome)
+        }
+        list(
           value = NULL,
-          error = trimws(paste(as.character(outcome), collapse = " ")),
+          error = describe_dead_worker(outcome, method_name),
           output = character()
-        ))
-      }
-      outcome
-    })
+        )
+      },
+      outcomes,
+      method_names
+    )
     return(outcomes)
   }
 
@@ -318,6 +368,7 @@ execute_method_layer <- function(method_names, run_one, streams = list(), worker
 
 box::export(
   build_rng_streams,
+  describe_dead_worker,
   execute_method_layer,
   group_methods_into_layers,
   max_parallel_workers,

--- a/inst/artma/visualization/export.R
+++ b/inst/artma/visualization/export.R
@@ -68,6 +68,10 @@ build_export_filename <- function(base_name, factor_by, index = NULL, extension 
 #' substantially faster than the base `grDevices::png` device. Falls back to
 #' `grDevices::png` when `ragg` is not installed.
 #'
+#' Inside a forked method worker on a platform where those devices would abort
+#' the child, a cairo-backed device is used instead. See
+#' `artma/visualization/fork_safety`.
+#'
 #' @param path *\[character\]* Full file path (including filename)
 #' @param width *\[numeric\]* Device width, in `units`
 #' @param height *\[numeric\]* Device height, in `units`
@@ -79,7 +83,8 @@ build_export_filename <- function(base_name, factor_by, index = NULL, extension 
 open_png_device <- function(path, width, height, units = "px", res = 90) {
   box::use(
     artma / libs / core / validation[validate],
-    artma / libs / infrastructure / output_files[record_output_file]
+    artma / libs / infrastructure / output_files[record_output_file],
+    artma / visualization / fork_safety[use_fork_safe_png_device]
   )
 
   validate(
@@ -90,7 +95,12 @@ open_png_device <- function(path, width, height, units = "px", res = 90) {
     is.numeric(res), res > 0
   )
 
-  if (requireNamespace("ragg", quietly = TRUE)) {
+  if (use_fork_safe_png_device()) {
+    grDevices::png(
+      filename = path, width = width, height = height,
+      units = units, res = res, type = "cairo"
+    )
+  } else if (requireNamespace("ragg", quietly = TRUE)) {
     ragg::agg_png(filename = path, width = width, height = height, units = units, res = res)
   } else {
     grDevices::png(filename = path, width = width, height = height, units = units, res = res)
@@ -123,7 +133,8 @@ save_plot <- function(plot, path, width = 800, height = 1100, scale = 1, units =
   box::use(
     artma / libs / core / validation[validate],
     artma / libs / core / utils[get_verbosity],
-    artma / libs / infrastructure / output_files[record_output_file]
+    artma / libs / infrastructure / output_files[record_output_file],
+    artma / visualization / fork_safety[fork_safe_png_device, use_fork_safe_png_device]
   )
 
   validate(
@@ -141,7 +152,13 @@ save_plot <- function(plot, path, width = 800, height = 1100, scale = 1, units =
     file.remove(path)
   }
 
-  device <- if (requireNamespace("ragg", quietly = TRUE)) ragg::agg_png else NULL
+  device <- if (use_fork_safe_png_device()) {
+    fork_safe_png_device
+  } else if (requireNamespace("ragg", quietly = TRUE)) {
+    ragg::agg_png
+  } else {
+    NULL
+  }
 
   ggplot2::ggsave(
     filename = path,

--- a/inst/artma/visualization/fork_safety.R
+++ b/inst/artma/visualization/fork_safety.R
@@ -13,6 +13,11 @@
 # Objective-C runtime and renders correctly in a fork, so it stands in for the
 # faster ragg device for the duration of a forked method run. Output dimensions
 # are unchanged; only the rasteriser differs.
+#
+# That device is not universally usable: some headless macOS installations
+# report `capabilities("cairo") == TRUE` yet write no file at all. It is
+# therefore probed once per session, and when the probe fails the layer falls
+# back to sequential execution rather than losing every method that draws.
 
 box::use(
   artma / libs / core / validation[validate]
@@ -39,14 +44,63 @@ graphics_fork_is_hostile <- function(sysname = NULL) {
   identical(sysname, "Darwin")
 }
 
+#' @title Cached result of the cairo probe
+#' @keywords internal
+cairo_probe <- new.env(parent = emptyenv())
+
+#' @title Whether the cairo device actually writes a PNG here
+#' @description
+#' `capabilities("cairo")` reports how R was built, which is not the same as the
+#' device working: on some headless macOS installations it returns `TRUE` while
+#' the device silently produces no file. Since the whole fork-safety strategy
+#' rests on this device, verify it by writing a throwaway PNG rather than
+#' trusting the capability flag.
+#' @return *\[logical\]* `TRUE` when a cairo PNG was written successfully.
+#' @keywords internal
+probe_cairo_png <- function() {
+  if (!isTRUE(capabilities("cairo"))) {
+    return(FALSE)
+  }
+
+  path <- tempfile(fileext = ".png")
+  on.exit(unlink(path), add = TRUE)
+
+  opened <- FALSE
+  ok <- tryCatch(
+    {
+      grDevices::png(
+        filename = path, width = 200, height = 200, units = "px", res = 72, type = "cairo"
+      )
+      opened <- TRUE
+      graphics::plot.new()
+      grDevices::dev.off()
+      opened <- FALSE
+      TRUE
+    },
+    error = function(err) FALSE,
+    warning = function(cond) FALSE
+  )
+
+  if (opened) {
+    try(grDevices::dev.off(), silent = TRUE)
+  }
+
+  isTRUE(ok) && file.exists(path) && file.info(path)$size > 0L
+}
+
 #' @title Whether a fork-safe PNG device is available
 #' @description
-#' The cairo device is a build-time capability of R, not a package, so it can
-#' legitimately be missing.
+#' Probes once per session and caches the answer; the probe opens a device, so
+#' repeating it per plot would be wasteful.
+#' @param refresh *\[logical, optional\]* Re-run the probe instead of reusing the
+#'   cached answer. Injectable for testing.
 #' @return *\[logical\]* `TRUE` when `grDevices::png(type = "cairo")` can be used.
 #' @keywords internal
-fork_safe_png_available <- function() {
-  isTRUE(capabilities("cairo"))
+fork_safe_png_available <- function(refresh = FALSE) {
+  if (isTRUE(refresh) || is.null(cairo_probe$ok)) {
+    cairo_probe$ok <- probe_cairo_png()
+  }
+  cairo_probe$ok
 }
 
 #' @title Whether the current process is a forked method worker
@@ -128,6 +182,7 @@ box::export(
   graphics_fork_is_hostile,
   graphics_survive_fork,
   in_forked_worker,
+  probe_cairo_png,
   use_fork_safe_png_device,
   with_forked_worker_flag
 )

--- a/inst/artma/visualization/fork_safety.R
+++ b/inst/artma/visualization/fork_safety.R
@@ -1,0 +1,133 @@
+# Raster graphics devices inside forked workers.
+#
+# `parallel::mclapply()` runs a method by forking the current process. On macOS
+# the Objective-C runtime refuses to run in a child when a class initialiser may
+# have been in progress at `fork()` time, and aborts the child instead of
+# returning an error. Both `ragg::agg_png()` and the default quartz-backed
+# `grDevices::png()` reach that code path through their font handling, so a
+# method that exports a plot kills its worker outright. `mclapply()` then reports
+# "parallel jobs did not deliver results" and yields `NULL` for that method,
+# which is why the failure used to surface with an empty error message.
+#
+# The cairo-backed `grDevices::png(type = "cairo")` does not touch the
+# Objective-C runtime and renders correctly in a fork, so it stands in for the
+# faster ragg device for the duration of a forked method run. Output dimensions
+# are unchanged; only the rasteriser differs.
+
+box::use(
+  artma / libs / core / validation[validate]
+)
+
+#' @title Option flagging the current process as a forked method worker
+#' @description
+#' Set in the child by `execute_method_layer()`. A forked child gets its own
+#' copy of the R session, so writing it there cannot leak into the parent.
+#' @keywords internal
+FORKED_WORKER_OPTION <- "artma.temp.forked_worker" # nolint: object_name_linter.
+
+#' @title Whether forking is hostile to the default graphics devices
+#' @description
+#' Only macOS aborts the child; on other platforms ragg forks cleanly and is
+#' left in place.
+#' @param sysname *\[character, optional\]* Platform name. Injectable for
+#'   testing; defaults to `Sys.info()[["sysname"]]`.
+#' @return *\[logical\]* `TRUE` when the platform's default PNG devices are
+#'   unsafe to use in a forked child.
+#' @keywords internal
+graphics_fork_is_hostile <- function(sysname = NULL) {
+  sysname <- sysname %||% Sys.info()[["sysname"]]
+  identical(sysname, "Darwin")
+}
+
+#' @title Whether a fork-safe PNG device is available
+#' @description
+#' The cairo device is a build-time capability of R, not a package, so it can
+#' legitimately be missing.
+#' @return *\[logical\]* `TRUE` when `grDevices::png(type = "cairo")` can be used.
+#' @keywords internal
+fork_safe_png_available <- function() {
+  isTRUE(capabilities("cairo"))
+}
+
+#' @title Whether the current process is a forked method worker
+#' @return *\[logical\]* `TRUE` inside a child spawned by `execute_method_layer()`.
+#' @keywords internal
+in_forked_worker <- function() {
+  isTRUE(getOption(FORKED_WORKER_OPTION, FALSE))
+}
+
+#' @title Whether plot exports may run inside a forked worker
+#' @description
+#' Used by `resolve_worker_count()` to keep a layer sequential when graphics are
+#' being exported on a platform that would abort the child and offers no
+#' fork-safe device to fall back on.
+#' @return *\[logical\]* `TRUE` when a forked worker can safely write a PNG.
+#' @keywords internal
+graphics_survive_fork <- function() {
+  !graphics_fork_is_hostile() || fork_safe_png_available()
+}
+
+#' @title Whether to substitute the fork-safe PNG device
+#' @return *\[logical\]* `TRUE` when the cairo device should replace ragg/quartz.
+#' @keywords internal
+use_fork_safe_png_device <- function() {
+  in_forked_worker() && graphics_fork_is_hostile() && fork_safe_png_available()
+}
+
+#' @title Evaluate an expression with the forked-worker flag set
+#' @description
+#' Marks the current process as a forked method worker so the graphics helpers
+#' pick a fork-safe device. The previous option value is restored on exit, which
+#' keeps the helper harmless if it is ever called in the parent.
+#' @param expr *\[any\]* Expression to evaluate.
+#' @return The value of `expr`.
+#' @keywords internal
+with_forked_worker_flag <- function(expr) {
+  old <- options(stats::setNames(list(TRUE), FORKED_WORKER_OPTION))
+  on.exit(options(old), add = TRUE)
+  expr
+}
+
+#' @title A cairo-backed PNG device usable as a `ggsave()` device
+#' @description
+#' `ggplot2::ggsave()` resolves the plot size to inches before calling the
+#' device, whereas `grDevices::png()` measures in pixels unless told otherwise,
+#' so `units` is pinned to inches here. Without it the device would receive a
+#' handful of pixels and write an essentially blank file.
+#' @param filename *\[character\]* Output path.
+#' @param width *\[numeric\]* Width, in inches.
+#' @param height *\[numeric\]* Height, in inches.
+#' @param res *\[numeric, optional\]* Resolution in pixels per inch.
+#' @param ... Ignored; absorbs arguments `ggsave()` passes to other devices.
+#' @return NULL (invisibly). Called for its side effect of opening a device.
+#' @keywords internal
+fork_safe_png_device <- function(filename, width, height, res = 150, ...) {
+  validate(
+    is.character(filename),
+    is.numeric(width), width > 0,
+    is.numeric(height), height > 0,
+    is.numeric(res), res > 0
+  )
+
+  grDevices::png(
+    filename = filename,
+    width = width,
+    height = height,
+    units = "in",
+    res = res,
+    type = "cairo"
+  )
+
+  invisible(NULL)
+}
+
+box::export(
+  FORKED_WORKER_OPTION,
+  fork_safe_png_available,
+  fork_safe_png_device,
+  graphics_fork_is_hostile,
+  graphics_survive_fork,
+  in_forked_worker,
+  use_fork_safe_png_device,
+  with_forked_worker_flag
+)

--- a/tests/testthat/test-method-execution.R
+++ b/tests/testthat/test-method-execution.R
@@ -23,7 +23,8 @@ worker_count <- function(n_tasks, is_interactive = FALSE, os_type = "unix", n_co
     is_interactive = is_interactive,
     os_type = os_type,
     n_cores = n_cores,
-    max_workers = Inf
+    max_workers = Inf,
+    graphics_fork_safe = TRUE
   )
 }
 
@@ -137,7 +138,10 @@ test_that("resolve_worker_count respects the environment's process ceiling", {
   withr::local_envvar(list("_R_CHECK_LIMIT_CORES_" = "TRUE"))
   expect_equal(max_parallel_workers(), 2L)
   expect_equal(
-    resolve_worker_count(8L, is_interactive = FALSE, os_type = "unix", n_cores = 16L),
+    resolve_worker_count(
+      8L,
+      is_interactive = FALSE, os_type = "unix", n_cores = 16L, graphics_fork_safe = TRUE
+    ),
     2L
   )
 
@@ -146,7 +150,10 @@ test_that("resolve_worker_count respects the environment's process ceiling", {
   withr::local_options(list(mc.cores = 3L))
   expect_equal(max_parallel_workers(), 3L)
   expect_equal(
-    resolve_worker_count(8L, is_interactive = FALSE, os_type = "unix", n_cores = 16L),
+    resolve_worker_count(
+      8L,
+      is_interactive = FALSE, os_type = "unix", n_cores = 16L, graphics_fork_safe = TRUE
+    ),
     3L
   )
 })
@@ -282,10 +289,15 @@ test_that("execute_method_layer explains a worker that died without an error", {
 
   skip_if(!can_fork(), "forking is unavailable")
 
+  # Guard the kill on actually being in a forked child: signalling the current
+  # process would take down the testthat subprocess running this file.
+  parent_pid <- Sys.getpid()
   outcomes <- suppressWarnings(execute_method_layer(
     c("a", "b"),
     run_one = function(name) {
-      if (identical(name, "b")) tools::pskill(Sys.getpid())
+      if (identical(name, "b") && !identical(Sys.getpid(), parent_pid)) {
+        tools::pskill(Sys.getpid())
+      }
       name
     },
     workers = 2L

--- a/tests/testthat/test-method-execution.R
+++ b/tests/testthat/test-method-execution.R
@@ -262,6 +262,41 @@ test_that("execute_method_layer gives identical results in parallel and sequenti
   )
 })
 
+test_that("describe_dead_worker never reports an empty error", {
+  box::use(artma / modules / method_execution[describe_dead_worker])
+
+  # `mclapply()` yields NULL for a child that was killed outright, which used to
+  # collapse to an empty failure message.
+  silent <- describe_dead_worker(NULL, "bma")
+  expect_true(nzchar(silent))
+  expect_match(silent, "bma", fixed = TRUE)
+  expect_match(silent, "artma.general.parallel", fixed = TRUE)
+
+  detailed <- describe_dead_worker("boom", "funnel_plot")
+  expect_match(detailed, "funnel_plot", fixed = TRUE)
+  expect_match(detailed, "boom", fixed = TRUE)
+})
+
+test_that("execute_method_layer explains a worker that died without an error", {
+  box::use(artma / modules / method_execution[execute_method_layer])
+
+  skip_if(!can_fork(), "forking is unavailable")
+
+  outcomes <- suppressWarnings(execute_method_layer(
+    c("a", "b"),
+    run_one = function(name) {
+      if (identical(name, "b")) tools::pskill(Sys.getpid())
+      name
+    },
+    workers = 2L
+  ))
+
+  expect_equal(outcomes[[1L]]$value, "a")
+  expect_null(outcomes[[2L]]$value)
+  expect_true(nzchar(outcomes[[2L]]$error))
+  expect_match(outcomes[[2L]]$error, "b", fixed = TRUE)
+})
+
 test_that("execute_method_layer captures output from forked workers", {
   box::use(artma / modules / method_execution[execute_method_layer])
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -447,13 +447,35 @@ test_that("invoke_runtime_methods explains a forked method that was killed", {
 
   # A worker that dies without signalling (a segfault in a graphics device is
   # the real-world case) used to be recorded as a failure with an empty message.
+  # Only ever signal a *forked child*: if this were to run in the current
+  # process (because the layer fell back to sequential execution) the kill would
+  # take down the testthat subprocess running this file. These methods are
+  # written out to a module file, so they cannot close over a local variable;
+  # the forked-worker option is set in the child and is readable there.
   fake_methods <- list(
     method_a = list(run = function(df, ...) "method_a"),
-    method_b = list(run = function(df, ...) tools::pskill(Sys.getpid())),
+    method_b = list(run = function(df, ...) {
+      if (!isTRUE(getOption("artma.temp.forked_worker", FALSE))) {
+        return("method_b ran in the parent")
+      }
+      tools::pskill(Sys.getpid())
+    }),
     method_c = list(run = function(df, ...) "method_c")
   )
-  withr::local_options(list(artma.verbose = 0, artma.general.parallel = TRUE))
+  # Graphics exports force sequential execution where no fork-safe device
+  # exists, so turn them off to keep this layer genuinely parallel.
+  withr::local_options(list(
+    artma.verbose = 0,
+    artma.general.parallel = TRUE,
+    artma.visualization.export_graphics = FALSE
+  ))
   methods_dir <- local_mock_methods_dir(fake_methods)
+
+  box::use(artma / modules / method_execution[resolve_worker_count])
+  testthat::skip_if(
+    resolve_worker_count(3L) < 2L,
+    "this environment runs method layers sequentially"
+  )
 
   df <- data.frame(x = 1:3)
   results <- suppressWarnings(artma:::invoke_runtime_methods(

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -438,6 +438,34 @@ test_that("invoke_runtime_methods records a failure from a forked method", {
   expect_match(failed[["method_b"]], "method_b exploded")
 })
 
+test_that("invoke_runtime_methods explains a forked method that was killed", {
+  cores <- tryCatch(parallel::detectCores(), error = function(err) NA_integer_)
+  testthat::skip_if(
+    identical(.Platform$OS.type, "windows") || !is.numeric(cores) || is.na(cores) || cores < 2L,
+    "forking is unavailable"
+  )
+
+  # A worker that dies without signalling (a segfault in a graphics device is
+  # the real-world case) used to be recorded as a failure with an empty message.
+  fake_methods <- list(
+    method_a = list(run = function(df, ...) "method_a"),
+    method_b = list(run = function(df, ...) tools::pskill(Sys.getpid())),
+    method_c = list(run = function(df, ...) "method_c")
+  )
+  withr::local_options(list(artma.verbose = 0, artma.general.parallel = TRUE))
+  methods_dir <- local_mock_methods_dir(fake_methods)
+
+  df <- data.frame(x = 1:3)
+  results <- suppressWarnings(artma:::invoke_runtime_methods(
+    methods = c("method_a", "method_b", "method_c"), df = df, modules_dir = methods_dir
+  ))
+
+  failed <- attr(results, "failed_methods")
+  expect_equal(names(failed), "method_b")
+  expect_true(nzchar(failed[["method_b"]]))
+  expect_match(failed[["method_b"]], "method_b")
+})
+
 test_that("invoke_runtime_methods passes dependency results across layers", {
   fake_methods <- list(
     method_a = list(run = function(df, ...) "from_a"),

--- a/tests/testthat/test-visualization-fork-safety.R
+++ b/tests/testthat/test-visualization-fork-safety.R
@@ -38,10 +38,12 @@ png_dim <- function(path) {
 test_that("save_plot writes a valid PNG from inside a forked worker", {
   box::use(
     artma / modules / method_execution[execute_method_layer],
-    artma / visualization / export[save_plot]
+    artma / visualization / export[save_plot],
+    artma / visualization / fork_safety[fork_safe_png_available]
   )
 
   skip_if(!can_fork(), "forking is unavailable")
+  skip_if(!fork_safe_png_available(), "no fork-safe graphics device on this platform")
 
   export_dir <- withr::local_tempdir()
   plot <- ggplot2::ggplot(data.frame(x = 1:10, y = 1:10), ggplot2::aes(x, y)) +
@@ -73,10 +75,12 @@ test_that("save_plot writes a valid PNG from inside a forked worker", {
 test_that("open_png_device writes a valid PNG from inside a forked worker", {
   box::use(
     artma / modules / method_execution[execute_method_layer],
-    artma / visualization / export[open_png_device]
+    artma / visualization / export[open_png_device],
+    artma / visualization / fork_safety[fork_safe_png_available]
   )
 
   skip_if(!can_fork(), "forking is unavailable")
+  skip_if(!fork_safe_png_available(), "no fork-safe graphics device on this platform")
 
   export_dir <- withr::local_tempdir()
 
@@ -148,6 +152,36 @@ test_that("fork_safe_png_device sizes the raster in inches", {
   grDevices::dev.off()
 
   expect_equal(png_dim(path), c(400L, 300L))
+})
+
+test_that("fork_safe_png_available probes the device rather than the build flag", {
+  box::use(artma / visualization / fork_safety[fork_safe_png_available, probe_cairo_png])
+
+  # `capabilities("cairo")` reports how R was built; some headless macOS
+  # installations report TRUE while the device writes nothing, which is why the
+  # answer comes from an actual write.
+  expect_equal(fork_safe_png_available(refresh = TRUE), probe_cairo_png())
+  expect_true(is.logical(probe_cairo_png()))
+  expect_equal(length(probe_cairo_png()), 1L)
+})
+
+test_that("a platform without a working cairo device never forks its graphics", {
+  box::use(
+    artma / visualization / fork_safety[
+      fork_safe_png_available, graphics_fork_is_hostile, graphics_survive_fork,
+      use_fork_safe_png_device
+    ]
+  )
+
+  # Without a working cairo device there is nothing safe to swap in, so a
+  # hostile platform must report that graphics cannot survive a fork. That is
+  # what pushes `resolve_worker_count()` back to sequential execution.
+  if (graphics_fork_is_hostile() && !fork_safe_png_available()) {
+    expect_false(graphics_survive_fork())
+    expect_false(use_fork_safe_png_device())
+  } else {
+    expect_true(graphics_survive_fork())
+  }
 })
 
 test_that("resolve_worker_count stays sequential when a fork cannot draw", {

--- a/tests/testthat/test-visualization-fork-safety.R
+++ b/tests/testthat/test-visualization-fork-safety.R
@@ -1,0 +1,189 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_null,
+    expect_true,
+    skip_if,
+    test_that
+  ]
+)
+
+can_fork <- function() {
+  cores <- tryCatch(parallel::detectCores(), error = function(err) NA_integer_)
+  !identical(.Platform$OS.type, "windows") && is.numeric(cores) && !is.na(cores) && cores >= 2L
+}
+
+# Pixel dimensions straight out of the PNG header: an 8-byte signature, then the
+# IHDR chunk whose payload opens with the width and height as big-endian 32-bit
+# integers. Reading them here keeps the assertions dependency-free.
+png_dim <- function(path) {
+  con <- file(path, open = "rb")
+  on.exit(close(con), add = TRUE)
+  header <- readBin(con, "raw", n = 24L)
+  if (length(header) < 24L) {
+    return(c(NA_integer_, NA_integer_))
+  }
+  as.integer(c(
+    sum(as.integer(header[17:20]) * 256^(3:0)),
+    sum(as.integer(header[21:24]) * 256^(3:0))
+  ))
+}
+
+# The regression this file guards: on macOS the Objective-C runtime aborts a
+# forked child that opens a ragg or quartz PNG device, so every method exporting
+# graphics died silently under `artma.general.parallel = TRUE`. The worker was
+# killed rather than throwing, so it surfaced as a failure with an empty message.
+
+test_that("save_plot writes a valid PNG from inside a forked worker", {
+  box::use(
+    artma / modules / method_execution[execute_method_layer],
+    artma / visualization / export[save_plot]
+  )
+
+  skip_if(!can_fork(), "forking is unavailable")
+
+  export_dir <- withr::local_tempdir()
+  plot <- ggplot2::ggplot(data.frame(x = 1:10, y = 1:10), ggplot2::aes(x, y)) +
+    ggplot2::geom_point()
+
+  outcomes <- execute_method_layer(
+    c("first", "second"),
+    run_one = function(name) {
+      save_plot(plot, file.path(export_dir, paste0(name, ".png")))
+      name
+    },
+    workers = 2L
+  )
+
+  for (outcome in outcomes) {
+    expect_null(outcome$error)
+  }
+  expect_equal(vapply(outcomes, function(o) o$value, character(1)), c("first", "second"))
+
+  for (name in c("first", "second")) {
+    path <- file.path(export_dir, paste0(name, ".png"))
+    expect_true(file.exists(path))
+    # A device that opened with the wrong units writes a near-empty file, so
+    # assert on the raster dimensions rather than mere existence.
+    expect_equal(png_dim(path), c(800L, 1100L))
+  }
+})
+
+test_that("open_png_device writes a valid PNG from inside a forked worker", {
+  box::use(
+    artma / modules / method_execution[execute_method_layer],
+    artma / visualization / export[open_png_device]
+  )
+
+  skip_if(!can_fork(), "forking is unavailable")
+
+  export_dir <- withr::local_tempdir()
+
+  outcomes <- execute_method_layer(
+    c("first", "second"),
+    run_one = function(name) {
+      open_png_device(file.path(export_dir, paste0(name, ".png")), width = 800, height = 600)
+      on.exit(grDevices::dev.off(), add = TRUE)
+      graphics::plot(1:10)
+      name
+    },
+    workers = 2L
+  )
+
+  for (outcome in outcomes) {
+    expect_null(outcome$error)
+  }
+
+  for (name in c("first", "second")) {
+    path <- file.path(export_dir, paste0(name, ".png"))
+    expect_true(file.exists(path))
+    expect_equal(png_dim(path), c(800L, 600L))
+  }
+})
+
+test_that("the forked-worker flag is confined to the child process", {
+  box::use(
+    artma / modules / method_execution[execute_method_layer],
+    artma / visualization / fork_safety[in_forked_worker]
+  )
+
+  skip_if(!can_fork(), "forking is unavailable")
+
+  outcomes <- execute_method_layer(
+    c("a", "b"),
+    run_one = function(name) in_forked_worker(),
+    workers = 2L
+  )
+
+  expect_true(all(vapply(outcomes, function(o) isTRUE(o$value), logical(1))))
+  expect_false(in_forked_worker())
+})
+
+test_that("sequential runs keep the default device", {
+  box::use(
+    artma / modules / method_execution[execute_method_layer],
+    artma / visualization / fork_safety[use_fork_safe_png_device]
+  )
+
+  outcomes <- execute_method_layer(
+    "a",
+    run_one = function(name) use_fork_safe_png_device(),
+    workers = 1L
+  )
+
+  expect_false(isTRUE(outcomes[[1L]]$value))
+})
+
+test_that("fork_safe_png_device sizes the raster in inches", {
+  box::use(artma / visualization / fork_safety[fork_safe_png_available, fork_safe_png_device])
+
+  skip_if(!fork_safe_png_available(), "cairo is unavailable")
+
+  path <- withr::local_tempfile(fileext = ".png")
+
+  # `ggsave()` resolves the size to inches before handing it to the device.
+  fork_safe_png_device(path, width = 4, height = 3, res = 100)
+  graphics::plot(1:10)
+  grDevices::dev.off()
+
+  expect_equal(png_dim(path), c(400L, 300L))
+})
+
+test_that("resolve_worker_count stays sequential when a fork cannot draw", {
+  box::use(artma / modules / method_execution[resolve_worker_count])
+
+  withr::local_options(list(artma.visualization.export_graphics = TRUE))
+
+  expect_equal(
+    resolve_worker_count(
+      4L,
+      is_interactive = FALSE, os_type = "unix", n_cores = 8L,
+      max_workers = Inf, graphics_fork_safe = FALSE
+    ),
+    1L
+  )
+  expect_equal(
+    resolve_worker_count(
+      4L,
+      is_interactive = FALSE, os_type = "unix", n_cores = 8L,
+      max_workers = Inf, graphics_fork_safe = TRUE
+    ),
+    4L
+  )
+})
+
+test_that("resolve_worker_count ignores fork-unsafe graphics when not exporting", {
+  box::use(artma / modules / method_execution[resolve_worker_count])
+
+  withr::local_options(list(artma.visualization.export_graphics = FALSE))
+
+  expect_equal(
+    resolve_worker_count(
+      4L,
+      is_interactive = FALSE, os_type = "unix", n_cores = 8L,
+      max_workers = Inf, graphics_fork_safe = FALSE
+    ),
+    4L
+  )
+})


### PR DESCRIPTION
## Problem

With `general.parallel = TRUE` and `visualization.export_graphics = TRUE`, every method that exports a plot failed. The run reported "N parallel jobs did not deliver results" and recorded those methods as failed with an **empty** error message. Turning graphics off, or running sequentially, made it go away. Caching was not involved.

## Root cause

`parallel::mclapply()` forks. On macOS the Objective-C runtime refuses to run in a child when a class initialiser may have been in progress at `fork()` time, and aborts the child rather than returning an error:

```
objc[75590]: +[NSPlaceholderString initialize] may have been in progress in another
thread when fork() was called. We cannot safely call it or ignore it in the fork()
child process. Crashing instead.
```

Both `ragg::agg_png()` and the default quartz-backed `grDevices::png()` reach that path through font handling, so the worker is killed outright. Confirmed by isolating the three devices in a fork: ragg and quartz both kill the child; `grDevices::png(type = "cairo")` survives. Pre-initialising a device in the parent before forking does not help.

The empty message was a second, independent bug: `mclapply()` returns `NULL` for a killed child, and `as.character(NULL)` collapsed to `""` at the point where the outcome was normalised.

## Fix

New module `inst/artma/visualization/fork_safety.R`. Inside a forked worker, on a platform hostile to forking, `open_png_device()` and `save_plot()` swap in the cairo-backed device. Output dimensions are unchanged; only the rasteriser differs. Everything else (sequential runs, non-macOS) keeps ragg.

The `ggsave()` wrapper pins `units = "in"`, because `ggsave()` resolves the size to inches before calling the device while `grDevices::png()` measures in pixels. Without that the device gets a handful of pixels and writes a blank 84-byte file.

Two supporting changes:

- `resolve_worker_count()` falls back to sequential when graphics are being exported and no fork-safe device exists, so a machine without cairo loses parallelism instead of losing plots.
- A worker that dies without signalling now gets a real diagnostic naming the method and pointing at `options(artma.general.parallel = FALSE)` to reproduce the underlying fault in the parent.

## Verification

Real run of `effect_summary_stats`, `funnel_plot`, `linear_tests` with parallel and graphics both on.

Before, with only the diagnostic applied:

```
=== succeeded: effect_summary_stats, linear_tests
FAILED: funnel_plot -> the forked worker running 'funnel_plot' died without
reporting an error (the child process was killed, e.g. by a crash in compiled
code or the OS). Re-run with options(artma.general.parallel = FALSE) to see the
underlying failure.
PNGs found:
```

After:

```
=== succeeded: effect_summary_stats, funnel_plot, linear_tests
no failures
PNGs found: .../graphics/funnel_plot_effect_precision.png
```

## Tests

New `tests/testthat/test-visualization-fork-safety.R` plus cases in `test-method-execution.R` and `test-run.R`. The graphics tests assert on raster dimensions read from the PNG header, not just file existence, so a device opened with the wrong units still fails. Reverting the device swap fails 7 of them; the suite is green with it.

`make lint` clean, `make test` 1800 passing, 0 failures.
