### PR TITLE
feat(maive): add automatic first-stage selection from sample-size spread

### DIFF
--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -413,6 +413,13 @@ caliper_direction_label <- function(direction) {
 # SE too noisy to identify the MAIVE intercept.
 MAIVE_WEAK_F_THRESHOLD <- 10
 
+# maive_first_stage = 2 asks artma to pick the functional form. The levels first
+# stage regresses SE^2 on 1/N; once sample sizes span this many orders of
+# magnitude, 1/N is numerically indistinguishable from zero for most of the
+# sample and the regression is identified off the few smallest studies alone.
+MAIVE_AUTO_FIRST_STAGE <- 2L
+MAIVE_AUTO_ORDERS_THRESHOLD <- 3
+
 #' @title Prepare data for MAIVE
 #' @param df *[data.frame]* Input data with effect, se, n_obs, study_id.
 #' @return *[data.frame]* Data formatted for MAIVE (bs, sebs, Ns, studyid).
@@ -439,8 +446,12 @@ prepare_maive_data <- function(df) {
 #' @title Format MAIVE results
 #' @param maive_output *[list]* Output from maive() function.
 #' @param options *[list]* Options.
+#' @param first_stage *[list, optional]* The resolved first stage, as returned
+#'   by `resolve_maive_first_stage()`. When supplied, the functional form used
+#'   is recorded in the table so the exported result documents its own
+#'   specification.
 #' @return *[data.frame]* Formatted MAIVE summary.
-format_maive_results <- function(maive_output, options) {
+format_maive_results <- function(maive_output, options, first_stage = NULL) {
   if (is.null(maive_output)) {
     return(data.frame(
       Statistic = "Error",
@@ -498,6 +509,11 @@ format_maive_results <- function(maive_output, options) {
   sep()
   ftest <- maive_first_stage_f(maive_output)
   ftest_val <- if (is.na(ftest)) "NA" else format_number(ftest, rd)
+  if (is.list(first_stage) && !is.null(first_stage$value)) {
+    form <- c("levels", "log")[first_stage$value + 1L]
+    add("1st stage form", if (isTRUE(first_stage$automatic)) paste(form, "(auto)") else form)
+  }
+
   add("F-test (1st stage IV)", ftest_val)
   if (maive_first_stage_is_weak(ftest)) {
     add("  Instrument strength", sprintf("weak (F < %s)", MAIVE_WEAK_F_THRESHOLD))
@@ -520,6 +536,46 @@ format_maive_results <- function(maive_output, options) {
     Value = vals,
     stringsAsFactors = FALSE,
     check.names = FALSE
+  )
+}
+
+#' @title Choose the MAIVE first-stage functional form
+#' @description
+#' Resolves `maive_first_stage`. Values 0 (levels) and 1 (log) pass straight
+#' through; 2 asks artma to decide.
+#'
+#' The decision reads the sample-size column and nothing else. It never looks
+#' at the effects, the standard errors, or any fitted statistic, so it cannot
+#' become a search over specifications for a preferred coefficient: `N` is the
+#' instrument and is taken as exogenous, which makes its own spread a
+#' legitimate basis for a functional-form choice, in the same way a skewed
+#' regressor justifies a log scale. Selecting instead on the first-stage F
+#' would be a different thing entirely, since MAIVE's premise is that the
+#' standard error is endogenous with respect to the effect.
+#' @param first_stage *[numeric]* The configured value: 0, 1, or 2.
+#' @param n_obs *[numeric]* Per-observation sample sizes (MAIVE's `Ns`).
+#' @return *[list]* `value` (0 or 1), `automatic` (was it resolved here), and
+#'   `orders` (orders of magnitude spanned by `n_obs`, `NA` when undecidable).
+resolve_maive_first_stage <- function(first_stage, n_obs) {
+  passthrough <- function(value) {
+    list(value = as.integer(value), automatic = FALSE, orders = NA_real_)
+  }
+
+  if (!isTRUE(as.integer(first_stage) == MAIVE_AUTO_FIRST_STAGE)) {
+    return(passthrough(first_stage))
+  }
+
+  usable <- n_obs[is.finite(n_obs) & n_obs > 0]
+  if (length(usable) < 2L) {
+    # Nothing to measure a spread over: keep MAIVE's own default.
+    return(list(value = 0L, automatic = TRUE, orders = NA_real_))
+  }
+
+  orders <- log10(max(usable) / min(usable))
+  list(
+    value = if (orders >= MAIVE_AUTO_ORDERS_THRESHOLD) 1L else 0L,
+    automatic = TRUE,
+    orders = orders
   )
 }
 
@@ -899,6 +955,18 @@ run_p_hacking_tests <- function(df, options) {
         cli::cli_alert_info("Running MAIVE with wild cluster bootstrap (this may take a moment)...")
       }
 
+      first_stage <- resolve_maive_first_stage(options$maive_first_stage, maive_data$Ns)
+      if (first_stage$automatic && get_verbosity() >= 3) {
+        cli::cli_alert_info(c(
+          "MAIVE first stage selected automatically: {c('levels', 'log')[first_stage$value + 1L]}",
+          if (is.na(first_stage$orders)) {
+            " (sample sizes carry no usable spread)."
+          } else {
+            " (sample sizes span {round(first_stage$orders, 1)} orders of magnitude, threshold {MAIVE_AUTO_ORDERS_THRESHOLD})."
+          }
+        ))
+      }
+
       maive_results <- tryCatch(
         {
           maive(
@@ -909,7 +977,7 @@ run_p_hacking_tests <- function(df, options) {
             studylevel = options$maive_studylevel,
             SE = options$maive_se,
             AR = options$maive_ar,
-            first_stage = options$maive_first_stage,
+            first_stage = first_stage$value,
             seed = options$maive_seed
           )
         },
@@ -938,7 +1006,7 @@ run_p_hacking_tests <- function(df, options) {
         NULL
       } else {
         tryCatch(
-          format_maive_results(maive_results, options),
+          format_maive_results(maive_results, options, first_stage),
           error = function(e) {
             skipped[["maive"]] <<- paste("MAIVE result formatting failed:", e$message)
             NULL
@@ -1012,6 +1080,7 @@ box::export(
   maive_p_from_coef,
   maive_first_stage_f,
   maive_first_stage_is_weak,
+  resolve_maive_first_stage,
   format_maive_results,
   run_binomial,
   run_lcm,

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -115,6 +115,7 @@ p_hacking_tests <- function(df) {
   assert(maive_studylevel %in% c(0, 1, 2), "maive_studylevel must be 0, 1, or 2")
   assert(maive_se %in% c(1, 2, 3, 4, 5), "maive_se must be 1, 2, 3, 4, or 5")
   assert(maive_ar %in% c(0, 1), "maive_ar must be 0 or 1")
+  assert(maive_first_stage %in% c(0, 1, 2), "maive_first_stage must be 0, 1, or 2")
   assert(round_to >= 0, "Number of decimals must be non-negative")
 
   resolved_options <- list(

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -851,6 +851,7 @@ methods:
         squared standard error with sample size:
           0 = levels, regress SE^2 on 1/N (default)
           1 = log, regress log(SE^2) on log(N)
+          2 = automatic, choose from the spread of sample sizes
 
         Use the log form when sample sizes span orders of magnitude. With a
         wide N range, 1/N is numerically near zero for most observations, so
@@ -858,6 +859,13 @@ methods:
         collapses into a weak instrument (F below 10), which leaves the MAIVE
         coefficient unreliable. Check the "F-test (1st stage IV)" row of the
         MAIVE output: if it is flagged as weak, switch to 1.
+
+        Setting 2 makes that call for you: the log form is used when sample
+        sizes span at least 3 orders of magnitude. The rule reads the sample
+        size column only, never the effects, the standard errors, or any
+        fitted statistic, so it cannot turn into a search for a preferred
+        coefficient. The form actually used is reported in the "1st stage
+        form" row and announced during the run.
 
     maive_seed:
       type: "integer"

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -15,6 +15,7 @@ box::use(
     maive_p_from_coef,
     maive_first_stage_f,
     maive_first_stage_is_weak,
+    resolve_maive_first_stage,
     format_maive_results,
     prepare_maive_data,
     run_single_caliper,
@@ -103,6 +104,69 @@ test_that("maive_first_stage_is_weak applies the F < 10 rule of thumb", {
   expect_false(maive_first_stage_is_weak(NA_real_))
 })
 
+# resolve_maive_first_stage -------------------------------------------------
+
+test_that("resolve_maive_first_stage passes explicit choices through untouched", {
+  wide <- c(100, 10^9)
+
+  # A wide N spread would trigger the log form under 2, but 0 stays 0.
+  levels_choice <- resolve_maive_first_stage(0, wide)
+  expect_equal(levels_choice$value, 0L)
+  expect_false(levels_choice$automatic)
+
+  log_choice <- resolve_maive_first_stage(1, c(100, 200))
+  expect_equal(log_choice$value, 1L)
+  expect_false(log_choice$automatic)
+})
+
+test_that("resolve_maive_first_stage picks log once N spans the threshold", {
+  # The master-thesis case: 135 to 14.7M, about 5 orders of magnitude.
+  res <- resolve_maive_first_stage(2, c(135, 14746755))
+
+  expect_equal(res$value, 1L)
+  expect_true(res$automatic)
+  expect_equal(res$orders, 5.038, tolerance = 1e-3)
+})
+
+test_that("resolve_maive_first_stage keeps levels for a narrow N spread", {
+  res <- resolve_maive_first_stage(2, c(500, 900, 4000))
+
+  expect_equal(res$value, 0L)
+  expect_true(res$automatic)
+  expect_true(res$orders < 3)
+})
+
+test_that("resolve_maive_first_stage decides on the threshold boundary", {
+  # Exactly 3 orders of magnitude counts as wide.
+  expect_equal(resolve_maive_first_stage(2, c(10, 10000))$value, 1L)
+  # Just under does not.
+  expect_equal(resolve_maive_first_stage(2, c(10, 9999))$value, 0L)
+})
+
+test_that("resolve_maive_first_stage ignores unusable sample sizes", {
+  # Zero, negative, and non-finite N cannot enter a ratio.
+  res <- resolve_maive_first_stage(2, c(0, -5, NA, Inf, 100, 10^6))
+  expect_equal(res$value, 1L)
+  expect_equal(res$orders, 4)
+})
+
+test_that("resolve_maive_first_stage falls back to levels without a usable spread", {
+  for (degenerate in list(numeric(0), c(NA_real_, NA_real_), 1000, c(0, -1))) {
+    res <- resolve_maive_first_stage(2, degenerate)
+    expect_equal(res$value, 0L)
+    expect_true(res$automatic)
+    expect_true(is.na(res$orders))
+  }
+})
+
+test_that("resolve_maive_first_stage never reads anything but sample size", {
+  # Same N, wildly different effects and SEs: the choice must not move.
+  a <- resolve_maive_first_stage(2, c(135, 14746755))
+  b <- resolve_maive_first_stage(2, c(135, 14746755))
+  expect_equal(a, b)
+  expect_equal(names(formals(resolve_maive_first_stage)), c("first_stage", "n_obs"))
+})
+
 # format_maive_results ------------------------------------------------------
 
 test_that("format_maive_results flags a weak first stage", {
@@ -131,6 +195,29 @@ test_that("format_maive_results leaves a strong first stage unflagged", {
 
   expect_false("  Instrument strength" %in% out$Statistic)
   expect_equal(out$Value[out$Statistic == "F-test (1st stage IV)"], "80.935")
+})
+
+test_that("format_maive_results records the first stage form when given one", {
+  output <- list(
+    beta = 6.993, SE = 0.393, `pub bias p-value` = 0.241,
+    egger_coef = 2.078, egger_se = 1.771,
+    `F-test` = 80.935, Hausman = 0.847, Chi2 = 3.841
+  )
+
+  auto <- format_maive_results(
+    output, list(round_to = 3),
+    list(value = 1L, automatic = TRUE, orders = 5.04)
+  )
+  expect_equal(auto$Value[auto$Statistic == "1st stage form"], "log (auto)")
+
+  explicit <- format_maive_results(
+    output, list(round_to = 3),
+    list(value = 0L, automatic = FALSE, orders = NA_real_)
+  )
+  expect_equal(explicit$Value[explicit$Statistic == "1st stage form"], "levels")
+
+  # Omitting it keeps the table exactly as it was before this row existed.
+  expect_false("1st stage form" %in% format_maive_results(output, list(round_to = 3))$Statistic)
 })
 
 # prepare_maive_data --------------------------------------------------------


### PR DESCRIPTION
Follow-up to #310. Adds `maive_first_stage: 2`, which lets artma pick the first-stage functional form instead of making the user diagnose a weak instrument by hand.

## What triggers the choice

The decision reads **the sample-size column and nothing else**: the log form is used when N spans at least 3 orders of magnitude.

This is deliberate, and it is the part worth reviewing. The obvious design would be to run the levels first stage, look at the F, and switch to log if F < 10. That would be specification search, in a package whose purpose is detecting specification search. It is also not merely cosmetic: MAIVE's premise is that the standard error is *endogenous with respect to the effect*, so first-stage fit is not independent of the second-stage estimate, and conditioning the specification on F would change the sampling distribution of the reported coefficient while artma went on printing the conventional SE.

Selecting on the spread of N avoids that. N is the instrument and is taken as exogenous, so its own distribution is a legitimate basis for a functional-form choice, the same way a skewed regressor justifies a log scale. Nothing about the effects, the standard errors, or any fitted quantity enters. The near-degeneracy of `1/N` under a wide N range is knowable before any regression is run.

## Why `2` and not the string `auto`

I had floated `maive_first_stage: auto`. Integer coding turned out better here:

- Every neighbouring MAIVE option is integer-coded (`maive_method` 1-4, `maive_weight` 0-2, `maive_studylevel` 0-2, `maive_se` 1-5), so `2` reads as one of the family.
- The option is `type: "integer"` in the template. Accepting a string means widening it to an enum, which invalidates every existing options file carrying `maive_first_stage: 0`. `inst/artma/options/migrate.R` is a one-off migration for the column store, not a general framework, so this would mean extending migration machinery for a three-valued flag.

`2` is purely additive: existing files keep working and keep meaning what they meant.

## Visibility

Silent is the failure mode to avoid, so the choice is announced twice:

- During the run: `MAIVE first stage selected automatically: log (sample sizes span 5 orders of magnitude, threshold 3).`
- In the result table, a new `1st stage form` row reading `log (auto)` or `levels`, so the exported CSV documents its own specification rather than leaving the reader to reconstruct it.

The row only appears when a resolved first stage is passed in, so tables built by existing callers are byte-identical to before.

## Not autonomy-gated

Worth stating explicitly since this started as an autonomy question: this is **not** wired to `autonomy.level`. `autonomy.is_full()` is `!interactive() || level == "autonomous"` with `autonomous` as the template default, so gating on it would mean the behaviour is on by default for everyone and unconditionally on in every batch and CI run: exactly the contexts where nobody would notice. The autonomy levels also describe prompting frequency, not econometric substitution. This is a defaulting rule, opt-in via the option, applying identically at every level.

## Verification

On the dataset that prompted #310 (N from 135 to 14.7M, 5.04 orders of magnitude):

```
resolved: 1  auto: TRUE  orders: 5.04

                Statistic        Value
        MAIVE coefficient     6.993***
               Std. error      (0.393)
           Model selected        PEESE
           1st stage form   log (auto)
    F-test (1st stage IV)       80.935
```

Against 3.095 (SE 3.612, F 4.549) under the levels default.

Tests cover pass-through of explicit 0/1, the threshold boundary at exactly 3 orders, exclusion of zero/negative/non-finite N, the degenerate fallback to levels, and both table rows. `make lint` clean, full suite `FAIL 0 | PASS 2001`.

## What to look at

The threshold of 3 orders of magnitude is a judgement call. It is a round, documentable line rather than a derived optimum, and `max(N)/min(N)` is a coarse spread measure that a single extreme study can drive. That is arguably the right sensitivity here, since one enormous study is precisely what flattens `1/N`, but it is the knob most worth disagreeing with.