### PR TITLE
fix(linear): stabilize bootstrap CIs and flag star/CI disagreement

### DIFF
--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -573,6 +573,29 @@ linear_model_specs <- function() {
   )
 }
 
+#' @title Flag disagreements between the analytic and bootstrap significance tests
+#' @description
+#' The analytic p-value comes from a clustered-vcov Wald test; the bootstrap CI
+#' is a nonparametric percentile interval. They can disagree, most often when
+#' the regressor (`se`) is heavy-tailed enough that a handful of resampled
+#' clusters dominate the bootstrap distribution. Both tests are evaluated at
+#' the same `conf_level` so the comparison is apples-to-apples regardless of
+#' the (coarser) `*`/`**`/`***` star thresholds.
+#' @param p_value *[numeric]* Analytic (clustered) p-values.
+#' @param bootstrap_lower *[numeric]* Lower bootstrap percentile CI bound.
+#' @param bootstrap_upper *[numeric]* Upper bootstrap percentile CI bound.
+#' @param conf_level *[numeric]* Confidence level shared by both tests.
+#' @return A logical vector, `NA` where no bootstrap CI is available.
+flag_ci_conflicts <- function(p_value, bootstrap_lower, bootstrap_upper, conf_level) {
+  ci_available <- is.finite(bootstrap_lower) & is.finite(bootstrap_upper)
+  analytic_significant <- is.finite(p_value) & p_value <= (1 - conf_level)
+  ci_excludes_zero <- ci_available & (bootstrap_lower > 0 | bootstrap_upper < 0)
+
+  conflict <- analytic_significant != ci_excludes_zero
+  conflict[!ci_available] <- NA
+  conflict
+}
+
 #' @title Run linear model specifications
 #' @param df *[data.frame]* Input dataset.
 #' @param options *[list]* Options controlling formatting and bootstrap.
@@ -685,6 +708,15 @@ run_linear_models <- function(df, options, is_pkg_available = NULL) {
     digits = options$round_to
   )
 
