### PR TITLE
fix(data): default zero-SE handling to remove-with-warning, not abort

### DIFF
--- a/inst/artma/data/index.R
+++ b/inst/artma/data/index.R
@@ -8,9 +8,9 @@ box::use(
 #   configure -> compute -> persist
 #
 # * configure (interactive, uncached, runs first): resolves schema drift and
-#   the missing-value strategy, prompting where the autonomy/interactivity gate
-#   allows it, and updating the persisted config. Skipped decisions fall back to
-#   deterministic defaults.
+#   the missing-value and zero-standard-error strategies, prompting where the
+#   autonomy/interactivity gate allows it, and updating the persisted config.
+#   Skipped decisions fall back to deterministic defaults.
 # * compute (pure, cached): read is shared with configure; standardizes,
 #   preprocesses, and derives columns using only the resolved config. It is the
 #   ONLY phase behind the cache and performs no prompts and no option writes.
@@ -37,8 +37,9 @@ prime_raw_df <- function(df_raw) {
 
 #' @title Configure phase
 #' @description Interactive, uncached phase. Resolves any schema drift and
-#'   decides the missing-value handling strategy before the cached compute phase
-#'   runs, so compute never prompts and its cache key is stable across runs.
+#'   decides the missing-value and zero-standard-error handling strategies
+#'   before the cached compute phase runs, so compute never prompts and its
+#'   cache key is stable across runs.
 #' @param df_raw *[data.frame]* Raw data frame with original column names.
 #' @return `NULL`, invisibly.
 #' @keywords internal
@@ -46,7 +47,7 @@ configure_data <- function(df_raw) {
   box::use(
     artma / data / utils[standardize_column_names],
     artma / data / schema_reconcile[reconcile_schema],
-    artma / data / preprocess[clean_data, resolve_na_handling]
+    artma / data / preprocess[clean_data, resolve_na_handling, resolve_se_zero_handling]
   )
 
   # Detect and resolve any schema drift before column standardization. This may
@@ -54,10 +55,12 @@ configure_data <- function(df_raw) {
   mode <- getOption("artma.data.reconcile_mode", "ask")
   reconcile_schema(df_raw, mode = mode)
 
-  # Decide the missing-value strategy on the cleaned, standardized frame so the
-  # compute phase can handle missing values without prompting.
+  # Decide the missing-value and zero-SE strategies on the cleaned, standardized
+  # frame so the compute phase can handle both without prompting.
   df_std <- standardize_column_names(df_raw, auto_detect = FALSE)
-  resolve_na_handling(clean_data(df_std))
+  df_clean <- clean_data(df_std)
+  resolve_na_handling(df_clean)
+  resolve_se_zero_handling(df_clean)
 
   invisible(NULL)
 }

--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -162,6 +162,75 @@ enforce_data_types <- function(df) {
   df
 }
 
+#' @title Resolve the zero-standard-error handling strategy
+#' @description Configure-phase decision that fixes `artma.calc.se_zero_handling`
+#'   before the cached compute phase runs. When the option is already set it is
+#'   a no-op. Otherwise, if the (already cleaned) data frame has rows with a
+#'   zero standard error, it prompts the user interactively when the autonomy
+#'   level warrants it (offering the strict `"stop"` choice among others), or
+#'   falls back to the friendlier `"remove"` strategy. This is intentionally
+#'   separate from `enforce_correct_values()` (the pure compute-phase step) so
+#'   that no prompt or option write ever happens inside the cached pipeline.
+#' @param df *\[data.frame\]* The cleaned data frame used to detect zero
+#'   standard errors (as produced by `clean_data()`).
+#' @return `NULL`, invisibly.
+#' @keywords internal
+resolve_se_zero_handling <- function(df) {
+  box::use(
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / core / autonomy[should_prompt_user],
+    artma / options / prompts[prompt_se_zero_handling],
+    artma / interactive / save_preference[prompt_save_preference]
+  )
+
+  se_zero_handling_option <- getOption("artma.calc.se_zero_handling", default = NA)
+
+  # Strategy already configured: nothing to decide.
+  if (!is.na(se_zero_handling_option)) {
+    return(invisible(NULL))
+  }
+
+  if (is.null(df[["se"]])) {
+    return(invisible(NULL))
+  }
+
+  zero_se_rows <- which(suppressWarnings(as.numeric(df$se)) == 0)
+
+  # Without zero standard errors there is no decision to make; the compute
+  # phase falls back to the deterministic "remove" default when it runs.
+  if (length(zero_se_rows) == 0) {
+    return(invisible(NULL))
+  }
+
+  if (should_prompt_user(required_level = "autonomous")) {
+    if (get_verbosity() >= 3) {
+      cli::cli_alert_info("Zero standard errors detected and no handling strategy configured")
+    }
+
+    # Prompt the user for their preference and record it for this session.
+    selected_strategy <- prompt_se_zero_handling()
+    options(artma.calc.se_zero_handling = selected_strategy)
+
+    # Offer to persist the preference to the options file.
+    prompt_save_preference(
+      option_path = "calc.se_zero_handling",
+      value = selected_strategy,
+      description = "zero standard error handling strategy",
+      respect_autonomy = FALSE
+    )
+  } else {
+    if (get_verbosity() >= 2) {
+      cli::cli_warn(c(
+        "!" = "{length(zero_se_rows)} row{?s} with zero standard errors detected.",
+        "i" = "Defaulting to the {.val remove} strategy. Set {.field artma.calc.se_zero_handling} to {.val stop} for stricter validation."
+      ))
+    }
+    options(artma.calc.se_zero_handling = "remove")
+  }
+
+  invisible(NULL)
+}
+
 #' @title Check for invalid values
 #' @description Check for invalid values and enforce correct ones
 #' @param df *\[data.frame\]* The data frame to check for invalid values for
@@ -176,7 +245,7 @@ enforce_correct_values <- function(df) {
 
   box::use(artma / libs / core / validation[assert])
 
-  se_zero_handling <- getOption("artma.calc.se_zero_handling", "stop")
+  se_zero_handling <- getOption("artma.calc.se_zero_handling", "remove")
 
   zero_se_rows <- which(df$se == 0)
 
@@ -186,6 +255,16 @@ enforce_correct_values <- function(df) {
     if (length(zero_se_rows) > 0) {
       if (get_verbosity() >= 3) {
         cli::cli_warn("The 'se' column contains zero values in {length(zero_se_rows)} rows")
+      }
+    }
+  } else if (se_zero_handling == "remove") {
+    if (length(zero_se_rows) > 0) {
+      df <- df[-zero_se_rows, , drop = FALSE]
+      if (get_verbosity() >= 3) {
+        cli::cli_warn(c(
+          "!" = "Removed {length(zero_se_rows)} row{?s} with zero standard errors.",
+          "i" = "Set {.field artma.calc.se_zero_handling} to {.val stop} for stricter validation."
+        ))
       }
     }
   }
@@ -355,7 +434,9 @@ preprocess_data <- function(df) {
 box::export(
   clean_data,
   enforce_data_types,
+  enforce_correct_values,
   apply_subset_conditions,
   preprocess_data,
-  resolve_na_handling
+  resolve_na_handling,
+  resolve_se_zero_handling
 )

--- a/inst/artma/options/prompts.R
+++ b/inst/artma/options/prompts.R
@@ -87,6 +87,52 @@ prompt_na_handling <- function(opt, ...) {
   selected_value
 }
 
+prompt_se_zero_handling <- function(opt, ...) {
+  box::use(artma / const[CONST])
+
+  choices <- c(
+    "Remove rows with zero SE, with a warning (default)" = "remove",
+    "Stop (abort if zero SE found)" = "stop",
+    "Warn but keep rows with zero SE" = "warn",
+    "Ignore silently" = "ignore"
+  )
+
+  cli::cli_h1("Zero Standard Error Handling")
+  cli::cli_text("Standard errors equal to zero cause division-by-zero errors (e.g. infinite t-statistics).")
+  cli::cat_line()
+
+  cli::cli_h3("Available strategies:")
+  cli::cli_ul(c(
+    "{.strong remove}: Remove rows with zero standard errors, with a warning (recommended)",
+    "{.strong stop}: Abort analysis if any zero standard errors are found (strictest)",
+    "{.strong warn}: Warn but keep rows with zero standard errors",
+    "{.strong ignore}: Silently ignore zero standard errors"
+  ))
+  cli::cat_line()
+
+  selected <- climenu::select(
+    choices = names(choices),
+    prompt = "Select zero standard error handling strategy",
+    selected = 1 # "remove" as default
+  )
+
+  if (rlang::is_empty(selected)) {
+    cli::cli_alert_info("No selection made. Using default: {CONST$STYLES$OPTIONS$VALUE('remove')}")
+    return("remove")
+  }
+
+  selected_value <- choices[selected][[1]]
+
+  if (selected_value == "stop") {
+    cli::cli_alert_warning("Strict mode: analysis will abort if any zero standard errors are found.")
+  }
+
+  cli::cli_alert_success("Selected strategy: {CONST$STYLES$OPTIONS$VALUE(selected_value)}")
+  cli::cat_line()
+
+  selected_value
+}
+
 prompt_autonomy_level <- function(opt, ...) {
   box::use(
     artma / const[CONST],
@@ -140,5 +186,6 @@ prompt_autonomy_level <- function(opt, ...) {
 box::export(
   prompt_autonomy_level,
   prompt_winsorization_level,
-  prompt_na_handling
+  prompt_na_handling,
+  prompt_se_zero_handling
 )

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -48,16 +48,24 @@ calc:
         {cli::symbol$bullet} {.strong DoF}: Calculate precision as sqrt(DoF)
 
   se_zero_handling:
-    type: "enum: stop|warn|ignore"
-    default: "stop"
+    type: "enum: stop|warn|remove|ignore"
+    default: .na
+    allow_na: true
+    prompt: "function"
+    prompt_function: "prompt_se_zero_handling"
+    suppress_help_in_prompt: true
     help: |
       Having standard errors equal to zero can lead to division by zero errors, introducing infinite t-statistics.
-      By default, the package will stop if any zero standard errors are found.
-      You can change this behavior by setting the option to 'warn' or 'ignore'.
+      By default, rows with zero standard errors are removed with a warning; set this option to 'stop'
+      for stricter validation, or to 'warn'/'ignore' to keep the affected rows.
       How to handle zero standard errors:
-        {cli::symbol$bullet} {.strong stop}: Abort if any zero standard errors are found
-        {cli::symbol$bullet} {.strong warn}: Warn if any zero standard errors are found
-        {cli::symbol$bullet} {.strong ignore}: Ignore zero standard errors
+        {cli::symbol$bullet} {.strong stop}: Abort if any zero standard errors are found (strictest)
+        {cli::symbol$bullet} {.strong warn}: Warn but keep rows with zero standard errors
+        {cli::symbol$bullet} {.strong remove}: Remove rows with zero standard errors, with a warning (default)
+        {cli::symbol$bullet} {.strong ignore}: Silently ignore zero standard errors
+
+      If this option is not set (NA), you will be prompted interactively when zero standard errors are
+      detected, subject to your autonomy level; a non-interactive session defaults to 'remove'.
 
 visualization:
   theme:

--- a/tests/testthat/test-data-preprocess.R
+++ b/tests/testthat/test-data-preprocess.R
@@ -4,6 +4,9 @@ box::use(
     expect_error,
     expect_true,
     expect_false,
+    expect_null,
+    expect_warning,
+    expect_no_warning,
     test_that
   ],
   withr[local_options]
@@ -14,6 +17,9 @@ expect_equal <- getFromNamespace("expect_equal", "testthat")
 expect_error <- getFromNamespace("expect_error", "testthat")
 expect_true <- getFromNamespace("expect_true", "testthat")
 expect_false <- getFromNamespace("expect_false", "testthat")
+expect_null <- getFromNamespace("expect_null", "testthat")
+expect_warning <- getFromNamespace("expect_warning", "testthat")
+expect_no_warning <- getFromNamespace("expect_no_warning", "testthat")
 
 # Tests for remove_redundant_columns, verify_variable_names, and
 # handle_extra_columns_with_data have been removed. Those functions were
@@ -162,4 +168,134 @@ test_that("apply_subset_conditions errors when a condition targets a missing col
 
   df <- data.frame(country = c("USA", "UK"), year = c(1999, 2001))
   expect_error(apply_subset_conditions(df), "Failed to evaluate subset condition")
+})
+
+# -- enforce_correct_values ------------------------------------------------------
+
+test_that("enforce_correct_values defaults to removing rows with zero SE when unset", {
+  box::use(artma / data / preprocess[enforce_correct_values])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = NULL,
+    "artma.verbose" = 3
+  ))
+
+  df <- data.frame(se = c(0.1, 0, 0.2, 0))
+  expect_warning(result <- enforce_correct_values(df), "Removed 2 rows")
+
+  expect_equal(nrow(result), 2)
+  expect_true(all(result$se != 0))
+})
+
+test_that("enforce_correct_values 'remove' strategy drops zero-SE rows with a warning", {
+  box::use(artma / data / preprocess[enforce_correct_values])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = "remove",
+    "artma.verbose" = 3
+  ))
+
+  df <- data.frame(se = c(0.1, 0, 0.2))
+  expect_warning(result <- enforce_correct_values(df), "stricter validation")
+
+  expect_equal(result$se, c(0.1, 0.2))
+})
+
+test_that("enforce_correct_values 'remove' strategy is a no-op without zero SE", {
+  box::use(artma / data / preprocess[enforce_correct_values])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = "remove",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(se = c(0.1, 0.2))
+  result <- expect_no_warning(enforce_correct_values(df))
+
+  expect_equal(result, df)
+})
+
+test_that("enforce_correct_values 'stop' strategy aborts on zero SE", {
+  box::use(artma / data / preprocess[enforce_correct_values])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = "stop",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(se = c(0.1, 0))
+  expect_error(enforce_correct_values(df), "contains zero values")
+})
+
+test_that("enforce_correct_values 'warn' strategy keeps rows but warns", {
+  box::use(artma / data / preprocess[enforce_correct_values])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = "warn",
+    "artma.verbose" = 3
+  ))
+
+  df <- data.frame(se = c(0.1, 0))
+  expect_warning(result <- enforce_correct_values(df), "contains zero values")
+
+  expect_equal(result, df)
+})
+
+test_that("enforce_correct_values 'ignore' strategy silently keeps rows", {
+  box::use(artma / data / preprocess[enforce_correct_values])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = "ignore",
+    "artma.verbose" = 3
+  ))
+
+  df <- data.frame(se = c(0.1, 0))
+  result <- expect_no_warning(enforce_correct_values(df))
+
+  expect_equal(result, df)
+})
+
+# -- resolve_se_zero_handling ------------------------------------------------------
+
+test_that("resolve_se_zero_handling is a no-op when the option is already configured", {
+  box::use(artma / data / preprocess[resolve_se_zero_handling])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = "stop",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(se = c(0.1, 0))
+  resolve_se_zero_handling(df)
+
+  expect_equal(getOption("artma.calc.se_zero_handling"), "stop")
+})
+
+test_that("resolve_se_zero_handling is a no-op when no zero SE rows are found", {
+  box::use(artma / data / preprocess[resolve_se_zero_handling])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = NULL,
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(se = c(0.1, 0.2))
+  resolve_se_zero_handling(df)
+
+  expect_null(getOption("artma.calc.se_zero_handling"))
+})
+
+test_that("resolve_se_zero_handling defaults to 'remove' in a non-interactive session", {
+  box::use(artma / data / preprocess[resolve_se_zero_handling])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = NULL,
+    "artma.autonomy.level" = NULL,
+    "artma.verbose" = 2
+  ))
+
+  df <- data.frame(se = c(0.1, 0, 0.2))
+  expect_warning(resolve_se_zero_handling(df), "stricter validation")
+
+  expect_equal(getOption("artma.calc.se_zero_handling"), "remove")
 })


