### PR TITLE
fix(exogeneity): fill formatted columns when p-uniform* skips estimation

### DIFF
--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -423,85 +423,33 @@ run_puniform_star <- function(df, add_significance_marks = TRUE, round_to = 3L, 
   sig_mask <- z_scores >= z_crit
 
   if (sum(sig_mask) < 2) {
-    # Not enough significant studies
-    return(list(
-      coefficients = data.frame(
-        term = c("effect", "publication_bias_test"),
-        term_label = c("Effect Beyond Bias", "Publication Bias Test"),
-        estimate = c(NA_real_, NA_real_),
-        std_error = c(NA_real_, NA_real_),
-        statistic = c(NA_real_, NA_real_),
-        p_value = c(NA_real_, NA_real_),
-        n_obs = nrow(df),
-        stringsAsFactors = FALSE
-      ),
-      test_statistic = NA_real_,
-      test_p_value = NA_real_
-    ))
-  }
-
-  yi_sig <- med_yi[sig_mask]
-  vi_sig <- med_vi[sig_mask]
-  ni_sig <- med_ni[sig_mask]
-
-  if (method == "P") {
-    mm_result <- run_puniform_mm(yi_sig, vi_sig, alpha)
-    theta_est <- mm_result$theta_est
-    theta_se <- mm_result$theta_se
-    l_stat <- mm_result$l_stat
-    l_pval <- mm_result$l_pval
+    # Not enough significant studies to estimate theta or run the LR test.
+    # Fall through to the shared coefficient formatting below so the returned
+    # data.frame always has the same columns as the fully-estimated case.
+    theta_est <- NA_real_
+    theta_se <- NA_real_
+    l_stat <- NA_real_
+    l_pval <- NA_real_
   } else {
-    # Optimize
-    start_theta <- mean(yi_sig)
-    start_tau <- stats::sd(yi_sig)
+    yi_sig <- med_yi[sig_mask]
+    vi_sig <- med_vi[sig_mask]
+    ni_sig <- med_ni[sig_mask]
 
-    opt_result <- tryCatch(
-      {
-        stats::optim(
-          par = c(start_theta, start_tau),
-          fn = puniform_star_nll,
-          yi = yi_sig,
-          vi = vi_sig,
-          ni = ni_sig,
-          alpha = alpha,
-          method = "BFGS"
-        )
-      },
-      error = function(e) {
-        list(par = c(NA_real_, NA_real_), value = NA_real_, convergence = 1)
-      }
-    )
-
-    if (opt_result$convergence != 0 || any(is.na(opt_result$par))) {
-      theta_est <- NA_real_
-      theta_se <- NA_real_
-      l_stat <- NA_real_
-      l_pval <- NA_real_
+    if (method == "P") {
+      mm_result <- run_puniform_mm(yi_sig, vi_sig, alpha)
+      theta_est <- mm_result$theta_est
+      theta_se <- mm_result$theta_se
+      l_stat <- mm_result$l_stat
+      l_pval <- mm_result$l_pval
     } else {
-      theta_est <- opt_result$par[1]
+      # Optimize
+      start_theta <- mean(yi_sig)
+      start_tau <- stats::sd(yi_sig)
 
-      # Approximate standard error using Hessian
-      theta_se <- tryCatch(
+      opt_result <- tryCatch(
         {
-          hess <- stats::optimHess(
-            par = opt_result$par,
-            fn = puniform_star_nll,
-            yi = yi_sig,
-            vi = vi_sig,
-            ni = ni_sig,
-            alpha = alpha
-          )
-          sqrt(solve(hess)[1, 1])
-        },
-        error = function(e) NA_real_
-      )
-
-      # Likelihood ratio test for publication bias (H0: theta = 0)
-      ll_full <- -opt_result$value
-      ll_null <- tryCatch(
-        {
-          opt_null <- stats::optim(
-            par = c(0, start_tau),
+          stats::optim(
+            par = c(start_theta, start_tau),
             fn = puniform_star_nll,
             yi = yi_sig,
             vi = vi_sig,
@@ -509,13 +457,57 @@ run_puniform_star <- function(df, add_significance_marks = TRUE, round_to = 3L, 
             alpha = alpha,
             method = "BFGS"
           )
-          -opt_null$value
         },
-        error = function(e) NA_real_
+        error = function(e) {
+          list(par = c(NA_real_, NA_real_), value = NA_real_, convergence = 1)
+        }
       )
 
-      l_stat <- 2 * (ll_full - ll_null)
-      l_pval <- if (is.finite(l_stat) && l_stat > 0) stats::pchisq(l_stat, df = 1, lower.tail = FALSE) else NA_real_
+      if (opt_result$convergence != 0 || any(is.na(opt_result$par))) {
+        theta_est <- NA_real_
+        theta_se <- NA_real_
+        l_stat <- NA_real_
+        l_pval <- NA_real_
+      } else {
+        theta_est <- opt_result$par[1]
+
+        # Approximate standard error using Hessian
+        theta_se <- tryCatch(
+          {
+            hess <- stats::optimHess(
+              par = opt_result$par,
+              fn = puniform_star_nll,
+              yi = yi_sig,
+              vi = vi_sig,
+              ni = ni_sig,
+              alpha = alpha
+            )
+            sqrt(solve(hess)[1, 1])
+          },
+          error = function(e) NA_real_
+        )
+
+        # Likelihood ratio test for publication bias (H0: theta = 0)
+        ll_full <- -opt_result$value
+        ll_null <- tryCatch(
+          {
+            opt_null <- stats::optim(
+              par = c(0, start_tau),
+              fn = puniform_star_nll,
+              yi = yi_sig,
+              vi = vi_sig,
+              ni = ni_sig,
+              alpha = alpha,
+              method = "BFGS"
+            )
+            -opt_null$value
+          },
+          error = function(e) NA_real_
+        )
+
+        l_stat <- 2 * (ll_full - ll_null)
+        l_pval <- if (is.finite(l_stat) && l_stat > 0) stats::pchisq(l_stat, df = 1, lower.tail = FALSE) else NA_real_
+      }
     }
   }
 

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -2,11 +2,13 @@ box::use(
   testthat[
     expect_equal,
     expect_error,
+    expect_no_error,
     expect_true,
     skip_if_not_installed,
     test_that
   ],
   withr[local_options],
+  artma / data / mock[create_mock_df],
   artma / methods / p_hacking_tests[p_hacking_tests],
   artma / methods / exogeneity_tests[exogeneity_tests]
 )
@@ -96,4 +98,23 @@ test_that("exogeneity_tests aborts when a required column is missing", {
   local_options(artma.verbose = 1)
   df <- make_exogeneity_df(n = 30)
   expect_error(exogeneity_tests(df[, c("effect", "se")]))
+})
+
+test_that("exogeneity_tests handles mock data with too few significant p-uniform studies", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  # The package's own mock generator spreads effect/se uniformly at random, so
+  # almost no study-level median clears the significance threshold p-uniform*
+  # requires. That drives run_puniform_star() down its early-return path,
+  # which used to omit the estimate_formatted/std_error_formatted columns and
+  # crash build_exogeneity_summary() with "replacement has 4 rows, data has 6".
+  df <- create_mock_df(nrow = 600, n_studies = 30)
+  df$study_size <- unname(as.integer(table(df$study_id)[as.character(df$study_id)]))
+
+  result <- expect_no_error(exogeneity_tests(df))
+
+  expect_true(is.data.frame(result$tables$summary))
+  expect_equal(nrow(result$tables$summary), 6L)
 })


### PR DESCRIPTION
## Summary
- `exogeneity_tests` crashed with `replacement has 4 rows, data has 6` when run on data where fewer than 2 studies clear the p-uniform* significance threshold, including the package's own mock data.
- Root cause: `run_puniform_star()`'s early-return path (too few significant studies) built a `coefficients` data.frame without the `significance`/`estimate_formatted`/`std_error_formatted` columns that the normal path adds. `build_exogeneity_summary()` reading the missing `estimate_formatted`/`std_error_formatted` columns got `NULL`, which silently vanished inside `c(...)`, shrinking the assigned vector and triggering the row-count mismatch.
- Fix: replace the early `return()` with a fall-through so both paths go through the same coefficient-building and formatting code, guaranteeing the returned data.frame always has the same columns.

## Test plan
- [x] Added a regression test (`test-methods-p-hacking-exogeneity.R`) that runs `exogeneity_tests()` on `create_mock_df(nrow = 600, n_studies = 30)`, which reliably has too few significant studies and reproduced the crash before the fix.
- [x] `make lint` — no lints found.
- [x] `make test` — 1771 passed, 0 failed.