### PR TITLE
fix(exogeneity): correct p-uniform* study variance and selection threshold

### DIFF
--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -308,16 +308,19 @@ puniform_star_nll <- function(params, yi, vi, ni, alpha = 0.05) {
   # Total variance
   vi_total <- vi + tau^2
 
-  # Z-statistics under null
-  zi <- yi / sqrt(vi_total)
-
   # Critical value
   z_crit <- stats::qnorm(1 - alpha / 2)
 
-  # Publication probability (conditional on being significant)
-  # We model only significant studies
-  pub_prob <- 1 - stats::pnorm(z_crit, mean = theta / sqrt(vi_total), sd = 1) +
-    stats::pnorm(-z_crit, mean = theta / sqrt(vi_total), sd = 1)
+  # Publication probability (conditional on being significant). Selection is
+  # on the observed z-statistic yi / se_i, so the threshold in effect space is
+  # z_crit * se_i, fixed in tau. Scaling the threshold by the total SD instead
+  # lets the null model inflate tau until the observed effects fall outside
+  # the selection region while it still divides by a small P(significant),
+  # which spuriously rewards the null and collapses the LR test.
+  crit_y <- z_crit * sqrt(vi)
+  pub_prob <- 1 - stats::pnorm(crit_y, mean = theta, sd = sqrt(vi_total)) +
+    stats::pnorm(-crit_y, mean = theta, sd = sqrt(vi_total))
+  pub_prob <- pmax(pub_prob, .Machine$double.eps)
 
   # Likelihood contribution
   ll <- sum(stats::dnorm(yi, mean = theta, sd = sqrt(vi_total), log = TRUE) - log(pub_prob))
@@ -536,12 +539,13 @@ run_puniform_star <- function(df, add_significance_marks = TRUE, round_to = 3L, 
   # Compute study medians
   med_yi <- compute_study_medians(df, "effect")
   med_ses <- compute_study_medians(df, "se")
-  med_sample_sizes <- compute_study_medians(df, "n_obs")
   med_ni <- compute_study_medians(df, "study_size")
 
-  # Compute variances
-  med_sdi <- med_ses * sqrt(med_sample_sizes)
-  med_vi <- med_sdi^2
+  # Sampling variance of each study's effect estimate. This must be se^2:
+  # multiplying by the sample size (as an earlier version did) yields the
+  # variance of the underlying micro observations, flattening the likelihood
+  # and destroying the power of the LR test.
+  med_vi <- med_ses^2
 
   # Filter for significant effects (basic p-uniform assumption)
   z_scores <- abs(med_yi / med_ses)

--- a/tests/testthat/test-econometric-exogeneity.R
+++ b/tests/testthat/test-econometric-exogeneity.R
@@ -205,6 +205,30 @@ test_that("run_puniform_star returns a finite estimate with significant studies"
   expect_true(is.finite(res$coefficients$estimate[1]))
 })
 
+test_that("run_puniform_star recovers the effect when n_obs is large", {
+  # Regression test: the study variance used to be computed as se^2 * n_obs
+  # (the variance of the underlying micro observations, not of the effect
+  # estimate), so large primary-study samples flattened the likelihood and
+  # dragged the estimate far below the true effect. With vi = se^2 the
+  # estimate must stay in the neighborhood of the simulated truth.
+  set.seed(11)
+  n <- 120
+  df <- data.frame(
+    effect = rnorm(n, 5, 0.5),
+    se = rep(0.5, n),
+    study_id = rep(seq_len(30), each = 4),
+    study_size = rep(5000L, n),
+    n_obs = rep(5000L, n)
+  )
+
+  res <- run_puniform_star(df, method = "ML")
+  eff <- res$coefficients[res$coefficients$term == "effect", ]
+
+  expect_equal(res$method_used, "ML")
+  expect_gt(eff$estimate, 4)
+  expect_lt(eff$estimate, 6)
+})
+
 test_that("run_puniform_star with method = 'P' returns a finite, positive estimate with significant studies", {
   set.seed(11)
   n <- 120


### PR DESCRIPTION
## Problem

The p-uniform* column in `exogeneity_tests` reported implausible results on real data (master thesis dataset: effect beyond bias 1.17 vs 6.3 to 6.8 from IV and every nonlinear model).

Two bugs in `inst/artma/econometric/exogeneity.R`:

1. **Study variance was `se^2 * n_obs`**, the variance of the underlying micro observations, not of the effect estimate. With median n_obs in the thousands this flattens the likelihood, drags theta toward zero, and destroys the power of the LR test. It was also internally inconsistent: the significance filter one block above already used the correct `se`. Fixed to `vi = se^2`.

2. **The selection threshold in `puniform_star_nll` scaled with the total SD** (`z_crit` relative to `theta / sqrt(vi + tau^2)`). Selection in p-uniform* is on the observed z-statistic, so the effect-space threshold must be `z_crit * se_i`, fixed in tau. The moving threshold let the null model inflate tau until observed effects fell outside the selection region while still dividing by a small P(significant), spuriously rewarding the null and collapsing the LRT.

## Effect on the master thesis dataset (alpha = 0.05, k = 108 significant studies)

| vi definition | ML theta | SE | L | p |
|---|---|---|---|---|
| before | 1.166 | 1.192 | 0.973 | 0.324 |
| after | 7.201 | 0.315 | 191.3 | <0.001 |

After the fix, ML (7.201) and the method-of-moments P estimator (7.197) agree, and both sit next to the WAAP/Top10/stem/hierarchical/selection estimates (6.5 to 6.8).

## Tests

- New regression test: with n_obs = 5000 the estimate must recover the simulated truth (old formula returns 0.887 for a true effect of 5; new returns 4.947).
- The existing LRT non-degeneracy test now exercises the threshold fix as well (the tau-cheat collapsed it to L = 0 once vi was corrected).
- `test-econometric-exogeneity.R`: 49 pass; `test-methods-p-hacking-exogeneity.R`: 13 pass.