### PR TITLE
test(p-hacking): pin Cox-Shi nested-window sensitivity to bin resolution

### DIFF
--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -482,6 +482,14 @@ run_discontinuity <- function(pvalues, cutoff = 0.05, bandwidth = NULL) {
 }
 
 #' @title Run Cox-Shi test wrapper
+#' @description
+#' `n_bins` fixes the bin *count*, not the bin *width*, so the same value
+#' applied to the [0, 0.05] and [0, 0.10] windows makes the wider window twice
+#' as coarse. A spike in the p-curve narrower than one bin can be averaged away
+#' on the wider window while remaining visible on the narrower one, and the two
+#' windows are then not comparable, nor need their p-values be ordered. Compare
+#' windows at a matched bin width (double `n_bins` when doubling `p_max`)
+#' before reading anything into a disagreement between them.
 #' @param pvalues *[numeric]* P-values to test.
 #' @param study_id *[vector]* Study identifiers for clustering.
 #' @param p_min *[numeric]* Lower bound of interval.

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -723,6 +723,13 @@ methods:
         Number of bins for discretization in Cox-Shi tests.
         More bins provide finer resolution but require more observations; empty
         bins make the covariance matrix singular and the test is then skipped.
+        The same bin count is used for both the [0, 0.05] and [0, 0.10] windows
+        (matching the canonical Elliott et al. code), so the wider window runs
+        at half the bin width of the narrower one. A spike in the p-curve that
+        is narrower than a bin can therefore be averaged away on [0, 0.10]
+        while still showing up on [0, 0.05], and the two windows may disagree
+        sharply. When they do, rerun with the bin count doubled to compare the
+        windows at a matched bin width before reading anything into the gap.
 
     cox_shi_order:
       type: "integer"

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -526,6 +526,59 @@ test_that("cox_shi_test returns 1 for a monotone p-curve with no binding constra
   )
 })
 
+# Bin counts of the class-size p-curve (meta-analysis.cz, PCC estimates) at
+# width 0.005 over [0, 0.10]. The curve spikes in [0.045, 0.05]: 36 estimates
+# against 16 in the preceding bin, the classic just-under-0.05 signature.
+class_shaped_pcurve <- function() {
+  counts <- c(
+    673, 80, 46, 42, 29, 35, 31, 23, 16, 36,
+    19, 21, 19, 20, 19, 20, 20, 11, 11, 18
+  )
+  edges <- seq(0, 0.10, by = 0.005)
+  midpoints <- (edges[-length(edges)] + edges[-1]) / 2
+  rep(midpoints, counts)
+}
+
+# `cox_shi_bins` is applied to both windows (as in the canonical `Example.R`,
+# which fixes J = 10 regardless of the interval), so [0, 0.10] runs at half the
+# bin resolution of [0, 0.05]. Its 0.01-wide bins merge the spike with its
+# neighbour -- 16 + 36 = 52 against 31 + 23 = 54 -- so the curve reads as
+# monotone and the p-value climbs. The nested windows therefore disagree
+# sharply. That is a property of the binning, not a defect in the port: on the
+# class-size data both windows agree once the bin *width* is held fixed instead
+# of the bin *count* (p = 0.0004 on [0, 0.05] with J = 20, p = 0.0044 on
+# [0, 0.10] with J = 20). All four values below were cross-checked against the
+# canonical `Tests.R` and agreed exactly.
+test_that("cox_shi_test reproduces the nested-window disagreement", {
+  pvalues <- class_shaped_pcurve()
+
+  expect_equal(
+    cox_shi_test(pvalues, 0, 0, 0.05, J = 10, K = 2, use_bounds = 1),
+    0.092150969638,
+    tolerance = 1e-6
+  )
+  expect_equal(
+    cox_shi_test(pvalues, 0, 0, 0.10, J = 10, K = 2, use_bounds = 1),
+    0.362149788835,
+    tolerance = 1e-6
+  )
+})
+
+test_that("cox_shi_test resolves the sub-bin spike when the bin width is halved", {
+  pvalues <- class_shaped_pcurve()
+
+  expect_equal(
+    cox_shi_test(pvalues, 0, 0, 0.05, J = 20, K = 2, use_bounds = 1),
+    0,
+    tolerance = 1e-9
+  )
+  expect_equal(
+    cox_shi_test(pvalues, 0, 0, 0.10, J = 20, K = 2, use_bounds = 1),
+    0.261350676443,
+    tolerance = 1e-6
+  )
+})
+
 test_that("cox_shi_test skips with a reason when the covariance is singular", {
   # Too few p-values in the window for 20 bins: empty bins make omega singular.
   set.seed(404, kind = "Mersenne-Twister", normal.kind = "Inversion")


### PR DESCRIPTION
## What

Investigates the non-monotone Cox-Shi result flagged on meta-analysis.cz class-size data (PCC): `Cox-Shi [0, 0.05]` p=0.090 but `Cox-Shi [0, 0.10]` p=0.951, a 10x swing across nested windows.

## Finding: the port is correct

Ran the artma `cox_shi_test` and the canonical `Tests.R` (`nvkudrin/Detecting-p-hacking-Code`, `CoxShi`) on the same standardized data (2819 obs, 66 studies; `idstudy`/`pcc`/`se_pcc`, `se > 0` dropped) with `J=10`, `K=2`, bounds on, seed 123:

| Window | canonical | artma | diff |
|---|---|---|---|
| [0, 0.05] | 0.0895691620 | 0.0895691620 | 7e-12 |
| [0, 0.10] | 0.9514188509 | 0.9514188508 | 2e-11 |

Both windows agree to ~1e-11. No porting bug.

## The swing is bin resolution, not a defect

The class-size p-curve spikes in `[0.045, 0.05]` (36 estimates vs 16 in the bin before it, the just-under-0.05 signature). The same `cox_shi_bins` is applied to both windows (matching the canonical `Example.R`, which fixes `J=10` regardless of interval), so `[0, 0.10]` runs at 0.01-wide bins that merge the spike with its neighbour (16+36 vs 31+23), the curve reads as monotone, and p climbs to 0.95.

Hold bin *width* fixed instead of bin *count* and the signal returns: `[0, 0.05]` J=20 -> p=0.0004, `[0, 0.10]` J=20 -> p=0.0044. Nested-window p-values need not be ordered, and here the gap is an artifact of comparing windows at mismatched bin widths.

## Changes

- **Regression tests** ([test-econometric-p-hacking.R](tests/testthat/test-econometric-p-hacking.R)): a deterministic fixture built from the class-size bin counts pins all four values (`{[0,0.05], [0,0.10]} x {J=10, J=20}`), each cross-checked against canonical `Tests.R` (exact agreement). Addresses the missing Cox-Shi coverage flagged in #260.
- **Docs**: the `cox_shi_bins` template help and the `run_cox_shi` roxygen now explain the count-vs-width trap and advise doubling `n_bins` when doubling `p_max` before reading into a window disagreement.

Default `cox_shi_bins` stays at 10 (the canonical convention).
