### PR TITLE
feat(p_hacking): raise default LCM iterations to 10000

### DIFF
--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -30,7 +30,7 @@ p_hacking_tests <- function(df) {
 
   # Elliott options
   include_elliott <- opt$include_elliott %||% TRUE
-  lcm_iterations <- opt$lcm_iterations %||% 3000L
+  lcm_iterations <- opt$lcm_iterations %||% 10000L
   lcm_grid_points <- opt$lcm_grid_points %||% 3000L
   simulate_cdfs_chunk_size <- opt[["simulate_cdfs.chunk_size"]] %||% 512L
   simulate_cdfs_seed <- opt[["simulate_cdfs.seed"]] %||% 123L

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -717,9 +717,10 @@ methods:
 
     lcm_iterations:
       type: "integer"
-      default: 3000
+      default: 10000
       help: |
-        Number of simulations for LCM test critical values.
+        Number of simulations for LCM test critical values, matching the
+        Monte-Carlo size used by Elliott et al. (2022).
         Higher values increase precision but take longer to compute.
 
     lcm_grid_points:


### PR DESCRIPTION
## What

Raises the default `lcm_iterations` for the Elliott LCM p-hacking test from 3000 to 10000, matching the Monte-Carlo size of Elliott et al. (2022). `lcm_grid_points` stays at 3000. Template default and the `%||%` fallback in `p_hacking_tests.R` are updated together.

## Why

At 3000 iterations the reported LCM p-value carries Monte-Carlo noise of about +/-0.008 (95% CI) near the 0.05 boundary; 10000 iterations cuts that to about +/-0.004, below the level that flips borderline calls. Measured cost of the simulation with the compiled path on an M-series laptop (7 forked workers): 0.40s before, 1.29s after, paid once per cache signature. The remaining known error from the 3000-point grid is a small anti-conservative bias (a statistic at the true 5% critical value reads p = 0.047); moving the grid to 10000 would triple the runtime, so it is left as is for now.

## Testing

- `make test-file FILE=test-econometric-p-hacking.R` (177 pass; tests pin their own small iteration counts, so no snapshot churn)
- `make test-file FILE=test-options-template-parity.R` and `test-options-strict.R` (pass)
