### PR TITLE
fix(nonlinear): skip degenerate corner-solution fits

### DIFF
--- a/inst/artma/calc/methods/selection_model.R
+++ b/inst/artma/calc/methods/selection_model.R
@@ -154,7 +154,11 @@ variation_variance_loglikelihood <- function(lambdabar, tauhat, betap, cutoffs, 
 #' @param cutoffs [numeric] Cut-off thresholds.
 #' @param symmetric [logical] Should symmetry be enforced?
 #' @param model [character] Either "normal" or "t".
-#' @return A list with parameter estimates and robust standard errors.
+#' @return A list with parameter estimates and robust standard errors, plus
+#'   `convergence` (the optimiser's exit code, 0 for success) and
+#'   `boundary_hit` (TRUE when a variance or publication-probability
+#'   parameter landed on its lower constraint of 0, a corner solution rather
+#'   than a genuine optimum).
 metastudies_estimation <- function(X, sigma, cutoffs, symmetric, model = "normal") {
   max_eval <- 1e5
   max_iter <- 1e5
@@ -177,9 +181,20 @@ metastudies_estimation <- function(X, sigma, cutoffs, symmetric, model = "normal
   upper <- rep(Inf, length(start))
   optimum <- stats::nlminb(start = start, objective = objective, lower = lower, upper = upper, control = list(eval.max = max_eval, iter.max = max_iter, abs.tol = tol))
   params <- optimum$par
-  covariance <- robust_variance(stepsize, n, params, llh, seq_len(n))
-  standard_errors <- base::sqrt(base::diag(covariance))
-  list(Psihat = params, SE = standard_errors)
+  covariance <- tryCatch(
+    robust_variance(stepsize, n, params, llh, seq_len(n)),
+    error = function(e) matrix(NA_real_, length(params), length(params))
+  )
+  standard_errors <- suppressWarnings(base::sqrt(base::diag(covariance)))
+  boundary_tolerance <- 1e-4
+  boundary_hit <- any(abs(params[-1]) < boundary_tolerance)
+  list(
+    Psihat = params,
+    SE = standard_errors,
+    convergence = optimum$convergence,
+    message = optimum$message,
+    boundary_hit = boundary_hit
+  )
 }
 
 #' Tidy table of selection model estimates

--- a/inst/artma/calc/methods/stem.R
+++ b/inst/artma/calc/methods/stem.R
@@ -1,3 +1,8 @@
+#' Minimum number of studies STEM will ever select. The MSE-minimising search
+#' never returns a window narrower than this, so a fit that lands exactly on
+#' it is a corner solution rather than a genuine MSE minimum.
+STEM_MIN_STUDIES <- 3L
+
 #' Compute the weighted mean for the first `i` studies
 #'
 #' @param beta [numeric] Effect sizes ordered by precision.
@@ -67,7 +72,7 @@ stem_compute <- function(beta, se, sigma0) {
   eb_squared <- weighted_mean_squared(beta[-1], se[-1], sigma0)
   mse_original <- eb_squared - 2 * beta[1] * eb_leave_top_out
   var_all <- variance_b(se, sigma0)
-  n_stem_min <- 3
+  n_stem_min <- STEM_MIN_STUDIES
   mse <- mse_original[(n_stem_min - 1):(n - 1)]
   bias <- mse - var_all[n_stem_min:n]
   index <- which.min(mse)
@@ -223,6 +228,7 @@ data_median <- function(data, id_var, main_var, additional_var) {
 
 
 box::export(
+  STEM_MIN_STUDIES,
   weighted_mean,
   weighted_mean_squared,
   variance_0,

--- a/inst/artma/econometric/nonlinear.R
+++ b/inst/artma/econometric/nonlinear.R
@@ -12,7 +12,7 @@ box::use(
     format_number,
     format_se
   ],
-  artma / calc / methods / stem[stem, stem_funnel, stem_MSE],
+  artma / calc / methods / stem[stem, stem_funnel, stem_MSE, STEM_MIN_STUDIES],
   artma / calc / methods / selection_model[metastudies_estimation],
   artma / calc / methods / endo_kink[run_endogenous_kink],
   artma / visualization / options[get_visualization_options],
@@ -45,22 +45,117 @@ format_standard_error <- function(std_error, digits) {
   formatted
 }
 
+#' Kish's effective sample size for a set of precision weights
+#'
+#' @param weights *\[numeric\]* Non-negative weights (e.g. inverse-variance weights).
+#' @return *\[numeric\]* The effective number of independent observations the
+#'   weighted average behaves like. Equals `length(weights)` when weights are
+#'   equal, and shrinks toward 1 when a single weight dominates the sum.
+#' @keywords internal
+effective_sample_size <- function(weights) {
+  sum(weights)^2 / sum(weights^2)
+}
+
+#' Detect a degenerate effect/std-error pair produced by a nonlinear estimator
+#'
+#' @description
+#' A term is degenerate when its estimate is not finite, or its standard
+#' error is exactly zero or non-finite (typically a sign that a single
+#' extreme-precision observation dominated the fit, or that an optimizer
+#' returned a garbage covariance). A term that is genuinely absent by design
+#' (an intentional `NA`, not a computed `NaN`) is left alone.
+#'
+#' @param component *\[list, optional\]* With elements `estimate` and `std_error`.
+#' @param label *\[character\]* Human-readable name used in the skip reason.
+#' @return *\[character or NULL\]* A skip reason, or `NULL` if not degenerate.
+#' @keywords internal
+degenerate_effect_reason <- function(component, label) {
+  if (is.null(component)) {
+    return(NULL)
+  }
+  estimate <- component$estimate
+  std_error <- component$std_error
+  if (is.na(std_error) && !is.nan(std_error)) {
+    return(NULL)
+  }
+  if (!is.finite(estimate)) {
+    return(paste0(label, " did not produce a finite estimate."))
+  }
+  if (!is.finite(std_error)) {
+    return(paste0(label, " produced a non-finite standard error, indicating a failed optimizer or singular Hessian."))
+  }
+  if (std_error <= 0) {
+    return(paste0(label, " produced a standard error of exactly zero, which is not a valid estimate."))
+  }
+  NULL
+}
+
+#' Flag WAAP/Top10 fits dominated by a single extreme-precision observation
+#'
+#' @param method_result *\[list\]* Runner output with `effective_n` and `n_model`.
+#' @return *\[character or NULL\]* A skip reason, or `NULL` if not degenerate.
+#' @keywords internal
+degenerate_check_precision_weighted <- function(method_result) {
+  eff_n <- method_result$effective_n
+  if (is.null(eff_n) || !is.finite(eff_n) || eff_n >= 2) {
+    return(NULL)
+  }
+  paste0(
+    "the estimate is dominated by a single extreme-precision observation (effective sample size ",
+    format_number(eff_n, 2), " across ", method_result$n_model, " model observations)."
+  )
+}
+
+#' Flag STEM fits that land on its algorithmic minimum window
+#'
+#' @param method_result *\[list\]* Runner output with `n_model`.
+#' @return *\[character or NULL\]* A skip reason, or `NULL` if not degenerate.
+#' @keywords internal
+degenerate_check_stem <- function(method_result) {
+  n_model <- method_result$n_model
+  if (is.null(n_model) || !is.finite(n_model) || n_model > STEM_MIN_STUDIES) {
+    return(NULL)
+  }
+  paste0(
+    "STEM selected only ", n_model, " studies, its algorithmic minimum of ", STEM_MIN_STUDIES,
+    "; the fit is a corner solution and carries too little information to report."
+  )
+}
+
+#' Flag selection-model fits that hit a boundary or failed to converge
+#'
+#' @param method_result *\[list\]* Runner output with `boundary_hit` and `convergence`.
+#' @return *\[character or NULL\]* A skip reason, or `NULL` if not degenerate.
+#' @keywords internal
+degenerate_check_selection <- function(method_result) {
+  if (isTRUE(method_result$boundary_hit)) {
+    return("the publication-probability or heterogeneity parameter landed on its boundary (near zero), a corner solution rather than a genuine optimum.")
+  }
+  if (!is.null(method_result$convergence) && !identical(method_result$convergence, 0L) && !identical(method_result$convergence, 0)) {
+    return(paste0("the optimizer did not converge (nlminb exit code ", method_result$convergence, ")."))
+  }
+  NULL
+}
+
 nonlinear_method_specs <- function(options) {
   list(
     list(
       name = "waap",
       label = "WAAP",
-      runner = function(df, total_n) run_waap(df, total_n)
+      runner = function(df, total_n) run_waap(df, total_n),
+      degenerate_check = degenerate_check_precision_weighted
     ),
     list(
       name = "top10",
       label = "Top10",
-      runner = function(df, total_n) run_top10(df, total_n)
+      runner = function(df, total_n) run_top10(df, total_n),
+      degenerate_check = degenerate_check_precision_weighted
     ),
     list(
       name = "stem",
       label = "Stem",
-      runner = function(df, total_n) run_stem(df, total_n, options)
+      runner = function(df, total_n) run_stem(df, total_n, options),
+      degenerate_check = degenerate_check_stem
     ),
     list(
       name = "hierarchical",
@@ -70,7 +165,8 @@ nonlinear_method_specs <- function(options) {
     list(
       name = "selection",
       label = "Selection",
-      runner = function(df, total_n) run_selection(df, total_n, options)
+      runner = function(df, total_n) run_selection(df, total_n, options),
+      degenerate_check = degenerate_check_selection
     ),
     list(
       name = "endogenous_kink",
@@ -118,7 +214,8 @@ run_waap <- function(df, total_n) {
       std_error = std_error,
       p_value = normal_p_value(estimate, std_error)
     ),
-    n_model = nrow(filtered)
+    n_model = nrow(filtered),
+    effective_n = effective_sample_size(weights)
   )
 }
 
@@ -143,7 +240,8 @@ run_top10 <- function(df, total_n) {
       std_error = std_error,
       p_value = normal_p_value(estimate, std_error)
     ),
-    n_model = nrow(filtered)
+    n_model = nrow(filtered),
+    effective_n = effective_sample_size(weights)
   )
 }
 
@@ -359,7 +457,9 @@ run_selection <- function(df, total_n, options) {
       std_error = pub_bias_se,
       p_value = normal_p_value(pub_bias_est, pub_bias_se)
     ),
-    n_model = nrow(data)
+    n_model = nrow(data),
+    convergence = estimates$convergence,
+    boundary_hit = estimates$boundary_hit
   )
 }
 
@@ -440,6 +540,16 @@ run_nonlinear_methods <- function(df, options) {
     tryCatch(
       {
         method_result <- spec$runner(df, total_n)
+        degenerate_reason <- degenerate_effect_reason(method_result$effect, "Effect estimate")
+        if (is.null(degenerate_reason)) {
+          degenerate_reason <- degenerate_effect_reason(method_result$publication_bias, "Publication-bias estimate")
+        }
+        if (is.null(degenerate_reason) && !is.null(spec$degenerate_check)) {
+          degenerate_reason <- spec$degenerate_check(method_result)
+        }
+        if (!is.null(degenerate_reason)) {
+          cli::cli_abort(degenerate_reason)
+        }
         coefficients <- list()
         pb <- method_result$publication_bias %||% list(estimate = NA_real_, std_error = NA_real_, p_value = NA_real_)
         effect <- method_result$effect

--- a/tests/testthat/test-calc-endo-kink.R
+++ b/tests/testthat/test-calc-endo-kink.R
@@ -74,6 +74,29 @@ test_that("run_endogenous_kink recovers a homogeneous true effect", {
   expect_true(is.finite(out[2]))
 })
 
+test_that("run_endogenous_kink's no-kink fallback matches a precision-weighted OLS fit", {
+  # Below the +/-1.96*sd band, compute_cutoff() returns 0 and
+  # final_endokink_fit() falls back to an unrestricted regression of bs_sebs
+  # on ones_sebs + pub_bias, which is algebraically the same as a weighted
+  # least-squares fit of effect on se with weights 1/se^2 (i.e. "precision
+  # weighted" when a dataset's precision column is defined as 1/se). A
+  # coincidental match between Endogenous Kink and a precision-weighted OLS
+  # spec in this regime is therefore expected, not a wiring bug.
+  set.seed(5)
+  n <- 40
+  se <- runif(n, 0.05, 0.5)
+  effect <- 0.3 + rnorm(n, 0, se)
+  df <- data.frame(effect, se)
+
+  out <- run_endogenous_kink(df, verbose = FALSE)
+  reference <- summary(stats::lm(effect ~ se, data = df, weights = 1 / se^2))$coefficients
+
+  expect_equal(unname(out[1]), unname(reference["(Intercept)", "Estimate"]))
+  expect_equal(unname(out[2]), unname(reference["(Intercept)", "Std. Error"]))
+  expect_equal(unname(out[3]), unname(reference["se", "Estimate"]))
+  expect_equal(unname(out[4]), unname(reference["se", "Std. Error"]))
+})
+
 test_that("run_endogenous_kink is deterministic for identical input", {
   set.seed(5)
   n <- 40

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -1,7 +1,9 @@
 box::use(
   testthat[
     expect_equal,
+    expect_false,
     expect_gt,
+    expect_match,
     expect_named,
     expect_s3_class,
     expect_setequal,
@@ -17,13 +19,18 @@ box::use(
 )
 
 make_demo_data <- function() {
-  n_studies <- 8L
+  # STEM picks the MSE-minimising number of (precision-ordered) studies; a
+  # small, widely spread study set can land on its algorithmic floor of 3,
+  # which the panel now treats as a degenerate corner solution and skips.
+  # More studies with tightly clustered effects keep STEM's window well
+  # above that floor so this fixture continues to exercise every model.
+  n_studies <- 15L
   per_study <- 6L
   study_ids <- rep(paste0("S", seq_len(n_studies)), each = per_study)
   base_se <- seq(0.05, 0.12, length.out = per_study)
   se_vals <- rep(base_se, times = n_studies)
-  effect_base <- seq(0.06, 0.3, length.out = n_studies)
-  effect_offsets <- seq(-0.07, 0.07, length.out = per_study)
+  effect_base <- 0.15 + seq(-0.01, 0.01, length.out = n_studies)
+  effect_offsets <- seq(-0.02, 0.02, length.out = per_study)
   effect_vals <- rep(effect_base, each = per_study) + rep(effect_offsets, times = n_studies)
   data.frame(
     study_id = study_ids,
@@ -103,6 +110,84 @@ test_that("nonlinear tests writes STEM diagnostic plot files when export is enab
   expect_true(file.exists(file.path(dir, "stem_mse.png")))
   expect_s3_class(res$plots$stem_funnel, "recordedplot")
   expect_s3_class(res$plots$stem_mse, "recordedplot")
+})
+
+make_degenerate_options <- function() {
+  list(
+    add_significance_marks = FALSE,
+    round_to = 3L,
+    stem_representative_sample = "medians",
+    selection_cutoffs = c(1.96),
+    selection_symmetric = FALSE,
+    selection_model = "normal",
+    hierarchical_iterations = 10L
+  )
+}
+
+test_that("WAAP and Top10 are skipped when a single observation dominates the weights", {
+  n_moderate <- 20
+  df <- data.frame(
+    effect = rep(0.2, n_moderate + 1),
+    se = c(rep(0.05, n_moderate), 0.0001),
+    study_id = paste0("S", seq_len(n_moderate + 1)),
+    stringsAsFactors = FALSE
+  )
+
+  res <- suppressWarnings(run_nonlinear_methods(df, make_degenerate_options()))
+
+  expect_true("waap" %in% names(res$skipped))
+  expect_match(res$skipped$waap$reason, "dominated by a single extreme-precision observation")
+  expect_false("waap" %in% res$coefficients$model)
+})
+
+test_that("Top10 is skipped when a single observation dominates the weights", {
+  df <- data.frame(
+    effect = rep(0.2, 50),
+    se = c(rep(0.05, 45), rep(0.01, 4), 0.0001),
+    study_id = paste0("S", seq_len(50)),
+    stringsAsFactors = FALSE
+  )
+
+  res <- suppressWarnings(run_nonlinear_methods(df, make_degenerate_options()))
+
+  expect_true("top10" %in% names(res$skipped))
+  expect_match(res$skipped$top10$reason, "dominated by a single extreme-precision observation")
+  expect_false("top10" %in% res$coefficients$model)
+})
+
+test_that("STEM is skipped when it lands on its algorithmic minimum window", {
+  set.seed(123)
+  n <- 30
+  se <- seq(0.02, 0.3, length.out = n)
+  effect <- c(0.9, 0.95, 0.85, rnorm(n - 3, 0, 0.05))
+  df <- data.frame(
+    effect = effect,
+    se = se,
+    study_id = paste0("S", seq_len(n)),
+    stringsAsFactors = FALSE
+  )
+
+  res <- suppressWarnings(run_nonlinear_methods(df, make_degenerate_options()))
+
+  expect_true("stem" %in% names(res$skipped))
+  expect_match(res$skipped$stem$reason, "corner solution")
+  expect_false("stem" %in% res$coefficients$model)
+})
+
+test_that("Selection model is skipped on a boundary (non-converged) solution", {
+  set.seed(42)
+  n <- 60
+  df <- data.frame(
+    effect = rnorm(n, 0, 0.001),
+    se = rep(1, n),
+    study_id = paste0("S", seq_len(n)),
+    stringsAsFactors = FALSE
+  )
+
+  res <- suppressWarnings(run_nonlinear_methods(df, make_degenerate_options()))
+
+  expect_true("selection" %in% names(res$skipped))
+  expect_false("selection" %in% res$coefficients$model)
 })
 
 test_that("nonlinear methods record skipped models when input is insufficient", {


### PR DESCRIPTION
## Summary

The nonlinear_tests summary table (WAAP, Top10, STEM, Selection, Hierarchical, Endogenous Kink) could tabulate degenerate fits as if they were ordinary estimates:

- **Selection model**: a boundary/non-converged optimum (heterogeneity or publication-probability parameter pinned near its lower constraint of 0, or a singular Hessian) produced finite-looking numbers with a blank or `NaN` standard error instead of being flagged.
- **WAAP / Top10**: a single extreme-precision observation could dominate the inverse-variance weights, collapsing the standard error toward zero while still reporting a plausible-looking point estimate.
- **STEM**: the MSE-minimising window can land exactly on its algorithmic floor of 3 studies, a corner solution that carries essentially no information regardless of how many studies are available.
- **Endogenous Kink vs. Precision-Weighted OLS**: verified this coincidence is *not* a wiring bug. When EK's kink point is below the minimum SE, it falls back to an unrestricted regression that is algebraically identical to a 1/se^2-weighted OLS fit — matching "Precision Weighted OLS" whenever a dataset's `precision` column is defined as `1/se`. Added a regression test documenting the equivalence.

Each of the first three is now folded into the existing skip mechanism (the same `tryCatch` → `skipped` path already used for "not enough observations"), so a degenerate fit is fully omitted from the summary table with a plain-language reason in `meta$skipped`, rather than showing spurious numbers.

Detection:
- Selection: exposes the optimizer's convergence code and flags any variance/publication-probability parameter that lands within `1e-4` of its lower bound of 0.
- WAAP/Top10: computes Kish's effective sample size from the fit's weights; an effective size below 2 means one observation is carrying the whole estimate.
- STEM: flags a fit whose selected window is at or below `STEM_MIN_STUDIES` (now an exported constant instead of a magic number).
- A shared check also catches any effect/publication-bias term with a non-finite estimate or a non-finite/zero standard error, across all six estimators.

## Test plan
- [x] `make test` (1792 passed, 0 failed)
- [x] `make lint` (no lints)
- [x] New tests cover: WAAP/Top10 single-observation domination, STEM's minimum-window corner solution, Selection's boundary/non-convergence case, and the EK/Precision-Weighted-OLS coincidence