### PR TITLE
perf(elliott): share pair lambdas across Cox-Shi bound orders

### DIFF
--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -310,32 +310,44 @@ lambda2 <- function(x1, x2, h) {
     stats::pnorm(stats::qnorm(1 - x1 / 2) + h) - stats::pnorm(stats::qnorm(1 - x2 / 2) + h)
 }
 
-#' Compute bounds for the p-curve and its derivatives
-compute_bounds <- function(p_min, p_max, J, order) {
+#' Adjacent-pair lambda vectors shared by all Cox-Shi bound orders
+#'
+#' Element `j` is `lambda2(grid[j], grid[j + 1], h)` on the common `h` grid.
+#' Every bound order is an elementwise combination of these J vectors, so
+#' they are computed once and reused instead of re-evaluated per order.
+pair_lambdas <- function(p_min, p_max, J) {
   h <- seq(0, 100, by = 0.001)
   grid <- linspace(p_min, p_max, J + 1)
+  lapply(seq_len(J), function(j) lambda2(grid[j], grid[j + 1], h))
+}
+
+#' Derive one order of Cox-Shi bounds from precomputed pair lambdas
+bounds_from_lambdas <- function(lam, order, p_min) {
   order <- as.integer(order)
   if (!order %in% 0:2) {
     cli::cli_abort("Unsupported order")
   }
-  width <- c(J, J - 1, J - 2)[order + 1]
+  n_pairs <- length(lam)
+  width <- c(n_pairs, n_pairs - 1, n_pairs - 2)[order + 1]
   bounds <- numeric(width)
   for (j in seq_len(width)) {
-    lambda_left <- lambda2(grid[j], grid[j + 1], h)
     if (order == 0L) {
-      bounds[j] <- max(lambda_left)
+      bounds[j] <- max(lam[[j]])
     } else if (order == 1L) {
-      lambda_right <- lambda2(grid[j + 1], grid[j + 2], h)
-      bounds[j] <- max(abs(lambda_right - lambda_left))
+      bounds[j] <- max(abs(lam[[j + 1]] - lam[[j]]))
     } else {
-      lambda_mid <- lambda2(grid[j + 2], grid[j + 3], h)
-      bounds[j] <- max(abs(lambda_mid - 2 * lambda2(grid[j + 1], grid[j + 2], h) + lambda_left))
+      bounds[j] <- max(abs(lam[[j + 2]] - 2 * lam[[j + 1]] + lam[[j]]))
     }
   }
   if (p_min == 0) {
     bounds[1] <- 1
   }
   matrix(bounds, ncol = 1)
+}
+
+#' Compute bounds for the p-curve and its derivatives
+compute_bounds <- function(p_min, p_max, J, order) {
+  bounds_from_lambdas(pair_lambdas(p_min, p_max, J), order, p_min)
 }
 
 bound0 <- function(p_min, p_max, J) compute_bounds(p_min, p_max, J, 0)
@@ -553,9 +565,10 @@ cox_shi_test <- function(Q, ind, p_min, p_max, J, K, use_bounds) {
   phat_data <- compute_phat(P, J, p_min, p_max)
   phat <- phat_data$phat
   bins <- phat_data$bins
-  B0 <- bound0(p_min, p_max, J)
-  B1 <- bound1(p_min, p_max, J)
-  B2 <- bound2(p_min, p_max, J)
+  lam <- pair_lambdas(p_min, p_max, J)
+  B0 <- bounds_from_lambdas(lam, 0L, p_min)
+  B1 <- bounds_from_lambdas(lam, 1L, p_min)
+  B2 <- bounds_from_lambdas(lam, 2L, p_min)
   omega <- compute_omega(P, ind_filtered, phat, bins)
   omega_inv <- if (is.finite(det(omega)) && abs(det(omega)) > 0) {
     tryCatch(solve(omega), error = function(e) NULL)

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -31,7 +31,16 @@ box::use(
     caliper_direction,
     build_caliper_summary
   ],
-  artma / calc / methods / elliott[cox_shi_test, simulate_cdfs_parallel]
+  artma / calc / methods / elliott[
+    bound0,
+    bound1,
+    bound2,
+    compute_bounds,
+    cox_shi_test,
+    lambda2,
+    linspace,
+    simulate_cdfs_parallel
+  ]
 )
 
 # compute_pvalues -----------------------------------------------------------
@@ -946,4 +955,57 @@ test_that("run_p_hacking_tests reports numeric Cox-Shi rows on clustered data", 
   cox_rows <- result$elliott[grepl("^Cox-Shi", result$elliott$Test), ]
   expect_equal(nrow(cox_rows), 2)
   expect_false(any(grepl("NA", cox_rows$`P-value`)))
+})
+
+# Cox-Shi bounds --------------------------------------------------------------
+
+# Direct transcription of the pre-refactor compute_bounds, which evaluated
+# lambda2 per order (and per pair within an order) instead of sharing the
+# adjacent-pair vectors. Guards the refactor against any numeric drift.
+reference_bounds <- function(p_min, p_max, n_bins, order) {
+  h <- seq(0, 100, by = 0.001)
+  grid <- linspace(p_min, p_max, n_bins + 1)
+  width <- c(n_bins, n_bins - 1, n_bins - 2)[order + 1]
+  bounds <- numeric(width)
+  for (j in seq_len(width)) {
+    lambda_left <- lambda2(grid[j], grid[j + 1], h)
+    if (order == 0) {
+      bounds[j] <- max(lambda_left)
+    } else if (order == 1) {
+      lambda_right <- lambda2(grid[j + 1], grid[j + 2], h)
+      bounds[j] <- max(abs(lambda_right - lambda_left))
+    } else {
+      lambda_mid <- lambda2(grid[j + 2], grid[j + 3], h)
+      bounds[j] <- max(abs(lambda_mid - 2 * lambda2(grid[j + 1], grid[j + 2], h) + lambda_left))
+    }
+  }
+  if (p_min == 0) {
+    bounds[1] <- 1
+  }
+  matrix(bounds, ncol = 1)
+}
+
+test_that("compute_bounds matches the per-order lambda2 formulas", {
+  configs <- list(
+    list(p_min = 0, p_max = 0.05, n_bins = 10L),
+    list(p_min = 0.01, p_max = 0.1, n_bins = 8L)
+  )
+  for (config in configs) {
+    shared <- lapply(0:2, function(order) {
+      compute_bounds(config$p_min, config$p_max, config$n_bins, order)
+    })
+    for (order in 0:2) {
+      expect_equal(
+        shared[[order + 1]],
+        reference_bounds(config$p_min, config$p_max, config$n_bins, order)
+      )
+    }
+    expect_equal(bound0(config$p_min, config$p_max, config$n_bins), shared[[1]])
+    expect_equal(bound1(config$p_min, config$p_max, config$n_bins), shared[[2]])
+    expect_equal(bound2(config$p_min, config$p_max, config$n_bins), shared[[3]])
+  }
+})
+
+test_that("compute_bounds still rejects an unsupported order", {
+  expect_error(compute_bounds(0, 0.05, 10L, 3), "Unsupported order")
 })


### PR DESCRIPTION
## Summary

The Cox-Shi bound computation in inst/artma/calc/methods/elliott.R re-evaluated lambda2 on its 100,001-point h grid for every bin of every order: order 0 cost J grid passes, order 1 cost 2(J-1) (recomputing each pair's left lambda), order 2 cost 3(J-2), and cox_shi_test paid all three separately via bound0/bound1/bound2 (about 52 passes for J = 10).

All three orders are elementwise combinations of the same J adjacent-pair vectors lambda2(grid[j], grid[j+1], h), so:

- new internal pair_lambdas(p_min, p_max, J) computes that list once
- new internal bounds_from_lambdas(lam, order, p_min) derives any order from it, keeping the p_min == 0 override and the "Unsupported order" abort exactly as before
- compute_bounds(p_min, p_max, J, order) and bound0/1/2 keep their signatures and are now thin wrappers, so the exported API is unchanged
- cox_shi_test builds the list once and derives B0, B1, B2 from it: J grid passes per call instead of about 6J - 8

Results are bit-identical (identical(), not just all.equal()) to the old formulas; verified across 12 configurations including p_min = 0 and p_min > 0. Locally the bound block of one cox_shi_test call drops from ~1.00s to ~0.14s, in line with the ~0.27s to ~0.05s (~5x) measured when this refactor was proposed; cox_shi_test runs twice per p_hacking_tests run. The existing golden-value tests against the canonical Elliott/Kudrin/Wuthrich implementation confirm cox_shi_test output is unchanged end to end.

Skipped the optional per-(p_min, p_max, J) memoisation: the two calls per run use different p_max, so it would never hit within a run.

## Testing

- New regression test compares compute_bounds and bound0/1/2 against a transcription of the pre-refactor per-order formulas for (p_min = 0, p_max = 0.05, J = 10) and (p_min = 0.01, p_max = 0.1, J = 8), all three orders, plus the unsupported-order error.
- make test: 2014 passing, 0 failures (9 pre-existing MAIVE fit warnings).
- styler clean, lintr clean on both changed files.