### PR TITLE
fix(p_hacking_tests): keep install/upgrade hints in MAIVE skip reason

### DIFF
--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -691,7 +691,10 @@ run_p_hacking_tests <- function(df, options) {
           )
         },
         error = function(e) {
-          skipped[["maive"]] <<- e$message
+          # conditionMessage(), not e$message: the latter keeps only the cli
+          # header, dropping the bullets that carry the install and upgrade
+          # hints the user needs to act on the skip.
+          skipped[["maive"]] <<- conditionMessage(e)
           NULL
         }
       )

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -386,6 +386,38 @@ test_that("run_p_hacking_tests records a skip reason when MAIVE lacks n_obs", {
   expect_true(is.null(result$maive))
 })
 
+test_that("the MAIVE skip reason keeps the install hint when the package is absent", {
+  local_options(artma.verbose = 1)
+  local_pretend_packages_absent("MAIVE")
+
+  result <- run_p_hacking_tests(
+    make_p_hacking_df(),
+    base_p_hacking_options(include_caliper = FALSE, include_maive = TRUE)
+  )
+
+  expect_true(is.null(result$maive))
+  expect_match(result$skipped$maive, "MAIVE")
+  # The actionable half lives in a cli bullet, which e$message would drop.
+  expect_match(result$skipped$maive, "install.packages")
+})
+
+test_that("the MAIVE skip reason reports the installed version when it is too old", {
+  # Without the package the absence check fires first and never reaches the
+  # version branch under test.
+  skip_if_not_installed("MAIVE")
+  local_options(artma.verbose = 1)
+  local_pretend_package_version("MAIVE", "0.0.2.11")
+
+  result <- run_p_hacking_tests(
+    make_p_hacking_df(),
+    base_p_hacking_options(include_caliper = FALSE, include_maive = TRUE)
+  )
+
+  expect_true(is.null(result$maive))
+  expect_match(result$skipped$maive, "0\\.2\\.4 or higher")
+  expect_match(result$skipped$maive, "0\\.0\\.2\\.11")
+})
+
 test_that("run_lcm skips with a reason instead of failing silently", {
   local_pretend_packages_absent("fdrtool")
 


### PR DESCRIPTION
## What

When the MAIVE estimator soft-skips inside `p_hacking_tests`, capture the full `cli` condition message (header plus bullets) instead of just the header.

## Why

The abort in `inst/artma/calc/methods/maive.R` builds an actionable message: a header plus an `i` bullet carrying the fix (`install.packages("MAIVE")` when absent, or `Installed version: X. Upgrade with: ...` when too old). The skip-reason handler captured `e$message`, which keeps only the header, so the user saw "MAIVE 0.2.4 or higher is required" with no version they have and no way to fix it. Switching to `conditionMessage(e)` preserves the bullet.

## Scope note

The runtime minimum-version check (`maive_version_ok`, `MAIVE_MIN_VERSION`), the CRAN install hint, and `MAIVE (>= 0.2.4)` in DESCRIPTION already exist from prior work; the fork is now the published CRAN package, so the hint correctly points at CRAN. This PR is the one remaining gap: the actionable text was being dropped on the way to the user. No README-dev change: the local `MAIVE` build under `4.4/site-library` is built for R 4.5.1 (not a stale orphan), so there is no R-minor mismatch to document.

## Verification

Ran `run_p_hacking_tests` across all four MAIVE paths; each messages a distinct, actionable skip reason (or runs):

- installed: runs
- absent: `Package MAIVE is required... install.packages("MAIVE")`
- too old (0.0.2.11): `Package MAIVE 0.2.4 or higher is required... Installed version: 0.0.2.11. Upgrade with: ...`
- missing `n_obs`: `requires the 'n_obs' column...`

Two tests added for the absent and stale-version paths. Full file: `FAIL 0 | PASS 89`. Lint clean.