+  coefficients$ci_conflict <- flag_ci_conflicts(
+    coefficients$p_value,
+    coefficients$bootstrap_lower,
+    coefficients$bootstrap_upper,
+    options$conf_level
+  )
+  conflicting <- !is.na(coefficients$ci_conflict) & coefficients$ci_conflict
+  coefficients$bootstrap_formatted[conflicting] <- paste0(coefficients$bootstrap_formatted[conflicting], " †")
+
   summary <- build_summary_table(coefficients, options$round_to)
 
   list(
@@ -755,7 +787,8 @@ build_summary_table <- function(coefficients, digits) {
 box::export(
   run_linear_models,
   linear_model_specs,
-  resample_cluster_rows
+  resample_cluster_rows,
+  flag_ci_conflicts
 )
 
 # nocov end -----------------------------------------------------------------

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -20,7 +20,7 @@ linear_tests <- function(df) {
   opt <- get_option_group("artma.methods.linear_tests")
 
   add_marks <- resolve_add_significance_marks()
-  bootstrap_replications <- opt$bootstrap_replications %||% 100L
+  bootstrap_replications <- opt$bootstrap_replications %||% 999L
   conf_level <- opt$conf_level %||% 0.95
   round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
 
@@ -43,9 +43,25 @@ linear_tests <- function(df) {
     round_to = round_to
   )
 
-  results <- run_linear_models(df, resolved_options)
-
   verbosity <- get_verbosity()
+
+  # Below this many expected draws per tail, the percentile CI bound is
+  # effectively pinned by a handful of extreme resamples and swings with the
+  # RNG seed rather than converging.
+  min_tail_draws <- 10
+  tail_draws <- bootstrap_replications * (1 - conf_level) / 2
+  if (verbosity >= 1 && bootstrap_replications > 0 && tail_draws < min_tail_draws) {
+    cli::cli_alert_warning(paste(
+      "Only {bootstrap_replications} bootstrap replications requested",
+      "(~{round(tail_draws, 1)} draws per confidence interval tail at the",
+      "{round(conf_level * 100)}% level). Percentile bootstrap CI bounds can",
+      "be unstable with so few draws, especially when {.field se} spans",
+      "several orders of magnitude. Consider raising",
+      "{.field artma.methods.linear_tests.bootstrap_replications}."
+    ))
+  }
+
+  results <- run_linear_models(df, resolved_options)
 
   if (verbosity >= 1) {
     cli::cli_h2("Linear model tests")
@@ -54,6 +70,17 @@ linear_tests <- function(df) {
       print_summary_table(results$summary)
     } else {
       cli::cli_alert_warning("No linear models were successfully estimated.")
+    }
+
+    n_conflicts <- sum(results$coefficients$ci_conflict, na.rm = TRUE)
+    if (n_conflicts > 0) {
+      cli::cli_alert_warning(paste(
+        "{n_conflicts} out of {nrow(results$coefficients)} estimates are",
+        "marked with †: the analytic significance test and the",
+        "{round(conf_level * 100)}% bootstrap confidence interval disagree",
+        "on whether the estimate differs from zero. Treat these estimates",
+        "with caution."
+      ))
     }
 
     if (length(results$skipped) > 0 && verbosity >= 2) {

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -132,10 +132,13 @@ methods:
   linear_tests:
     bootstrap_replications:
       type: "integer"
-      default: 100
+      default: 999
       help: |
         Number of bootstrap replications to use when computing cluster-robust
-        confidence intervals. Set to `0` to disable bootstrapping.
+        confidence intervals. Percentile confidence intervals need several
+        hundred draws per tail to be stable; values below 999 can produce
+        visibly unstable interval bounds, especially with heavy-tailed or
+        widely spread standard errors. Set to `0` to disable bootstrapping.
 
     conf_level:
       type: "numeric"

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -3,7 +3,9 @@ box::use(
     expect_equal,
     expect_false,
     expect_gt,
+    expect_message,
     expect_named,
+    expect_no_message,
     expect_true,
     skip_if_not_installed,
     test_that
@@ -13,6 +15,7 @@ box::use(
 
 box::use(
   artma / econometric / linear[
+    flag_ci_conflicts,
     linear_model_specs,
     resample_cluster_rows,
     run_linear_models
@@ -35,6 +38,119 @@ make_demo_data <- function() {
     check.names = FALSE
   )
 }
+
+# A study with an extreme, trend-breaking `se`/`effect` pair gives the
+# unweighted specs a high-leverage point: the analytic clustered-vcov test and
+# the percentile bootstrap CI reliably disagree on several rows, which is
+# exactly the disagreement `flag_ci_conflicts()` is meant to surface.
+make_conflict_data <- function() {
+  set.seed(1)
+  n_studies <- 10L
+  per_study <- 4L
+  study_ids <- rep(paste0("S", seq_len(n_studies)), each = per_study)
+  se_level <- runif(n_studies, 0.05, 0.15)
+  se_level[1] <- 8
+  se_vals <- rep(se_level, each = per_study) * exp(rnorm(n_studies * per_study, 0, 0.05))
+  effect_level <- rnorm(n_studies, mean = -0.05, sd = 0.02) + 0.02 * se_level
+  effect_level[1] <- 5
+  effect <- rep(effect_level, each = per_study) + rnorm(n_studies * per_study, 0, 0.01)
+  data.frame(
+    study_id = study_ids,
+    effect = effect,
+    se = se_vals,
+    study_size = sample(20:80, n_studies * per_study, replace = TRUE),
+    precision = 1 / se_vals,
+    check.names = FALSE
+  )
+}
+
+test_that("flag_ci_conflicts marks disagreement between the analytic test and the bootstrap CI", {
+  p_value <- c(0.01, 0.5, 0.5, 0.01, NA, 0.01)
+  bootstrap_lower <- c(-0.1, -0.1, 0.2, 0.2, -0.1, NA)
+  bootstrap_upper <- c(0.5, 0.5, 0.5, 0.5, 0.1, NA)
+
+  result <- flag_ci_conflicts(p_value, bootstrap_lower, bootstrap_upper, conf_level = 0.95)
+
+  expect_equal(
+    result,
+    c(
+      TRUE, # significant analytically, CI includes zero
+      FALSE, # not significant, CI includes zero
+      TRUE, # not significant, CI excludes zero
+      FALSE, # significant, CI excludes zero
+      FALSE, # p-value missing (treated as not significant), CI includes zero -> no conflict
+      NA # bootstrap CI unavailable
+    )
+  )
+})
+
+test_that("run_linear_models flags and marks conflicting rows on high-leverage data", {
+  skip_if_not_installed("plm")
+
+  df <- make_conflict_data()
+  opts <- list(
+    add_significance_marks = TRUE,
+    bootstrap_replications = 60L,
+    conf_level = 0.95,
+    round_to = 3L
+  )
+
+  set.seed(100)
+  res <- run_linear_models(df, opts)
+
+  conflicts <- res$coefficients[res$coefficients$ci_conflict %in% TRUE, , drop = FALSE]
+  expect_gt(nrow(conflicts), 0)
+  expect_true(all(grepl("†$", conflicts$bootstrap_formatted)))
+
+  non_conflicts <- res$coefficients[res$coefficients$ci_conflict %in% FALSE, , drop = FALSE]
+  if (nrow(non_conflicts) > 0) {
+    expect_false(any(grepl("†", non_conflicts$bootstrap_formatted)))
+  }
+})
+
+test_that("linear_tests warns when few bootstrap replications are requested", {
+  skip_if_not_installed("plm")
+
+  df <- make_demo_data()
+
+  local_options(
+    "artma.methods.linear_tests.bootstrap_replications" = 10L,
+    "artma.methods.linear_tests.conf_level" = 0.95,
+    "artma.verbose" = 1
+  )
+
+  expect_message(linear_tests(df), "Only 10 bootstrap replications")
+})
+
+test_that("linear_tests does not warn about replications when the count is high enough", {
+  skip_if_not_installed("plm")
+
+  df <- make_demo_data()
+
+  local_options(
+    "artma.methods.linear_tests.bootstrap_replications" = 999L,
+    "artma.methods.linear_tests.conf_level" = 0.95,
+    "artma.verbose" = 1
+  )
+
+  expect_no_message(linear_tests(df), message = "bootstrap replications")
+})
+
+test_that("linear_tests reports the count of estimates with disagreeing stars and CIs", {
+  skip_if_not_installed("plm")
+
+  df <- make_conflict_data()
+
+  local_options(
+    "artma.methods.add_significance_marks" = TRUE,
+    "artma.methods.linear_tests.bootstrap_replications" = 60L,
+    "artma.methods.linear_tests.conf_level" = 0.95,
+    "artma.verbose" = 1
+  )
+
+  set.seed(100)
+  expect_message(linear_tests(df), "estimates are.*marked with")
+})
 
 test_that("linear tests return tidy coefficients and summary", {
   skip_if_not_installed("plm")
@@ -74,7 +190,7 @@ test_that("linear tests return tidy coefficients and summary", {
       "model_label", "n_obs", "term_label", "bootstrap_lower",
       "bootstrap_upper", "significance", "estimate_rounded",
       "std_error_rounded", "estimate_formatted", "std_error_formatted",
-      "bootstrap_formatted"
+      "bootstrap_formatted", "ci_conflict"
     )
   )
 


### PR DESCRIPTION
## Summary

`linear_tests` bootstrap percentile CIs could disagree wildly with the analytic clustered-vcov significance stars, e.g. on meta-analysis.cz class-size data (PCC, winsorization off, SEs spanning 5.5e-4 to 10.3): OLS publication bias -0.216 (SE 0.012, `***`) had a bootstrap CI of [-0.228, 0.667], while the unstarred effect-beyond-bias estimate had a CI that excluded zero.

Root cause: with `se` spanning several orders of magnitude, the OLS/FE/RE/BE slope estimators are dominated by a few high-leverage clusters, so the bootstrap sampling distribution is heavy-tailed. The default of 100 replications only yields ~2-3 draws per 2.5% tail, so the reported percentile bound is essentially whichever extreme draw happened to land there - it swings with the RNG seed rather than converging. The resampling itself (cluster-level, `quantile(..., type = 7)`) was verified correct; the instability is a replication-count problem, not a computation bug.

Changes in `inst/artma/econometric/linear.R` and `inst/artma/methods/linear_tests.R`:
- Raise the default `bootstrap_replications` from 100 to 999 (`inst/artma/options/templates/options_template.yaml`), and document why in the option help text.
- Warn (via cli, gated on verbosity) when the configured replication count yields fewer than 10 expected draws per CI tail at the chosen confidence level, so a user who deliberately lowers it still gets a heads-up.
- Add `flag_ci_conflicts()`: compares the analytic significance test and the bootstrap CI at the *same* confidence level (rather than the coarser `*`/`**`/`***` thresholds) and flags rows where they disagree. Conflicting cells get a `†` suffix in the printed/exported `Bootstrap CI` rows, and `linear_tests()` prints a summary count of how many estimates are affected.

## Test plan
- [x] `make lint`
- [x] `make test` (full suite, 1775 passed)
- [x] Added unit tests for `flag_ci_conflicts()` and integration tests for the low-replication warning and the `†` marking/summary message, using a synthetic high-leverage dataset that reliably reproduces the disagreement.