### PR TITLE
fix(exogeneity): rank IV instruments by first-stage F

### DIFF
--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -68,14 +68,37 @@ get_robust_vcov <- function(model, cluster) {
 
 # IV regression utilities --------------------------------------------------
 
-#' @title Identify best instrument for IV regression
+#' @title Conventional threshold for the first-stage weak-instruments F-test
 #' @description
-#' Evaluates multiple instruments for IV regression using diagnostics
-#' (R-squared, weak instruments test, Wu-Hausman test, Sargan test).
+#' Staiger-Stock/Stock-Yogo rule-of-thumb minimum first-stage F-statistic
+#' below which an instrument is considered weak.
+WEAK_INSTRUMENT_F_THRESHOLD <- 10
+
+#' @title Default tie-break instrument among equally strong candidates
+#' @description
+#' `1/sqrt(n_obs)` is the theoretically motivated instrument for a
+#' meta-analysis IV regression of effect on se, since the standard error
+#' of an estimator scales with `1/sqrt(N)`. It is preferred whenever
+#' several candidate instruments tie on first-stage strength.
+WEAK_INSTRUMENT_TIEBREAK <- "1/sqrt(n_obs)"
+
+#' @title Identify the strongest instrument for IV regression
+#' @description
+#' Ranks candidate instruments by first-stage strength: the "Weak
+#' instruments" F-statistic reported by `AER::ivreg`'s diagnostics, which is
+#' the standard weak-instruments diagnostic for a single endogenous
+#' regressor. R-squared, Wu-Hausman, and Sargan are deliberately not used
+#' for selection: IV R-squared is unbounded below and has no
+#' instrument-quality interpretation; Wu-Hausman measures how strongly the
+#' data reject exogeneity, a property of the data rather than the
+#' instrument, so favoring a low Wu-Hausman p-value biases selection toward
+#' concluding endogeneity; and Sargan is unidentified (df1 = 0, p = NA)
+#' whenever there is exactly one instrument for one endogenous regressor,
+#' the case here.
 #' @param df *[data.frame]* Data frame with columns: effect, se, study_id, n_obs.
 #' @param instruments *[list]* List of numeric vectors, each representing a potential instrument.
 #' @param instruments_verbose *[character]* Verbose names for each instrument.
-#' @return *[character]* Name(s) of the best instrument(s).
+#' @return *[character]* Name of the strongest instrument by first-stage F-statistic.
 find_best_instrument <- function(df, instruments, instruments_verbose) {
   validate(
     is.data.frame(df),
@@ -87,12 +110,7 @@ find_best_instrument <- function(df, instruments, instruments_verbose) {
   required_cols <- c("effect", "se", "study_id", "n_obs")
   validate(all(required_cols %in% colnames(df)))
 
-  results <- data.frame(
-    r_squared = numeric(length(instruments)),
-    weak_instruments = numeric(length(instruments)),
-    wu_hausman = numeric(length(instruments)),
-    sargan = numeric(length(instruments))
-  )
+  first_stage_fstat <- rep(NA_real_, length(instruments))
 
   for (i in seq_along(instruments)) {
     instrument <- instruments[[i]]
@@ -107,7 +125,6 @@ find_best_instrument <- function(df, instruments, instruments_verbose) {
     )
 
     if (is.null(model)) {
-      results[i, ] <- NA_real_
       next
     }
 
@@ -116,43 +133,29 @@ find_best_instrument <- function(df, instruments, instruments_verbose) {
       error = function(e) NULL
     )
 
-    if (is.null(model_summary)) {
-      results[i, ] <- NA_real_
+    if (is.null(model_summary) || is.null(model_summary$diagnostics)) {
       next
     }
 
-    results[i, "r_squared"] <- model_summary$r.squared
-
-    if (!is.null(model_summary$diagnostics)) {
-      diag_names <- rownames(model_summary$diagnostics)
-      if ("Weak instruments" %in% diag_names) {
-        results[i, "weak_instruments"] <- model_summary$diagnostics["Weak instruments", "p-value"]
-      }
-      if ("Wu-Hausman" %in% diag_names) {
-        results[i, "wu_hausman"] <- model_summary$diagnostics["Wu-Hausman", "p-value"]
-      }
-      if ("Sargan" %in% diag_names) {
-        results[i, "sargan"] <- model_summary$diagnostics["Sargan", "p-value"]
-      }
+    diag_names <- rownames(model_summary$diagnostics)
+    if ("Weak instruments" %in% diag_names) {
+      first_stage_fstat[i] <- model_summary$diagnostics["Weak instruments", "statistic"]
     }
   }
 
-  rownames(results) <- instruments_verbose
+  names(first_stage_fstat) <- instruments_verbose
 
-  # Determine best instrument based on frequency across metrics
-  best_r_squared_idx <- if (any(!is.na(results$r_squared))) which.max(results$r_squared) else NA_integer_
-  best_weak_instruments_idx <- if (any(!is.na(results$weak_instruments))) which.min(results$weak_instruments) else NA_integer_
-  best_wu_hausman_idx <- if (any(!is.na(results$wu_hausman))) which.min(results$wu_hausman) else NA_integer_
-  best_sargan_idx <- if (any(!is.na(results$sargan))) which.min(results$sargan) else NA_integer_
+  assert(
+    any(!is.na(first_stage_fstat)),
+    "Unable to determine best instrument - first-stage F-statistic unavailable for all candidates"
+  )
 
-  best_instruments_idx <- c(best_r_squared_idx, best_weak_instruments_idx, best_wu_hausman_idx, best_sargan_idx)
-  freqs <- table(best_instruments_idx[!is.na(best_instruments_idx)])
+  max_fstat <- max(first_stage_fstat, na.rm = TRUE)
+  best_instruments <- instruments_verbose[!is.na(first_stage_fstat) & first_stage_fstat == max_fstat]
 
-  assert(length(freqs) > 0, "Unable to determine best instrument - all diagnostics returned NA")
-
-  max_freq <- max(freqs)
-  max_values <- as.integer(names(freqs[freqs == max_freq]))
-  best_instruments <- rownames(results)[max_values]
+  if (length(best_instruments) > 1 && WEAK_INSTRUMENT_TIEBREAK %in% best_instruments) {
+    best_instruments <- WEAK_INSTRUMENT_TIEBREAK
+  }
 
   best_instruments
 }
@@ -215,6 +218,21 @@ run_iv_regression <- function(df, iv_instrument = "automatic", add_significance_
     error = function(e) NA_real_
   )
 
+  # First-stage F-statistic for the chosen instrument (weak-instruments diagnostic)
+  first_stage_fstat <- NA_real_
+  if (!is.null(model_summary$diagnostics) && "Weak instruments" %in% rownames(model_summary$diagnostics)) {
+    first_stage_fstat <- model_summary$diagnostics["Weak instruments", "statistic"]
+  }
+
+  weak_instrument <- is.na(first_stage_fstat) || first_stage_fstat < WEAK_INSTRUMENT_F_THRESHOLD
+
+  if (weak_instrument) {
+    fstat_label <- format_number(first_stage_fstat, round_to)
+    cli::cli_alert_warning(
+      "Weak instrument: {.field {best_instrument}} has a first-stage F-statistic of {fstat_label} (below the conventional threshold of {WEAK_INSTRUMENT_F_THRESHOLD}). Publication-bias estimates from the IV regression may be unreliable."
+    )
+  }
+
   # Extract coefficients
   all_coefs <- model_summary$coefficients
 
@@ -246,7 +264,9 @@ run_iv_regression <- function(df, iv_instrument = "automatic", add_significance_
   list(
     coefficients = coefficients,
     instrument_name = best_instrument,
-    ar_fstat = fstat
+    ar_fstat = fstat,
+    first_stage_fstat = first_stage_fstat,
+    weak_instrument = weak_instrument
   )
 }
 
@@ -587,6 +607,8 @@ run_exogeneity_tests <- function(df, options) {
         coefficients = NULL,
         instrument_name = NA_character_,
         ar_fstat = NA_real_,
+        first_stage_fstat = NA_real_,
+        weak_instrument = NA,
         error = e$message
       )
     }
@@ -649,6 +671,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
     "Effect Beyond Bias",
     "(Std. Error)",
     "Total Observations",
+    "First-stage F",
     "F-test (AR)"
   )
 
@@ -664,12 +687,18 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
     pb <- iv_coef[iv_coef$term == "publication_bias", , drop = FALSE]
     eff <- iv_coef[iv_coef$term == "effect", , drop = FALSE]
 
+    first_stage_str <- format_number(iv_results$first_stage_fstat, options$round_to)
+    if (isTRUE(iv_results$weak_instrument) && !is.na(first_stage_str)) {
+      first_stage_str <- paste0(first_stage_str, " (weak instrument)")
+    }
+
     summary[["IV"]] <- na_to_not_computable(c(
       if (nrow(pb) > 0) pb$estimate_formatted else NA_character_,
       if (nrow(pb) > 0) pb$std_error_formatted else NA_character_,
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
       if (nrow(eff) > 0) eff$std_error_formatted else NA_character_,
       if (nrow(iv_coef) > 0) format_number(iv_coef$n_obs[1], 0) else NA_character_,
+      first_stage_str,
       format_number(iv_results$ar_fstat, options$round_to)
     ))
   } else {
@@ -701,6 +730,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
       if (nrow(eff) > 0) eff$std_error_formatted else NA_character_,
       if (nrow(pu_coef) > 0) format_number(pu_coef$n_obs[1], 0) else NA_character_,
+      "", # No first-stage F for p-uniform
       "" # No F-test for p-uniform
     ))
   } else {
@@ -715,5 +745,6 @@ box::export(
   run_exogeneity_tests,
   run_iv_regression,
   run_puniform_star,
-  find_best_instrument
+  find_best_instrument,
+  WEAK_INSTRUMENT_F_THRESHOLD
 )

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -191,9 +191,13 @@ methods:
       default: "automatic"
       help: |
         Instrument to use for the instrumental variable (IV) regression.
-        Use {.strong automatic} to automatically select the best instrument
-        based on diagnostics (R-squared, weak instruments, Wu-Hausman, Sargan).
-        Alternatively, specify a specific instrument formula involving n_obs.
+        Use {.strong automatic} to rank candidates by first-stage F-statistic
+        (the weak-instruments diagnostic) and pick the strongest, breaking
+        ties in favor of {.strong 1/sqrt(n_obs)}, the theoretically motivated
+        instrument. A warning is printed if the selected instrument's
+        first-stage F falls below the conventional weak-instrument threshold
+        of 10. Alternatively, specify a specific instrument formula involving
+        n_obs.
 
     puniform_alpha:
       type: "numeric"

--- a/tests/testthat/test-econometric-exogeneity.R
+++ b/tests/testthat/test-econometric-exogeneity.R
@@ -2,6 +2,8 @@ box::use(
   testthat[
     expect_equal,
     expect_error,
+    expect_false,
+    expect_message,
     expect_true,
     skip_if_not_installed,
     test_that
@@ -11,7 +13,8 @@ box::use(
     run_iv_regression,
     run_puniform_star,
     find_best_instrument,
-    run_exogeneity_tests
+    run_exogeneity_tests,
+    WEAK_INSTRUMENT_F_THRESHOLD
   ]
 )
 
@@ -27,6 +30,22 @@ make_exogeneity_df <- function(seed = 2024, n = 300, mu = 0.5, bias = 1.0) {
   set.seed(seed)
   n_obs <- sample(30:600, n, replace = TRUE)
   se <- 2 / sqrt(n_obs) + abs(rnorm(n, 0, 0.01))
+  effect <- mu + bias * se + rnorm(n, 0, 0.05)
+  data.frame(
+    effect = effect,
+    se = se,
+    study_id = rep(seq_len(60), length.out = n),
+    n_obs = n_obs,
+    study_size = n_obs
+  )
+}
+
+# A DGP where se is essentially unrelated to n_obs, so any instrument built
+# from n_obs is a weak predictor of se in the first stage.
+make_weak_instrument_df <- function(seed = 99, n = 300, mu = 0.5, bias = 1.0) {
+  set.seed(seed)
+  n_obs <- sample(30:600, n, replace = TRUE)
+  se <- 0.1 + abs(rnorm(n, 0, 0.05))
   effect <- mu + bias * se + rnorm(n, 0, 0.05)
   data.frame(
     effect = effect,
@@ -67,6 +86,8 @@ test_that("run_iv_regression recovers the effect and bias from a known DGP", {
   expect_equal(bias_est, 1.0, tolerance = 0.2)
   # Strong instrument: Anderson-Rubin F well above conventional weak thresholds.
   expect_true(res$ar_fstat > 30)
+  expect_true(res$first_stage_fstat > WEAK_INSTRUMENT_F_THRESHOLD)
+  expect_false(res$weak_instrument)
 })
 
 test_that("run_iv_regression auto-selects the sample-size instrument", {
@@ -87,6 +108,21 @@ test_that("run_iv_regression rejects an instrument without n_obs", {
   expect_error(run_iv_regression(df, iv_instrument = "1/sqrt(study_size)"))
 })
 
+test_that("run_iv_regression warns and flags a weak instrument", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  df <- make_weak_instrument_df()
+  expect_message(
+    res <- run_iv_regression(df, iv_instrument = "1/sqrt(n_obs)"),
+    "Weak instrument"
+  )
+
+  expect_true(res$weak_instrument)
+  expect_true(res$first_stage_fstat < WEAK_INSTRUMENT_F_THRESHOLD)
+})
+
 # find_best_instrument ------------------------------------------------------
 
 test_that("find_best_instrument returns one of the candidate instruments", {
@@ -99,6 +135,35 @@ test_that("find_best_instrument returns one of the candidate instruments", {
 
   best <- find_best_instrument(df, instruments, names_verbose)
   expect_true(all(best %in% names_verbose))
+})
+
+test_that("find_best_instrument selects by first-stage F, not Wu-Hausman or R-squared", {
+  skip_if_not_installed("AER")
+  local_options(artma.verbose = 1)
+
+  # se depends on n_obs, so 1/sqrt(n_obs) is a strong instrument; log(n_obs) is
+  # a much weaker predictor of se and would previously have been able to win
+  # a majority vote via the (backwards) Wu-Hausman or R-squared criteria.
+  df <- make_exogeneity_df()
+  instruments <- list(1 / sqrt(df$n_obs), log(df$n_obs))
+  names_verbose <- c("1/sqrt(n_obs)", "log(n_obs)")
+
+  best <- find_best_instrument(df, instruments, names_verbose)
+  expect_equal(best, "1/sqrt(n_obs)")
+})
+
+test_that("find_best_instrument breaks ties in favor of 1/sqrt(n_obs)", {
+  skip_if_not_installed("AER")
+  local_options(artma.verbose = 1)
+
+  # A rescaled copy of the same instrument has an identical first-stage F,
+  # so this is a genuine tie that the tie-break rule must resolve.
+  df <- make_exogeneity_df()
+  instruments <- list(1 / sqrt(df$n_obs), 2 / sqrt(df$n_obs))
+  names_verbose <- c("1/sqrt(n_obs)", "rescaled")
+
+  best <- find_best_instrument(df, instruments, names_verbose)
+  expect_equal(best, "1/sqrt(n_obs)")
 })
 
 # run_puniform_star ---------------------------------------------------------
@@ -186,11 +251,24 @@ test_that("run_exogeneity_tests assembles IV and p-uniform results", {
 
   expect_true(all(c("iv", "puniform", "summary") %in% names(res)))
   expect_true(is.data.frame(res$summary))
-  expect_equal(nrow(res$summary), 6L)
+  expect_equal(nrow(res$summary), 7L)
   expect_true("IV" %in% colnames(res$summary))
+  expect_true("First-stage F" %in% res$summary$Metric)
 
   effect_est <- res$iv$coefficients$estimate[res$iv$coefficients$term == "effect"]
   expect_equal(effect_est, 0.5, tolerance = 0.05)
+})
+
+test_that("run_exogeneity_tests flags a weak instrument in the summary table", {
+  skip_if_not_installed("AER")
+  skip_if_not_installed("ivmodel")
+  local_options(artma.verbose = 1)
+
+  df <- make_weak_instrument_df()
+  res <- run_exogeneity_tests(df, default_exogeneity_options(iv_instrument = "1/sqrt(n_obs)"))
+
+  fstat_row <- res$summary[res$summary$Metric == "First-stage F", "IV"]
+  expect_true(grepl("weak instrument", fstat_row))
 })
 
 test_that("run_exogeneity_tests skips gracefully when columns are missing", {

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -85,7 +85,7 @@ test_that("exogeneity_tests returns the standard contract with IV results", {
 
   expect_true(is.list(result))
   expect_true(is.data.frame(result$tables$summary))
-  expect_equal(nrow(result$tables$summary), 6L)
+  expect_equal(nrow(result$tables$summary), 7L)
   # The IV model lives in the meta slot and recovers the true effect (mu = 0.5).
   iv_coef <- result$meta$iv$coefficients
   effect_est <- iv_coef$estimate[iv_coef$term == "effect"]


### PR DESCRIPTION
## Summary
- `find_best_instrument` picked a winner by majority vote over four diagnostics, three of which were wrong: Wu-Hausman rewards data that most strongly rejects exogeneity (a property of the data, not the instrument), Sargan is unidentified (df1 = 0, p = NA) with one instrument, and IV R-squared is unbounded below with no instrument-quality meaning. It now ranks candidates solely by the standard first-stage weak-instruments F-statistic, breaking ties in favor of `1/sqrt(n_obs)`, the theoretically motivated instrument.
- `run_iv_regression` now surfaces the chosen instrument's first-stage F-statistic and prints a `cli` warning plus a "weak instrument" note in the printed summary table when it falls below the conventional threshold of 10 (previously the "F-test (AR)" row could show a large Anderson-Rubin statistic with no warning even when the underlying first-stage F was well below 1).
- Updated the `iv_instrument` option help text to describe the new selection rule and weak-instrument warning.

## Test plan
- [x] `make_exogeneity_df()`-based tests confirm the strong instrument is selected, `first_stage_fstat`/`weak_instrument` fields are populated, and no warning fires.
- [x] New `make_weak_instrument_df()` DGP (se independent of n_obs) confirms a weak instrument triggers the `cli` warning and `weak_instrument = TRUE`.
- [x] New test confirms tie-breaking favors `1/sqrt(n_obs)` when two instruments have identical first-stage F (a rescaled duplicate).
- [x] New test confirms `find_best_instrument` no longer prefers a weaker instrument via Wu-Hausman/R-squared.
- [x] Updated summary-table row-count assertions (6 -> 7 for the new "First-stage F" row) in both `test-econometric-exogeneity.R` and `test-methods-p-hacking-exogeneity.R`.
- [x] `styler::style_file()` and `lintr::lint()` clean on changed files; targeted `testthat` runs (exogeneity, p-hacking-exogeneity, options-template-parity, generated-check-manifest) pass.