### PR DESCRIPTION
## Summary

`calc.se_zero_handling` defaulted to `stop`, so any dataset with a zero standard error (e.g. meta-analysis.cz's `class.xlsx`, which has 87/2906 such rows) triggered a fatal abort on a first run with no config yet in place. This flips the friendly default to `remove`: affected rows are dropped with a clear warning (row count + a hint to set `stop` for stricter validation).

## Changes

- `options_template.yaml`: `se_zero_handling` enum gains a `remove` value; default becomes unset (`.na`, `allow_na: true`) so behavior is resolved at runtime like `na_handling` already is.
- `preprocess.R`: new `resolve_se_zero_handling()` configure-phase step (mirrors `resolve_na_handling()`) that, when zero SEs are detected and the option is unset, prompts interactively via `should_prompt_user(required_level = "autonomous")` — offering the strict `stop` choice at `ask_more`/`balanced` autonomy — or silently defaults to `remove` at `autonomous`/non-interactive. `enforce_correct_values()` gains the `remove` branch (drops rows, warns with count) and its fallback default changes from `stop` to `remove`.
- `prompts.R`: `prompt_se_zero_handling()` climenu prompt, mirroring `prompt_na_handling()`.
- `index.R`: wires the new resolver into `configure_data()` alongside `resolve_na_handling()`.
- Tests: new coverage for `enforce_correct_values` (all four strategies) and `resolve_se_zero_handling` (no-op cases, non-interactive default).

## Test plan

- [x] `make test` — full suite passes (1784 passed, 0 failed)
- [x] `make lint` — no lints
- [x] New tests exercise `stop`/`warn`/`remove`/`ignore` branches and the resolver's no-op/default paths