### PR TITLE
fix(elliott): use integer knot indices in pure R CDF simulation fallback

### DIFF
--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -145,12 +145,15 @@ simulate_cdfs_parallel <- function(
       hky <- hull$y.knots
       hks <- hull$slope.knots
 
-      for (s in 2:length(hkx)) {
+      # The x-knots are grid points j / gp, but the product hkx * gp can land
+      # just below the integer j (e.g. 86.999...); indexing with it truncates
+      # and writes the chord one grid slot too low. Round to recover j exactly.
+      ki <- as.integer(round(hkx * gp))
+
+      for (s in 2:length(ki)) {
         a <- hky[s] - hks[s - 1L] * hkx[s]
         b_slope <- hks[s - 1L]
-        lower <- hkx[s - 1L] * gp + 1
-        upper <- hkx[s] * gp
-        idx <- lower:upper
+        idx <- (ki[s - 1L] + 1L):ki[s]
         y[idx] <- a + b_slope * (idx * inv_gp)
       }
 

--- a/tests/testthat/test-elliott-simulate-cdfs.R
+++ b/tests/testthat/test-elliott-simulate-cdfs.R
@@ -4,24 +4,27 @@ box::use(
     expect_length,
     expect_null,
     expect_true,
+    skip_if_not,
     test_that
   ],
   withr[local_options],
   artma / calc / methods / elliott[simulate_cdfs_parallel]
 )
 
-run_simulation <- function(seed, iterations, grid_points, show_progress = FALSE, verbose = 0) {
+run_simulation <- function(seed, iterations, grid_points, show_progress = FALSE, verbose = 0,
+                           use_cpp = FALSE, workers = NULL) {
   old_kind <- RNGkind()
   on.exit(do.call(RNGkind, as.list(old_kind)), add = TRUE)
   RNGkind(kind = "Mersenne-Twister", normal.kind = "Inversion", sample.kind = "Rejection")
   local_options(list(
     artma.verbose = verbose,
-    artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
+    artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = use_cpp
   ))
   set.seed(seed)
   simulate_cdfs_parallel(
     iterations = iterations,
     grid_points = grid_points,
+    workers = workers,
     show_progress = show_progress
   )
 }
@@ -79,4 +82,42 @@ test_that("simulate_cdfs responds to different RNG seeds", {
   res_b <- run_simulation(seed = 202, iterations = 3, grid_points = 30)
 
   expect_true(any(abs(res_a - res_b) > 0))
+})
+
+test_that("pure R fallback matches the compiled implementation elementwise", {
+  cpp_available <- tryCatch(
+    {
+      .Call("_artma_simulate_cdfs_block_cpp", PACKAGE = "artma", matrix(0, 1, 1))
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+  skip_if_not(cpp_available, "compiled simulate_cdfs_block_cpp is unavailable")
+
+  # Grid sizes where some gcmlcm x-knots times grid_points land just below an
+  # integer (e.g. 86.999...). The fallback used to index with those raw
+  # products, so truncation wrote hull chords one grid slot too low and its
+  # suprema drifted from the C++ results by up to ~0.9 on a few draws.
+  configs <- list(
+    list(grid_points = 100L, iterations = 300L),
+    list(grid_points = 700L, iterations = 300L)
+  )
+
+  for (cf in configs) {
+    res_cpp <- run_simulation(
+      seed = 42, iterations = cf$iterations, grid_points = cf$grid_points,
+      use_cpp = TRUE, workers = 1L
+    )
+    res_r <- run_simulation(
+      seed = 42, iterations = cf$iterations, grid_points = cf$grid_points,
+      use_cpp = FALSE, workers = 1L
+    )
+
+    expect_length(res_r, cf$iterations)
+    max_diff <- max(abs(res_r - res_cpp))
+    expect_true(
+      max_diff <= 1e-9,
+      info = sprintf("grid_points = %d, max abs diff = %.3g", cf$grid_points, max_diff)
+    )
+  }
 })


### PR DESCRIPTION
## Problem

The pure R fallback in `simulate_cdfs_parallel` (`inst/artma/calc/methods/elliott.R`, used when the compiled routine is unavailable) disagrees with `simulate_cdfs_block_cpp` (`src/elliott_cdfs.cpp`) on a small share of simulated draws, with per-draw errors up to ~0.9 on suprema of typical size ~0.6.

The fallback derives per-segment grid indices from the LCM hull's x-knots as

```r
lower <- hkx[s - 1L] * gp + 1
upper <- hkx[s] * gp
idx <- lower:upper
```

`hkx` are `fdrtool::gcmlcm` x-knots, i.e. grid values `j * (1/gp)`. When `hkx * gp` lands just below the integer `j` in floating point (e.g. 86.99999999999999), the non-integer `lower:upper` sequence truncates during indexing, so the chord values of that hull segment are written one grid slot too low (or a slot is skipped entirely and left at 0), and `max(abs(y - b_values))` is wrong for that draw.

Whether a given `grid_points` is affected depends on the rounding direction of `j * (1/gp) * gp`: products that round up truncate back to the correct index, products that round down shift the segment. That is why `grid_points = 300` (all 101 inexact products round up) never disagrees, while e.g. 100, 700, 3000, and the default 10000 have harmful patterns. An independent integer-indexed monotone-chain hull reproduces the C++ results exactly on all disagreeing draws, so the C++ side is correct and only the fallback needed fixing. Distribution quantiles (0.9/0.95/0.99) are essentially unaffected; this is a robustness fix for the fallback path.

## Changes

- `worker_chunk` now recovers the integer knot index once per hull with `ki <- as.integer(round(hkx * gp))` and indexes each segment as `(ki[s - 1L] + 1L):ki[s]`, matching the integer arithmetic of `compute_lcm_sup` in `src/elliott_cdfs.cpp`. Rounding is exact here because the x-knots are grid points, so the products sit within an ulp of an integer.
- New regression test in `test-elliott-simulate-cdfs.R` runs both paths on fixed-seed batches (300 draws each at `grid_points = 100` and `700`, both of which have downward-rounding knot products) and asserts elementwise agreement within 1e-9. It skips when the compiled routine is unavailable. The test helper gains `use_cpp` and `workers` passthroughs, with defaults preserving the existing tests' behavior.

## Verification

- Against the unfixed code, the new test fails with max abs diff 0.921 at `grid_points = 100` (3 of 300 draws off) and 0.712 at `grid_points = 700` (5 of 300 draws off).
- With the fix, both paths agree to ~1e-15 elementwise across `grid_points` in {40, 87, 100, 250, 300, 700, 1000, 3000, 10000} on fixed-seed batches, including the previously clean grids.
- `make lint` clean on the changed files; full suite `FAIL 0 | WARN 9 | SKIP 0 | PASS 1974` (warnings are pre-existing MAIVE fit warnings on synthetic test data).
