### PR TITLE
docs: require absolute output paths in ad-hoc scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ The level is stored in the options file under `autonomy.level` and loaded with t
 - Style: 2-space indentation; `snake_case` or `dotted.case` names (max 40 chars); prefer `cli::cli_*` over base messaging; custom linters live in `.lintr.R`.
 - Documentation: roxygen2 with type annotations: `@param x *\[character, optional\]* Description`.
 - Commits: Conventional Commits, enforced by the commitlint workflow; the changelog is generated from them via `git-chglog`.
+- Ad-hoc scripts: write outputs to absolute paths; never derive a save path from `commandArgs()`.
 
 ## Testing
 


### PR DESCRIPTION
Adds a Conventions line to CLAUDE.md: ad-hoc scripts must write outputs to absolute paths and never derive a save path from `commandArgs()`.

Background: under Rscript, `commandArgs(trailingOnly = FALSE)[1]` is the R interpreter binary in `R_HOME/bin/exec/`, not the script. A scratchpad script using `dirname(commandArgs(...)[1])` as "the script's directory" dropped an RDS file into that directory, which `R CMD INSTALL` reads as the sub-architecture list. Every subsequent install then failed with `No rule to make target 'RcppExports.o'` plus a phantom `*** arch` pass, and materialized a stray `src-<filename>/` copy in the repo (removed in bb08e2c).