### PR TITLE
fix(options): keep the unified column store when migrating legacy options

### DIFF
--- a/inst/artma/options/migrate.R
+++ b/inst/artma/options/migrate.R
@@ -27,8 +27,12 @@ is_legacy_options_format <- function(nested_options) {
 #' @param colnames_map *\[list\]* The legacy `data.colnames` mapping
 #'   (standard name -> source column name).
 #' @param config *\[list\]* The legacy `data.config` per-variable entries.
+#' @param existing *\[list, optional\]* Records already present in the unified
+#'   `data.columns` store. A file can carry all three stores at once when it was
+#'   partially written by a newer version; the unified store is the most recent
+#'   of the three, so its fields win over the legacy ones.
 #' @return *\[list\]* The unified per-column records.
-build_unified_columns <- function(colnames_map, config) {
+build_unified_columns <- function(colnames_map, config, existing = NULL) {
   records <- list()
 
   if (is.list(config)) {
@@ -49,6 +53,18 @@ build_unified_columns <- function(colnames_map, config) {
       if (!is.list(entry)) entry <- list()
       entry$source_name <- as.character(src)
       records[[std]] <- entry
+    }
+  }
+
+  if (is.list(existing)) {
+    for (key in names(existing)) {
+      entry <- existing[[key]]
+      if (!is.list(entry)) next
+      records[[key]] <- if (is.list(records[[key]])) {
+        utils::modifyList(records[[key]], entry)
+      } else {
+        entry
+      }
     }
   }
 
@@ -95,7 +111,8 @@ migrate_legacy_options <- function(options_file_name, options_dir = NULL) {
 
   records <- build_unified_columns(
     colnames_map = nested[["data"]][["colnames"]],
-    config = nested[["data"]][["config"]]
+    config = nested[["data"]][["config"]],
+    existing = nested[["data"]][["columns"]]
   )
 
   nested[["data"]][["colnames"]] <- NULL

--- a/tests/testthat/test-options-migration.R
+++ b/tests/testthat/test-options-migration.R
@@ -79,6 +79,28 @@ test_that("build_unified_columns merges both legacy stores into one record per c
   expect_null(records$t_stat)
 })
 
+test_that("build_unified_columns keeps an existing unified store and lets it win", {
+  box::use(artma / options / migrate[build_unified_columns])
+
+  records <- build_unified_columns(
+    colnames_map = list(effect = "pcc"),
+    config = list(effect = list(bma = TRUE)),
+    existing = list(
+      effect = list(source_name = "b"),
+      gdp_growth = list(bma = FALSE)
+    )
+  )
+
+  # The newer unified store overrides the legacy name mapping
+  expect_equal(records$effect$source_name, "b")
+
+  # Legacy fields the unified store does not mention survive the merge
+  expect_true(records$effect$bma)
+
+  # Records only present in the unified store are not dropped
+  expect_false(records$gdp_growth$bma)
+})
+
 test_that("a legacy options file migrates automatically with clear messaging", {
   box::use(artma / options / migrate[migrate_legacy_options])
 


### PR DESCRIPTION
## Context

Regenerating my four local options files (`bachelor`, `class`, `master-thesis`, `tmp_options`) against the current template surfaced a data-loss bug in the legacy migration.

## The bug

`build_unified_columns()` in `inst/artma/options/migrate.R` built the unified `data.columns` store purely from the two legacy stores (`data.colnames` + `data.config`), then assigned the result over `nested$data$columns`. Any records already in the modern store were discarded.

Files written by a newer version can carry all three stores at once. Two of my four files did. Running `options.fix()` on `master-thesis.yaml` wiped 200+ lines of column records, and `data.columns` came out empty.

## The fix

`build_unified_columns()` now takes an `existing` argument and merges it last, per field via `modifyList()`. The unified store is the most recently written of the three, so its fields win over the legacy ones while legacy fields it does not mention survive.

Covered by a new test in `tests/testthat/test-options-migration.R`.

## Verification

All four local options files now migrate and validate clean. A key-level diff against pre-run backups shows the only dropped keys are the legacy `data.config.*` / `data.colnames.*` entries, all of which are accounted for under `data.columns`, plus 14 conflicts where the modern store held an explicit contradicting value and won by design.

`make lint` clean; `make test` 0 failures, 1771 passing.