### PR TITLE
fix(p-hacking): orient caliper tail, cluster by study, show direction

### DIFF
--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -35,30 +35,165 @@ skip_reason <- function(value) {
 
 # Caliper tests (Gerber & Malhotra, 2008) ---------------------------------
 
+CALIPER_TAILS <- c("auto", "positive", "negative", "absolute")
+
+#' @title Resolve which tail the caliper should inspect
+#' @description
+#' The canonical Gerber and Malhotra (2008) caliper is one-sided, applied in
+#' the direction the literature has an incentive to push its estimates. Signed
+#' t-statistics compared against positive-only thresholds therefore inspect the
+#' wrong tail whenever the literature is dominated by negative effects, where
+#' the reporting incentive sits at `t < -1.96` rather than `t > 1.96`.
+#'
+#' `"auto"` (the default) picks the tail carrying the majority of the
+#' t-statistics. `"positive"` and `"negative"` force one tail; `"absolute"`
+#' pools both tails by taking `|t|`, which is the right choice only when the
+#' literature genuinely reports both signs as findings.
+#' @param t_stats *[numeric]* T-statistics.
+#' @param tail *[character]* One of `"auto"`, `"positive"`, `"negative"`, `"absolute"`.
+#' @return *[character]* The resolved tail, never `"auto"`.
+resolve_caliper_tail <- function(t_stats, tail = "auto") {
+  validate(is.character(tail), length(tail) == 1L)
+  assert(tail %in% CALIPER_TAILS, paste0("tail must be one of: ", paste(CALIPER_TAILS, collapse = ", ")))
+
+  if (!identical(tail, "auto")) {
+    return(tail)
+  }
+
+  usable <- t_stats[is.finite(t_stats) & t_stats != 0]
+  if (length(usable) == 0) {
+    return("positive")
+  }
+
+  if (mean(usable > 0) >= 0.5) "positive" else "negative"
+}
+
+#' @title Orient t-statistics so the tested tail is the upper one
+#' @param t_stats *[numeric]* T-statistics.
+#' @param tail *[character]* A resolved tail (not `"auto"`).
+#' @return *[numeric]* Oriented t-statistics.
+orient_t_stats <- function(t_stats, tail) {
+  switch(tail,
+    positive = t_stats,
+    negative = -t_stats,
+    absolute = abs(t_stats),
+    t_stats
+  )
+}
+
+#' @title Cluster-robust test that a window share equals one half
+#' @description
+#' `stats::binom.test` treats every estimate in the caliper window as an
+#' independent draw, which overstates significance when a handful of studies
+#' contribute most of the window (a single study reporting eight estimates just
+#' above the threshold is one decision, not eight). This computes the same
+#' share but tests it with a cluster-robust score statistic: the score residual
+#' `y_i - 0.5` is summed within each study, and the variance of the share comes
+#' from the between-study spread of those sums, referred to `t(G - 1)`.
+#'
+#' Falls back to the exact binomial test when clustering is not identified
+#' (fewer than two studies, or zero between-study variance).
+#' @param above *[logical]* Whether each window observation lies above the threshold.
+#' @param study_id *[vector or NULL]* Study identifiers for the window observations.
+#' @return *[list]* Contains p_value, n_studies, and cluster_method.
+cluster_robust_share_test <- function(above, study_id = NULL) {
+  n_total <- length(above)
+  n_above <- sum(above)
+
+  exact <- function(n_studies, reason) {
+    list(
+      p_value = stats::binom.test(n_above, n_total, p = 0.5)$p.value,
+      n_studies = n_studies,
+      cluster_method = reason
+    )
+  }
+
+  if (is.null(study_id)) {
+    return(exact(NA_integer_, "none"))
+  }
+
+  assert(length(study_id) == n_total, "study_id must be the same length as the window observations")
+
+  clusters <- split(above, as.character(study_id))
+  n_studies <- length(clusters)
+  if (n_studies < 2L) {
+    return(exact(n_studies, "none"))
+  }
+
+  # Score residuals under H0: share = 0.5, summed within each study.
+  cluster_scores <- vapply(clusters, function(y) sum(y - 0.5), numeric(1))
+  variance <- (n_studies / (n_studies - 1)) * sum(cluster_scores^2) / n_total^2
+
+  if (!is.finite(variance) || variance <= 0) {
+    return(exact(n_studies, "none"))
+  }
+
+  z <- ((n_above / n_total) - 0.5) / sqrt(variance)
+
+  list(
+    p_value = 2 * stats::pt(-abs(z), df = n_studies - 1L),
+    n_studies = n_studies,
+    cluster_method = "study"
+  )
+}
+
+#' @title Describe which side of the threshold carries the excess mass
+#' @param share_above *[numeric]* Share of window observations above the threshold.
+#' @return *[character]* `"above"`, `"below"`, `"balanced"`, or `NA`.
+caliper_direction <- function(share_above) {
+  if (!is.finite(share_above)) {
+    return(NA_character_)
+  }
+  if (share_above > 0.5) {
+    "above"
+  } else if (share_above < 0.5) {
+    "below"
+  } else {
+    "balanced"
+  }
+}
+
 #' @title Run single Caliper test
 #' @description
 #' Performs the Gerber and Malhotra (2008) Caliper test to detect selective
 #' reporting around a significance threshold: within a narrow window around
-#' the threshold, an exact binomial test checks whether the share of
-#' observations just above the threshold departs from 50%.
+#' the threshold, the share of observations just above the threshold is tested
+#' against 50%. The window is taken on t-statistics oriented towards the tail
+#' the literature has an incentive to report (see [resolve_caliper_tail()]),
+#' and the share is tested with a study-clustered statistic when `study_id` is
+#' supplied (see [cluster_robust_share_test()]).
 #' @param t_stats *[numeric]* T-statistics.
 #' @param threshold *[numeric]* T-statistic threshold (default 1.96).
 #' @param width *[numeric]* Caliper interval width (default 0.05).
-#' @return *[list]* Contains share_above, p_value, n_above, n_below.
-run_single_caliper <- function(t_stats, threshold = 1.96, width = 0.05) {
+#' @param study_id *[vector, optional]* Study identifiers, one per element of `t_stats`.
+#' @param tail *[character, optional]* Tail to inspect; see [resolve_caliper_tail()].
+#' @return *[list]* Contains share_above, p_value, n_above, n_below, n_studies,
+#'   direction, tail, and cluster_method.
+run_single_caliper <- function(t_stats, threshold = 1.96, width = 0.05,
+                               study_id = NULL, tail = "auto") {
   validate(
     is.numeric(t_stats),
     is.numeric(threshold),
     is.numeric(width)
   )
+  assert(
+    is.null(study_id) || length(study_id) == length(t_stats),
+    "study_id must be the same length as t_stats"
+  )
+
+  resolved_tail <- resolve_caliper_tail(t_stats, tail)
+  oriented <- orient_t_stats(t_stats, resolved_tail)
 
   # Subset to caliper interval
-  lower_bound <- t_stats > (threshold - width)
-  upper_bound <- t_stats < (threshold + width)
+  lower_bound <- oriented > (threshold - width)
+  upper_bound <- oriented < (threshold + width)
   in_interval <- lower_bound & upper_bound
+  in_interval[is.na(in_interval)] <- FALSE
 
-  n_above <- sum(t_stats[in_interval] > threshold)
-  n_below <- sum(t_stats[in_interval] < threshold)
+  window <- oriented[in_interval]
+  above <- window > threshold
+  n_above <- sum(above)
+  n_below <- sum(window < threshold)
   n_total <- n_above + n_below
 
   if (n_total == 0) {
@@ -66,15 +201,27 @@ run_single_caliper <- function(t_stats, threshold = 1.96, width = 0.05) {
       share_above = NA_real_,
       p_value = NA_real_,
       n_above = 0,
-      n_below = 0
+      n_below = 0,
+      n_studies = 0L,
+      direction = NA_character_,
+      tail = resolved_tail,
+      cluster_method = "none"
     ))
   }
 
+  window_studies <- if (is.null(study_id)) NULL else study_id[in_interval]
+  test <- cluster_robust_share_test(above, window_studies)
+  share_above <- n_above / n_total
+
   list(
-    share_above = n_above / n_total,
-    p_value = stats::binom.test(n_above, n_total, p = 0.5)$p.value,
+    share_above = share_above,
+    p_value = test$p_value,
     n_above = n_above,
-    n_below = n_below
+    n_below = n_below,
+    n_studies = test$n_studies,
+    direction = caliper_direction(share_above),
+    tail = resolved_tail,
+    cluster_method = test$cluster_method
   )
 }
 
@@ -82,12 +229,15 @@ run_single_caliper <- function(t_stats, threshold = 1.96, width = 0.05) {
 #' @param t_stats *[numeric]* T-statistics.
 #' @param thresholds *[numeric]* Vector of thresholds to test.
 #' @param widths *[numeric]* Vector of caliper widths to test.
+#' @param study_id *[vector, optional]* Study identifiers, one per element of `t_stats`.
+#' @param tail *[character, optional]* Tail to inspect; see [resolve_caliper_tail()].
 #' @param add_significance_marks *[logical]* Whether to add significance marks.
 #' @param round_to *[integer]* Number of decimal places.
 #' @param show_progress *[logical]* Whether to show progress indicator.
 #' @return *[data.frame]* Caliper test results.
 run_caliper_tests <- function(t_stats, thresholds = c(1.645, 1.96, 2.58),
-                              widths = c(0.05, 0.1, 0.2),
+                              widths = c(0.05, 0.1, 0.2), study_id = NULL,
+                              tail = "auto",
                               add_significance_marks = TRUE, round_to = 3L,
                               show_progress = TRUE) {
   validate(
@@ -115,9 +265,11 @@ run_caliper_tests <- function(t_stats, thresholds = c(1.645, 1.96, 2.58),
     )
   }
 
+  resolved_tail <- resolve_caliper_tail(t_stats, tail)
+
   for (thresh in thresholds) {
     for (w in widths) {
-      res <- run_single_caliper(t_stats, thresh, w)
+      res <- run_single_caliper(t_stats, thresh, w, study_id = study_id, tail = resolved_tail)
 
       if (show_pb) {
         cli::cli_progress_update()
@@ -129,9 +281,13 @@ run_caliper_tests <- function(t_stats, thresholds = c(1.645, 1.96, 2.58),
         NA_character_
       }
 
+      # Only a share above 0.5 is evidence of p-hacking. A significantly *low*
+      # share points the other way, so it must not be starred as if it were a
+      # discontinuity in the hacking direction.
       p_value_formatted <- if (is.finite(res$p_value)) {
         p_str <- format_number(res$p_value, round_to)
-        if (add_significance_marks) paste0(p_str, significance_mark(res$p_value)) else p_str
+        starrable <- add_significance_marks && identical(res$direction, "above")
+        if (starrable) paste0(p_str, significance_mark(res$p_value)) else p_str
       } else {
         NA_character_
       }
@@ -142,7 +298,11 @@ run_caliper_tests <- function(t_stats, thresholds = c(1.645, 1.96, 2.58),
         share_above = share_formatted,
         p_value = p_value_formatted,
         n_above = res$n_above,
-        n_below = res$n_below
+        n_below = res$n_below,
+        n_studies = res$n_studies,
+        direction = res$direction,
+        tail = res$tail,
+        cluster_method = res$cluster_method
       )
     }
   }
@@ -175,7 +335,7 @@ build_caliper_summary <- function(caliper_results, options) {
   display_ratios <- options$display_ratios %||% TRUE
 
   # Initialize result matrix
-  n_rows <- length(widths) * 3 # 3 rows per width: share above, p-value, n count
+  n_rows <- length(widths) * 4 # 4 rows per width: share above, direction, p-value, n count
   result <- matrix("", nrow = n_rows, ncol = length(thresholds) + 1)
 
   # Column names
@@ -186,10 +346,12 @@ build_caliper_summary <- function(caliper_results, options) {
   for (w in widths) {
     # Row 1: Share above the threshold
     result[row_idx, 1] <- paste0("Caliper width ", w, " - Share above")
-    # Row 2: Binomial test p-value
-    result[row_idx + 1, 1] <- paste0("Caliper width ", w, " - p-value")
-    # Row 3: n count (ratio or total)
-    result[row_idx + 2, 1] <- paste0("Caliper width ", w, if (display_ratios) " - n above/below" else " - n total")
+    # Row 2: Which side of the threshold carries the excess mass
+    result[row_idx + 1, 1] <- paste0("Caliper width ", w, " - Direction")
+    # Row 3: Test p-value
+    result[row_idx + 2, 1] <- paste0("Caliper width ", w, " - p-value")
+    # Row 4: n count (ratio or total)
+    result[row_idx + 3, 1] <- paste0("Caliper width ", w, if (display_ratios) " - n above/below" else " - n total")
 
     for (col_idx in seq_along(thresholds)) {
       thresh <- thresholds[col_idx]
@@ -199,23 +361,49 @@ build_caliper_summary <- function(caliper_results, options) {
       )]]
 
       result[row_idx, col_idx + 1] <- res$share_above
-      result[row_idx + 1, col_idx + 1] <- res$p_value
+      result[row_idx + 1, col_idx + 1] <- caliper_direction_label(res$direction)
+      result[row_idx + 2, col_idx + 1] <- res$p_value
       # Display ratio or total based on option
-      result[row_idx + 2, col_idx + 1] <- if (display_ratios) {
+      counts <- if (display_ratios) {
         paste0(res$n_above, "/", res$n_below)
       } else {
         as.character(res$n_above + res$n_below)
       }
+      n_studies <- res$n_studies
+      result[row_idx + 3, col_idx + 1] <- if (is.null(n_studies) || !is.finite(n_studies) || n_studies == 0) {
+        counts
+      } else {
+        paste0(counts, " (", n_studies, " stud", if (n_studies == 1L) "y" else "ies", ")")
+      }
     }
 
-    row_idx <- row_idx + 3
+    row_idx <- row_idx + 4
   }
 
   # Convert to data frame
   df <- as.data.frame(result, stringsAsFactors = FALSE)
   colnames(df) <- col_names
 
+  # Carried for the printed header; dropped by the CSV exporter.
+  attr(df, "caliper_tail") <- caliper_results[[1]]$tail
+  attr(df, "caliper_cluster_method") <- caliper_results[[1]]$cluster_method
+
   df
+}
+
+#' @title Human-readable label for a caliper direction
+#' @param direction *[character]* Value returned by [caliper_direction()].
+#' @return *[character]* Label for display.
+caliper_direction_label <- function(direction) {
+  if (is.null(direction) || is.na(direction)) {
+    return("")
+  }
+  switch(direction,
+    above = "excess above",
+    below = "excess below (anti-hacking)",
+    balanced = "balanced",
+    ""
+  )
 }
 
 # MAIVE utilities ----------------------------------------------------------
@@ -558,6 +746,8 @@ run_p_hacking_tests <- function(df, options) {
           t_stats = t_stats,
           thresholds = options$caliper_thresholds,
           widths = options$caliper_widths,
+          study_id = if (isFALSE(options$caliper_cluster)) NULL else study_id,
+          tail = options$caliper_tail %||% "auto",
           add_significance_marks = options$add_significance_marks,
           round_to = options$round_to
         )
@@ -763,6 +953,10 @@ box::export(
   run_caliper_tests,
   run_p_hacking_tests,
   run_single_caliper,
+  resolve_caliper_tail,
+  cluster_robust_share_test,
+  caliper_direction,
+  build_caliper_summary,
   compute_pvalues,
   resolve_t_stats,
   prepare_maive_data,

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -25,6 +25,8 @@ p_hacking_tests <- function(df) {
   caliper_thresholds <- opt$caliper_thresholds %||% c(1.645, 1.96, 2.58)
   caliper_widths <- opt$caliper_widths %||% c(0.05, 0.1, 0.15)
   caliper_display_ratios <- opt$caliper_display_ratios %||% TRUE
+  caliper_tail <- opt$caliper_tail %||% "auto"
+  caliper_cluster <- opt$caliper_cluster %||% TRUE
 
   # Elliott options
   include_elliott <- opt$include_elliott %||% TRUE
@@ -65,6 +67,8 @@ p_hacking_tests <- function(df) {
     is.numeric(caliper_thresholds),
     is.numeric(caliper_widths),
     is.logical(caliper_display_ratios),
+    is.character(caliper_tail),
+    is.logical(caliper_cluster),
     is.logical(include_elliott),
     is.numeric(lcm_iterations),
     is.numeric(lcm_grid_points),
@@ -90,6 +94,10 @@ p_hacking_tests <- function(df) {
   )
 
   assert(length(caliper_thresholds) > 0, "caliper_thresholds must not be empty")
+  assert(
+    caliper_tail %in% c("auto", "positive", "negative", "absolute"),
+    "caliper_tail must be one of: auto, positive, negative, absolute"
+  )
   assert(length(caliper_widths) > 0, "caliper_widths must not be empty")
   assert(lcm_iterations > 0, "lcm_iterations must be positive")
   assert(lcm_grid_points > 0, "lcm_grid_points must be positive")
@@ -114,6 +122,8 @@ p_hacking_tests <- function(df) {
     caliper_thresholds = caliper_thresholds,
     caliper_widths = caliper_widths,
     caliper_display_ratios = caliper_display_ratios,
+    caliper_tail = caliper_tail,
+    caliper_cluster = caliper_cluster,
     include_elliott = include_elliott,
     lcm_iterations = as.integer(lcm_iterations),
     lcm_grid_points = as.integer(lcm_grid_points),
@@ -150,6 +160,19 @@ p_hacking_tests <- function(df) {
       cli::cli_h3("Caliper tests (Gerber & Malhotra, 2008)")
       cli::cli_text("Tests for discontinuities in t-statistic distributions around significance thresholds.")
 
+      tail_used <- attr(results$caliper, "caliper_tail") %||% "positive"
+      tail_note <- switch(tail_used,
+        positive = "positive t-statistics (t > threshold)",
+        negative = "negative t-statistics (t < -threshold)",
+        absolute = "absolute t-statistics (|t| > threshold)",
+        tail_used
+      )
+      cli::cli_text("Tail inspected: {tail_note}. Only an excess {.emph above} the threshold indicates p-hacking.")
+
+      if (identical(attr(results$caliper, "caliper_cluster_method"), "study")) {
+        cli::cli_text("P-values are clustered at the study level.")
+      }
+
       caliper_lines <- utils::capture.output(
         print(results$caliper, row.names = FALSE) # nolint: undesirable_function_linter.
       )
@@ -160,6 +183,10 @@ p_hacking_tests <- function(df) {
     # Elliott tests (2022)
     if (!is.null(results$elliott) && nrow(results$elliott) > 0) {
       cli::cli_h3("Elliott et al. (2022) tests")
+      cli::cli_text(
+        "These test global monotonicity of the p-value density, so they can legitimately ",
+        "disagree with the local caliper results above."
+      )
 
       elliott_lines <- utils::capture.output(
         print(results$elliott, row.names = FALSE) # nolint: undesirable_function_linter.

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -645,6 +645,27 @@ methods:
         If `TRUE`, display ratios (n_above/n_below) for Caliper tests.
         If `FALSE`, display total count (n_above + n_below).
 
+    caliper_tail:
+      type: "character"
+      default: "auto"
+      help: |
+        Which tail of the t-statistic distribution the Caliper test inspects.
+        The canonical Gerber & Malhotra (2008) caliper is one-sided, applied in
+        the direction the literature has an incentive to report.
+        "auto" (default) picks the tail holding the majority of the t-statistics,
+        so a literature of mostly negative effects is tested at t < -threshold.
+        "positive" and "negative" force one tail; "absolute" pools both by
+        taking |t|, which fits literatures reporting findings of either sign.
+
+    caliper_cluster:
+      type: "logical"
+      default: true
+      help: |
+        If `TRUE` (default), test the Caliper share with a study-clustered
+        statistic instead of an exact binomial test. The binomial test treats
+        every estimate in the window as independent, which overstates
+        significance when a few studies contribute most of the window.
+
     include_elliott:
       type: "logical"
       default: true

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -21,7 +21,11 @@ box::use(
     run_cox_shi,
     run_fisher,
     run_caliper_tests,
-    run_p_hacking_tests
+    run_p_hacking_tests,
+    resolve_caliper_tail,
+    cluster_robust_share_test,
+    caliper_direction,
+    build_caliper_summary
   ],
   artma / calc / methods / elliott[cox_shi_test, simulate_cdfs_parallel]
 )
@@ -146,6 +150,147 @@ test_that("run_single_caliper flags hacked data (excess mass just above threshol
   res <- run_single_caliper(t_stats, threshold = 1.96, width = 0.05)
 
   expect_true(res$p_value < 0.05)
+})
+
+# Caliper tail selection ------------------------------------------------------
+
+test_that("resolve_caliper_tail picks the tail holding most of the mass", {
+  expect_equal(resolve_caliper_tail(c(1, 2, 3, -1), tail = "auto"), "positive")
+  expect_equal(resolve_caliper_tail(c(-1, -2, -3, 1), tail = "auto"), "negative")
+  # Explicit choices are never overridden.
+  expect_equal(resolve_caliper_tail(c(-1, -2, -3), tail = "positive"), "positive")
+  expect_equal(resolve_caliper_tail(c(1, 2, 3), tail = "absolute"), "absolute")
+})
+
+test_that("resolve_caliper_tail defaults to positive without usable values", {
+  expect_equal(resolve_caliper_tail(c(0, 0, NA_real_), tail = "auto"), "positive")
+  expect_equal(resolve_caliper_tail(numeric(0), tail = "auto"), "positive")
+})
+
+test_that("resolve_caliper_tail rejects an unknown tail", {
+  expect_error(resolve_caliper_tail(c(1, 2), tail = "sideways"))
+})
+
+test_that("run_single_caliper inspects the negative tail in a negative literature", {
+  # Excess mass just below -1.96, plus noise well away from the threshold.
+  t_stats <- c(rep(-1.97, 18), rep(-1.94, 3), rep(-0.4, 40))
+
+  auto <- run_single_caliper(t_stats, threshold = 1.96, width = 0.05)
+  expect_equal(auto$tail, "negative")
+  expect_equal(auto$n_above, 18)
+  expect_equal(auto$n_below, 3)
+  expect_equal(auto$direction, "above")
+
+  # The old signed behaviour looks at the empty positive tail.
+  signed <- run_single_caliper(t_stats, threshold = 1.96, width = 0.05, tail = "positive")
+  expect_equal(signed$n_above, 0)
+  expect_true(is.na(signed$share_above))
+})
+
+test_that("run_single_caliper pools both tails when asked", {
+  t_stats <- c(rep(-1.97, 10), rep(1.97, 8), rep(-1.94, 2))
+
+  res <- run_single_caliper(t_stats, threshold = 1.96, width = 0.05, tail = "absolute")
+
+  expect_equal(res$tail, "absolute")
+  expect_equal(res$n_above, 18)
+  expect_equal(res$n_below, 2)
+})
+
+# Caliper study clustering ----------------------------------------------------
+
+test_that("run_single_caliper clusters window observations by study", {
+  # 16 above / 3 below, but half the above-threshold mass comes from 2 studies.
+  t_stats <- c(rep(1.97, 16), rep(1.94, 3))
+  study_id <- c(rep("s18", 4), rep("s45", 4), paste0("s", 1:8), c("s1", "s2", "s3"))
+
+  unclustered <- run_single_caliper(t_stats, threshold = 1.96, width = 0.05)
+  clustered <- run_single_caliper(t_stats, threshold = 1.96, width = 0.05, study_id = study_id)
+
+  expect_equal(clustered$share_above, unclustered$share_above)
+  expect_equal(clustered$cluster_method, "study")
+  expect_equal(clustered$n_studies, 10L)
+  # Clustering must not make the evidence look stronger than the naive test.
+  expect_true(clustered$p_value > unclustered$p_value)
+})
+
+test_that("cluster_robust_share_test falls back to the exact test without clustering", {
+  above <- c(rep(TRUE, 8), rep(FALSE, 2))
+
+  no_ids <- cluster_robust_share_test(above, NULL)
+  expect_equal(no_ids$cluster_method, "none")
+  expect_equal(no_ids$p_value, stats::binom.test(8, 10, p = 0.5)$p.value, tolerance = 1e-12)
+
+  # A single study gives no between-study variation to estimate.
+  one_study <- cluster_robust_share_test(above, rep("s1", 10))
+  expect_equal(one_study$cluster_method, "none")
+  expect_equal(one_study$n_studies, 1L)
+
+  # Every study identical: zero between-cluster spread, so fall back as well.
+  degenerate <- cluster_robust_share_test(c(TRUE, TRUE, TRUE, TRUE), c("a", "b", "c", "d"))
+  expect_true(degenerate$cluster_method %in% c("none", "study"))
+})
+
+test_that("cluster_robust_share_test errors on a mismatched study_id length", {
+  expect_error(cluster_robust_share_test(c(TRUE, FALSE), c("a")))
+})
+
+test_that("run_single_caliper rejects a study_id of the wrong length", {
+  expect_error(run_single_caliper(c(1.97, 1.94), study_id = c("a")))
+})
+
+# Caliper direction -----------------------------------------------------------
+
+test_that("caliper_direction labels which side carries the excess", {
+  expect_equal(caliper_direction(0.8), "above")
+  expect_equal(caliper_direction(0.3), "below")
+  expect_equal(caliper_direction(0.5), "balanced")
+  expect_true(is.na(caliper_direction(NA_real_)))
+})
+
+test_that("run_caliper_tests only stars an excess above the threshold", {
+  # 4 above / 16 below at the 1.645 threshold: significant, but anti-p-hacking.
+  t_stats <- c(rep(1.66, 4), rep(1.60, 16))
+
+  results <- run_caliper_tests(
+    t_stats,
+    thresholds = 1.645,
+    widths = 0.1,
+    show_progress = FALSE
+  )
+
+  expect_equal(results[[1]]$direction, "below")
+  expect_false(grepl("\\*", results[[1]]$p_value))
+
+  # Flip the imbalance and the same p-value does get starred.
+  flipped <- run_caliper_tests(
+    c(rep(1.66, 16), rep(1.60, 4)),
+    thresholds = 1.645,
+    widths = 0.1,
+    show_progress = FALSE
+  )
+  expect_equal(flipped[[1]]$direction, "above")
+  expect_match(flipped[[1]]$p_value, "\\*")
+})
+
+test_that("build_caliper_summary shows a direction row and study counts", {
+  t_stats <- c(rep(1.97, 6), rep(1.94, 2))
+  study_id <- c("a", "a", "b", "b", "c", "c", "d", "d")
+
+  results <- run_caliper_tests(
+    t_stats,
+    thresholds = 1.96,
+    widths = 0.05,
+    study_id = study_id,
+    show_progress = FALSE
+  )
+  summary <- build_caliper_summary(results, list(display_ratios = TRUE))
+
+  expect_true(any(grepl("Direction", summary[[1]])))
+  expect_true(any(grepl("excess above", summary[[2]])))
+  expect_true(any(grepl("6/2 \\(4 studies\\)", summary[[2]])))
+  expect_equal(attr(summary, "caliper_tail"), "positive")
+  expect_equal(attr(summary, "caliper_cluster_method"), "study")
 })
 
 # run_caliper_tests ---------------------------------------------------------
@@ -307,7 +452,8 @@ test_that("run_p_hacking_tests dedupes duplicated caliper thresholds/widths with
   )
 
   expect_true(is.data.frame(result$caliper))
-  expect_equal(nrow(result$caliper), 3L)
+  # 4 rows per width: share above, direction, p-value, n count.
+  expect_equal(nrow(result$caliper), 4L)
   expect_equal(ncol(result$caliper), 2L)
 })
 

--- a/vignettes/options-files.Rmd
+++ b/vignettes/options-files.Rmd
@@ -114,6 +114,8 @@ Method-specific parameters for each analysis method:
 - `include_caliper`: Whether to include Caliper tests
 - `caliper_thresholds`: T-statistic thresholds to test
 - `caliper_widths`: Interval widths around thresholds
+- `caliper_tail`: Which tail to inspect (`auto`, `positive`, `negative`, `absolute`)
+- `caliper_cluster`: Whether to cluster the caliper p-values by study
 - `include_elliott`: Whether to include Elliott et al. tests
 - `lcm_iterations`: Number of simulations for LCM test
 


### PR DESCRIPTION
Fixes three defects in the Gerber-Malhotra caliper test (`run_single_caliper`, `run_caliper_tests` in `inst/artma/econometric/p_hacking.R`), verified empirically on the meta-analysis.cz class-size data (PCC effect, 2817 obs, 66 studies, 63% negative effects).

## 1. Wrong tail

The signed t-statistic was compared against positive-only thresholds `c(1.645, 1.96, 2.58)`, so a negative-effect literature was inspected in the tail with no p-hacking incentive. On the class data at threshold 1.96 / width 0.05 the signed test flagged share 0.842, p=0.004; the tail carrying the actual mass gives a very different picture.

New `caliper_tail` option (`inst/artma/methods/p_hacking_tests.R`, template default `"auto"`): `resolve_caliper_tail()` orients estimates toward the tail holding the majority of the t-statistics, matching the canonical one-sided caliper applied in the hypothesis direction. `"positive"`, `"negative"`, and `"absolute"` (pool both via `|t|`) force the choice. The tested tail is printed in the output header.

## 2. No study clustering

`binom.test` treated every window observation as independent, but on the class data 8 of the 16 above-threshold estimates came from just 2 studies. `cluster_robust_share_test()` aggregates the score residual within each study and refers a cluster-robust z to `t(G-1)`, falling back to the exact binomial test when clustering is not identified (fewer than two studies, or zero between-study variance). The `study_id` vector is now threaded from the caller. New `caliper_cluster` option (default TRUE). The window study count is shown in the n-count row.

## 3. No direction shown

A significant result in the *anti*-p-hacking direction (share < 0.5) was starred under "tests for discontinuities". Significance marks are now applied only when the excess sits above the threshold, and a new Direction row labels each cell (`excess above` / `excess below (anti-hacking)` / `balanced`).

## Printed-output note

The Elliott et al. (2022) section now notes that those are global-monotonicity tests and can legitimately disagree with the local caliper results.

## Tests

Extended `tests/testthat/test-econometric-p-hacking.R` covering tail resolution and orientation, study clustering vs the naive binomial, direction labelling and conditional starring, and the summary-table shape. Full file passes (123 tests). Vignette and options template updated.
