### PR TITLE
feat(maive): split MAIVE into its own method with sectioned, annotated output

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ List them at any time with `artma::methods.list()`. The current set:
 | `nonlinear_tests` | Publication bias diagnostics based on non-linear estimators |
 | `exogeneity_tests` | Diagnostics that relax the exogeneity assumption (IV regression, p-uniform*) |
 | `p_hacking_tests` | A suite of tests for p-hacking and selective reporting |
+| `maive` | The MAIVE estimator, correcting for publication bias, p-hacking, and spurious precision |
 | `bma` | Bayesian Model Averaging over moderator variables for heterogeneity analysis |
 | `fma` | Frequentist Model Averaging, reusing the BMA model to order predictors |
 | `best_practice_estimate` | Best-practice estimates computed from the BMA coefficients |

--- a/inst/artma/econometric/maive.R
+++ b/inst/artma/econometric/maive.R
@@ -1,0 +1,715 @@
+#' @title MAIVE estimator helpers
+#' @description
+#' Data preparation, verdict derivation, summary-table construction, and
+#' plain-language interpretation for the MAIVE estimator (Irsova et al., 2025).
+#' The estimator itself lives in `artma/calc/methods/maive`; everything here is
+#' about turning its return value into something a reader can act on.
+NULL
+
+box::use(
+  artma / libs / core / validation[validate],
+  artma / libs / formatting / results[
+    format_number,
+    format_se,
+    format_ci,
+    significance_mark
+  ],
+  artma / calc / methods / maive[maive]
+)
+
+#' @title Threshold below which the first-stage instrument counts as weak
+WEAK_INSTRUMENT_F <- 10
+
+#' @title Threshold below which running the first stage in logs is advised
+LOG_FIRST_STAGE_F <- 30
+
+#' @title Anderson-Rubin interval width beyond which identification is dubious
+WIDE_AR_CI <- 100
+
+# first_stage = 2 asks artma to pick the functional form. The levels first
+# stage regresses SE^2 on 1/N; once sample sizes span this many orders of
+# magnitude, 1/N is numerically indistinguishable from zero for most of the
+# sample and the regression is identified off the few smallest studies alone.
+AUTO_FIRST_STAGE <- 2L
+AUTO_ORDERS_THRESHOLD <- 3
+
+# Option labels -------------------------------------------------------------
+
+#' @title Human-readable label for the MAIVE funnel model
+#' @param x *[integer]* The `method` option (1..4).
+#' @return *[character]* Label for display.
+maive_method_label <- function(x) {
+  switch(as.character(x),
+    "1" = "FAT-PET",
+    "2" = "PEESE",
+    "3" = "PET-PEESE",
+    "4" = "Endogenous kink (EK)",
+    as.character(x)
+  )
+}
+
+#' @title Human-readable label for the MAIVE weighting scheme
+#' @param x *[integer]* The `weight` option (0..2).
+#' @return *[character]* Label for display.
+maive_weight_label <- function(x) {
+  switch(as.character(x),
+    "0" = "none",
+    "1" = "standard",
+    "2" = "adjusted",
+    as.character(x)
+  )
+}
+
+#' @title Human-readable label for the MAIVE instrumenting switch
+#' @param x *[integer]* The `instrument` option (0 or 1).
+#' @return *[character]* Label for display.
+maive_instrument_label <- function(x) {
+  switch(as.character(x),
+    "0" = "off (no IV correction)",
+    "1" = "on (1/N instrument)",
+    as.character(x)
+  )
+}
+
+#' @title Human-readable label for the MAIVE study-level structure
+#' @param x *[integer]* The `studylevel` option (0..2).
+#' @return *[character]* Label for display.
+maive_studylevel_label <- function(x) {
+  switch(as.character(x),
+    "0" = "none",
+    "1" = "study fixed effects",
+    "2" = "cluster-robust",
+    as.character(x)
+  )
+}
+
+#' @title Human-readable label for the MAIVE standard-error mode
+#' @param x *[integer]* The `se` option (1..5).
+#' @return *[character]* Label for display.
+maive_se_label <- function(x) {
+  switch(as.character(x),
+    "1" = "asymptotic",
+    "2" = "pairs cluster bootstrap",
+    "3" = "wild bootstrap",
+    "4" = "wild cluster bootstrap",
+    "5" = "pairs bootstrap",
+    as.character(x)
+  )
+}
+
+#' @title First-stage specification and matching F-statistic label
+#' @description
+#' The first stage runs either in levels or in logs, and the F statistic tests a
+#' different coefficient in each case. Showing which one produced the number is
+#' the difference between a diagnostic and a bare figure.
+#' @param x *[integer]* The `first_stage` option (0 = levels, 1 = logs).
+#' @return *[list]* With `spec` (the regression written out) and `f_label`.
+maive_first_stage_spec <- function(x) {
+  if (identical(as.integer(x), 1L)) {
+    return(list(
+      spec = "log(SE^2) ~ log N (Duan smearing)",
+      f_label = "First-stage F (gamma1)",
+      f_phrase = "first-stage F on gamma1"
+    ))
+  }
+  list(spec = "SE^2 ~ 1/N", f_label = "First-stage F", f_phrase = "first-stage F")
+}
+
+#' @title Choose the MAIVE first-stage functional form
+#' @description
+#' Resolves the `first_stage` option. Values 0 (levels) and 1 (log) pass
+#' straight through; 2 asks artma to decide.
+#'
+#' The decision reads the sample-size column and nothing else. It never looks
+#' at the effects, the standard errors, or any fitted statistic, so it cannot
+#' become a search over specifications for a preferred coefficient: `N` is the
+#' instrument and is taken as exogenous, which makes its own spread a
+#' legitimate basis for a functional-form choice, in the same way a skewed
+#' regressor justifies a log scale. Selecting instead on the first-stage F
+#' would be a different thing entirely, since MAIVE's premise is that the
+#' standard error is endogenous with respect to the effect.
+#' @param first_stage *[numeric]* The configured value: 0, 1, or 2.
+#' @param n_obs *[numeric]* Per-observation sample sizes (MAIVE's `Ns`).
+#' @return *[list]* `value` (0 or 1), `automatic` (was it resolved here), and
+#'   `orders` (orders of magnitude spanned by `n_obs`, `NA` when undecidable).
+resolve_maive_first_stage <- function(first_stage, n_obs) {
+  passthrough <- function(value) {
+    list(value = as.integer(value), automatic = FALSE, orders = NA_real_)
+  }
+
+  if (!isTRUE(as.integer(first_stage) == AUTO_FIRST_STAGE)) {
+    return(passthrough(first_stage))
+  }
+
+  usable <- n_obs[is.finite(n_obs) & n_obs > 0]
+  if (length(usable) < 2L) {
+    # Nothing to measure a spread over: keep MAIVE's own default.
+    return(list(value = 0L, automatic = TRUE, orders = NA_real_))
+  }
+
+  orders <- log10(max(usable) / min(usable))
+  list(
+    value = if (orders >= AUTO_ORDERS_THRESHOLD) 1L else 0L,
+    automatic = TRUE,
+    orders = orders
+  )
+}
+
+# Verdicts ------------------------------------------------------------------
+
+#' @title Extract the first-stage F statistic from MAIVE output
+#' @description MAIVE reports the statistic as the literal string "NA" when
+#'   instrumenting is switched off, so a plain `as.numeric()` is not enough.
+#' @param maive_output *[list]* Output from `maive()`.
+#' @return *[numeric]* The F statistic, or `NA_real_` when unavailable.
+maive_first_stage_f <- function(maive_output) {
+  raw <- maive_output$`F-test`
+  if (is.null(raw) || length(raw) != 1L || identical(raw, "NA")) {
+    return(NA_real_)
+  }
+  val <- suppressWarnings(as.numeric(raw))
+  if (!is.finite(val)) NA_real_ else val
+}
+
+#' @title Classify first-stage instrument strength
+#' @param f_stat *[numeric]* The first-stage F statistic.
+#' @return *[character]* One of `"strong"`, `"weak"`, or `"unknown"`.
+instrument_strength <- function(f_stat) {
+  if (!is.numeric(f_stat) || length(f_stat) != 1L || !is.finite(f_stat)) {
+    return("unknown")
+  }
+  if (f_stat >= WEAK_INSTRUMENT_F) "strong" else "weak"
+}
+
+#' @title Flag a weak MAIVE first stage
+#' @param f_stat *[numeric]* First-stage F statistic.
+#' @return *[logical]* TRUE when the instrument is weak by the Stock-Yogo rule
+#'   of thumb.
+maive_first_stage_is_weak <- function(f_stat) {
+  identical(instrument_strength(f_stat), "weak")
+}
+
+#' @title Does the Hausman statistic exceed its critical value?
+#' @param statistic *[numeric]* The Hausman statistic.
+#' @param critical *[numeric]* The 5% chi-squared critical value.
+#' @return *[logical]* `TRUE`, `FALSE`, or `NA` when the test is uninformative.
+hausman_rejects <- function(statistic, critical) {
+  finite <- function(x) is.numeric(x) && length(x) == 1L && is.finite(x)
+  if (!finite(statistic) || !finite(critical)) {
+    return(NA)
+  }
+  statistic > critical
+}
+
+#' @title Does a confidence interval exclude zero?
+#' @param ci *[numeric]* A length-2 interval.
+#' @return *[logical]* `TRUE`, `FALSE`, or `NA` when the interval is unusable.
+ci_excludes_zero <- function(ci) {
+  if (!is.numeric(ci) || length(ci) != 2L || !all(is.finite(ci))) {
+    return(NA)
+  }
+  ci[[1L]] > 0 || ci[[2L]] < 0
+}
+
+#' @title Verdict text for an Anderson-Rubin interval
+#' @param ci *[numeric]* The interval, or anything non-finite when unavailable.
+#' @param computed *[logical]* Whether AR computation was requested.
+#' @return *[list]* With `value`, `note`, and `tone`.
+ar_ci_verdict <- function(ci, computed) {
+  if (!isTRUE(computed)) {
+    return(list(value = "not computed", note = "enable the ar option to compute it", tone = ""))
+  }
+  if (!is.numeric(ci) || length(ci) != 2L || !all(is.finite(ci))) {
+    return(list(value = "NA", note = "no valid acceptance region found", tone = "bad"))
+  }
+  width <- abs(ci[[2L]] - ci[[1L]])
+  if (width > WIDE_AR_CI) {
+    return(list(value = NA_character_, note = "very wide: weak identification", tone = "bad"))
+  }
+  list(value = NA_character_, note = "weak-instrument robust", tone = "")
+}
+
+# Data preparation ----------------------------------------------------------
+
+#' @title Prepare data for MAIVE
+#' @param df *[data.frame]* Input data with effect, se, n_obs, study_id.
+#' @return *[data.frame]* Data formatted for MAIVE (bs, sebs, Ns, studyid).
+prepare_maive_data <- function(df) {
+  validate(is.data.frame(df))
+
+  required_cols <- c("effect", "se", "n_obs")
+  validate(all(required_cols %in% colnames(df)))
+
+  maive_data <- data.frame(
+    bs = df$effect,
+    sebs = df$se,
+    Ns = df$n_obs,
+    stringsAsFactors = FALSE
+  )
+
+  if ("study_id" %in% colnames(df)) {
+    maive_data$studyid <- df$study_id
+  }
+
+  maive_data
+}
+
+#' @title Compute two-sided p-value from coefficient and SE
+#' @param beta *[numeric]* Coefficient.
+#' @param se *[numeric]* Standard error.
+#' @return *[numeric]* P-value, or NA if inputs are not finite.
+maive_p_from_coef <- function(beta, se) {
+  if (!is.numeric(beta) || !is.numeric(se) || !is.finite(beta) || !is.finite(se) || se <= 0) {
+    return(NA_real_)
+  }
+  2 * stats::pnorm(-abs(beta / se))
+}
+
+#' @title Normal-approximation confidence interval
+#' @param beta *[numeric]* Coefficient.
+#' @param se *[numeric]* Standard error.
+#' @param level *[numeric]* Confidence level.
+#' @return *[numeric]* Length-2 interval, or `c(NA, NA)` for degenerate inputs.
+maive_ci <- function(beta, se, level = 0.95) {
+  if (!is.numeric(beta) || !is.numeric(se) || !is.finite(beta) || !is.finite(se) || se <= 0) {
+    return(c(NA_real_, NA_real_))
+  }
+  half_width <- stats::qnorm(1 - (1 - level) / 2) * se
+  c(beta - half_width, beta + half_width)
+}
+
+# Summary table -------------------------------------------------------------
+
+#' @title Build the sectioned MAIVE summary table
+#' @description
+#' Produces a tidy `Section` / `Statistic` / `Value` / `Note` frame. Sections are
+#' data rather than blank separator rows, so the exported CSV keeps the grouping
+#' and the console renderer can print real headings. The verdict colours ride
+#' along in a `tone` attribute so they never reach the CSV.
+#' @param maive_output *[list]* Output of [maive()].
+#' @param options *[list]* Resolved MAIVE options.
+#' @param data_info *[list, optional]* With `n_obs` and `n_studies`.
+#' @param resolved_first_stage *[list, optional]* The first stage actually used,
+#'   as returned by [resolve_maive_first_stage()]. Defaults to the configured
+#'   value, which is only wrong when automatic selection was in play.
+#' @return *[data.frame]* The summary table, with a `tone` attribute.
+build_maive_summary <- function(maive_output, options, data_info = list(),
+                                resolved_first_stage = NULL) {
+  validate(is.list(maive_output), is.list(options))
+
+  rd <- options$round_to %||% 3L
+  marks <- !isFALSE(options$add_significance_marks)
+  instrumented <- identical(as.integer(options$instrument %||% 1L), 1L)
+  fixed_intercept <- identical(as.integer(options$studylevel %||% 2L), 1L)
+  resolved_first_stage <- resolved_first_stage %||%
+    resolve_maive_first_stage(options$first_stage %||% 0L, numeric(0))
+  first_stage <- maive_first_stage_spec(resolved_first_stage$value)
+
+  rows <- list()
+  self_env <- environment()
+  add <- function(section, stat, value, note = "", tone = "") {
+    if (length(value) != 1L || is.na(value)) {
+      value <- "NA"
+    }
+    self_env$rows[[length(self_env$rows) + 1L]] <- list(
+      section = section, stat = stat, value = as.character(value),
+      note = note, tone = tone
+    )
+  }
+  mark <- function(p_value) if (marks) significance_mark(p_value) else ""
+
+  # --- Specification ---
+  spec <- "Specification"
+  add(spec, "Model", maive_method_label(options$method %||% 3L))
+  add(spec, "Instrument", maive_instrument_label(options$instrument %||% 1L))
+  add(spec, "Weights", maive_weight_label(options$weight %||% 0L))
+  add(spec, "Study-level structure", maive_studylevel_label(options$studylevel %||% 2L))
+  add(spec, "Standard errors", maive_se_label(options$se %||% 1L))
+  if (instrumented) {
+    add(
+      spec, "First-stage specification", first_stage$spec,
+      note = if (isTRUE(resolved_first_stage$automatic)) {
+        if (is.na(resolved_first_stage$orders)) {
+          "chosen automatically (no usable spread in N)"
+        } else {
+          sprintf(
+            "chosen automatically (N spans %s orders of magnitude)",
+            format_number(resolved_first_stage$orders, 1L)
+          )
+        }
+      } else {
+        ""
+      }
+    )
+  }
+  if (is.numeric(data_info$n_obs)) {
+    add(spec, "Observations", format(as.integer(data_info$n_obs)))
+  }
+  if (is.numeric(data_info$n_studies)) {
+    add(spec, "Studies", format(as.integer(data_info$n_studies)))
+  }
+
+  # --- Corrected mean estimate ---
+  est <- "Corrected mean estimate"
+  beta <- maive_output$beta
+  beta_se <- maive_output$SE
+  beta_p <- maive_p_from_coef(beta, beta_se)
+  beta_significant <- is.finite(beta_p) && beta_p <= 0.05
+  add(
+    est, "MAIVE estimate", paste0(format_number(beta, rd), mark(beta_p)),
+    note = if (is.na(beta_p)) {
+      ""
+    } else if (beta_significant) {
+      "significant at 5%"
+    } else {
+      "not significant at 5%"
+    },
+    tone = if (is.na(beta_p)) "" else if (beta_significant) "good" else "bad"
+  )
+  add(est, "Std. error", format_se(beta_se, rd))
+  beta_ci <- maive_ci(beta, beta_se)
+  add(est, "95% CI", format_ci(beta_ci[[1L]], beta_ci[[2L]], rd))
+
+  ar <- ar_ci_verdict(maive_output$AR_CI, identical(as.integer(options$ar %||% 0L), 1L))
+  ar_value <- ar$value
+  if (is.na(ar_value)) {
+    ar_value <- format_ci(maive_output$AR_CI[[1L]], maive_output$AR_CI[[2L]], rd)
+  }
+  add(est, "Anderson-Rubin 95% CI", ar_value, note = ar$note, tone = ar$tone)
+
+  selected <- maive_output$petpeese_selected
+  if (!is.null(selected) && !is.na(selected)) {
+    add(est, "Model selected", selected, note = "chosen by the PET-PEESE rule")
+  }
+
+  beta_standard <- maive_output$beta_standard
+  if (is.numeric(beta_standard) && is.finite(beta_standard)) {
+    add(
+      est, "Unadjusted estimate", format_number(beta_standard, rd),
+      note = "same model without the IV correction"
+    )
+    if (is.numeric(maive_output$SE_standard) && is.finite(maive_output$SE_standard)) {
+      add(est, "Std. error", format_se(maive_output$SE_standard, rd))
+    }
+  }
+
+  # --- Publication bias and p-hacking ---
+  bias <- "Publication bias and p-hacking"
+  pub_p <- maive_output$`pub bias p-value`
+  pub_p <- if (is.numeric(pub_p) && is.finite(pub_p)) pub_p else NA_real_
+  bias_detected <- is.finite(pub_p) && pub_p <= 0.05
+  add(
+    bias, "Egger coefficient", paste0(format_number(maive_output$egger_coef, rd), mark(pub_p)),
+    note = if (is.na(pub_p)) {
+      ""
+    } else if (bias_detected) {
+      "bias detected at 5%"
+    } else {
+      "no bias detected at 5%"
+    },
+    tone = if (is.na(pub_p)) "" else if (bias_detected) "bad" else "good"
+  )
+  add(bias, "Std. error", format_se(maive_output$egger_se, rd))
+  add(bias, "p-value", format_number(pub_p, rd))
+
+  boot_ci <- maive_output$egger_boot_ci
+  if (is.numeric(boot_ci) && length(boot_ci) == 2L && all(is.finite(boot_ci))) {
+    excludes <- ci_excludes_zero(boot_ci)
+    add(
+      bias, "95% CI (bootstrap)", format_ci(boot_ci[[1L]], boot_ci[[2L]], rd),
+      note = if (isTRUE(excludes)) "excludes 0" else "includes 0",
+      tone = if (isTRUE(excludes)) "bad" else "good"
+    )
+  }
+
+  egger_ar <- maive_output$egger_ar_ci
+  if (is.numeric(egger_ar) && length(egger_ar) == 2L && all(is.finite(egger_ar))) {
+    add(
+      bias, "Anderson-Rubin 95% CI", format_ci(egger_ar[[1L]], egger_ar[[2L]], rd),
+      note = "weak-instrument robust"
+    )
+  }
+
+  peese_coef <- maive_output$peese_se2_coef
+  if (is.numeric(peese_coef) && is.finite(peese_coef)) {
+    add(bias, "Coefficient on SE^2", format_number(peese_coef, rd))
+    peese_se <- maive_output$peese_se2_se
+    if (is.numeric(peese_se) && is.finite(peese_se)) {
+      add(bias, "Std. error", format_se(peese_se, rd))
+    }
+  }
+
+  # --- Diagnostics ---
+  if (instrumented) {
+    diag <- "Diagnostics"
+    f_stat <- maive_first_stage_f(maive_output)
+    strength <- instrument_strength(f_stat)
+    add(
+      diag, first_stage$f_label, format_number(f_stat, rd),
+      note = switch(strength,
+        strong = sprintf("strong instrument (>= %s)", WEAK_INSTRUMENT_F),
+        weak = sprintf("weak instrument (< %s)", WEAK_INSTRUMENT_F),
+        ""
+      ),
+      tone = switch(strength,
+        strong = "good",
+        weak = "bad",
+        ""
+      )
+    )
+
+    if (!fixed_intercept) {
+      rejects <- hausman_rejects(maive_output$Hausman, maive_output$Chi2)
+      add(
+        diag, "Hausman statistic", format_number(maive_output$Hausman, rd),
+        note = if (is.na(rejects)) {
+          "uninformative: IV and OLS variances too close"
+        } else if (rejects) {
+          "rejects OLS = IV at 5%"
+        } else {
+          "does not reject OLS = IV at 5%"
+        },
+        tone = if (is.na(rejects)) "" else if (rejects) "good" else "bad"
+      )
+      add(diag, "Chi-sq. critical value (5%)", format_number(maive_output$Chi2, rd))
+    }
+  }
+
+  summary <- data.frame(
+    Section = vapply(rows, `[[`, "", "section"),
+    Statistic = vapply(rows, `[[`, "", "stat"),
+    Value = vapply(rows, `[[`, "", "value"),
+    Note = vapply(rows, `[[`, "", "note"),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  attr(summary, "tone") <- vapply(rows, `[[`, "", "tone")
+  summary
+}
+
+# Interpretation ------------------------------------------------------------
+
+#' @title Generate a plain-language reading of the MAIVE results
+#' @description
+#' Turns the numbers into the sentences a reader would otherwise have to derive:
+#' whether the corrected effect differs from zero, whether the funnel is
+#' asymmetric, and whether the instrument is strong enough to trust the point
+#' estimate over the Anderson-Rubin interval.
+#' @param maive_output *[list]* Output of [maive()].
+#' @param options *[list]* Resolved MAIVE options.
+#' @param resolved_first_stage *[list, optional]* The first stage actually used,
+#'   as returned by [resolve_maive_first_stage()].
+#' @return *[character]* Sentences, in reading order.
+build_maive_interpretation <- function(maive_output, options, resolved_first_stage = NULL) {
+  validate(is.list(maive_output), is.list(options))
+
+  resolved_first_stage <- resolved_first_stage %||%
+    resolve_maive_first_stage(options$first_stage %||% 0L, numeric(0))
+
+  rd <- min(options$round_to %||% 3L, 2L)
+  sentences <- character()
+  self_env <- environment()
+  say <- function(...) {
+    self_env$sentences <- c(self_env$sentences, paste0(...))
+  }
+
+  # --- Effect ---
+  beta <- maive_output$beta
+  beta_se <- maive_output$SE
+  beta_ci <- maive_ci(beta, beta_se)
+  beta_p <- maive_p_from_coef(beta, beta_se)
+  model_label <- maive_method_label(options$method %||% 3L)
+
+  if (is.finite(beta)) {
+    verdict <- if (is.na(beta_p)) {
+      "of undetermined significance"
+    } else if (beta_p <= 0.05) {
+      "statistically different from zero at the 5% level"
+    } else {
+      "not different from zero at the 5% level"
+    }
+    ci_text <- if (all(is.finite(beta_ci))) {
+      sprintf(" (95%% CI %s, %s)", format_number(beta_ci[[1L]], rd), format_number(beta_ci[[2L]], rd))
+    } else {
+      ""
+    }
+    say(sprintf(
+      "Using MAIVE (%s), the bias-corrected mean effect is %s%s, %s.",
+      model_label, format_number(beta, rd), ci_text, verdict
+    ))
+
+    beta_standard <- maive_output$beta_standard
+    if (is.numeric(beta_standard) && is.finite(beta_standard)) {
+      say(sprintf(
+        "The same model without the IV correction gives %s.",
+        format_number(beta_standard, rd)
+      ))
+    }
+  }
+
+  # --- Publication bias ---
+  egger_ci <- maive_output$egger_boot_ci
+  if (!(is.numeric(egger_ci) && length(egger_ci) == 2L && all(is.finite(egger_ci)))) {
+    egger_ci <- maive_ci(maive_output$egger_coef, maive_output$egger_se)
+  }
+  excludes <- ci_excludes_zero(egger_ci)
+  if (!is.na(excludes)) {
+    bias_kind <- if (identical(as.integer(options$instrument %||% 1L), 1L)) {
+      "publication bias or p-hacking"
+    } else {
+      "publication bias"
+    }
+    say(sprintf(
+      "We %s evidence of substantial %s (Egger 95%% CI %s 0).",
+      if (excludes) "find" else "do not find",
+      bias_kind,
+      if (excludes) "excludes" else "includes"
+    ))
+  }
+
+  # --- Diagnostics ---
+  if (!identical(as.integer(options$instrument %||% 1L), 1L)) {
+    return(sentences)
+  }
+
+  f_stat <- maive_first_stage_f(maive_output)
+  strength <- instrument_strength(f_stat)
+  if (!identical(strength, "unknown")) {
+    say(sprintf(
+      "The instrument is %s (%s = %s), so the Anderson-Rubin interval is %s.",
+      strength,
+      maive_first_stage_spec(resolved_first_stage$value)$f_phrase,
+      format_number(f_stat, rd),
+      if (identical(strength, "weak")) "the one to report" else "optional but recommended"
+    ))
+  }
+
+  if (!identical(as.integer(options$studylevel %||% 2L), 1L)) {
+    rejects <- hausman_rejects(maive_output$Hausman, maive_output$Chi2)
+    if (is.na(rejects)) {
+      say(
+        "The Hausman test is uninformative here because the IV and OLS variances are ",
+        "nearly identical."
+      )
+    } else {
+      say(sprintf(
+        "The Hausman test %s equality of OLS and IV, so evidence of spurious precision is %s.",
+        if (rejects) "rejects" else "does not reject",
+        if (rejects) "strong" else "moderate"
+      ))
+    }
+  }
+
+  if (is.finite(f_stat) && f_stat < LOG_FIRST_STAGE_F &&
+    !identical(as.integer(resolved_first_stage$value), 1L)) {
+    say(sprintf(
+      "Because the first-stage F is below %s, running the first stage in logs (first_stage = 1) is recommended.",
+      LOG_FIRST_STAGE_F
+    ))
+  }
+
+  sentences
+}
+
+# Orchestration -------------------------------------------------------------
+
+#' @title Run the MAIVE estimator and format its output
+#' @description
+#' Runs MAIVE, then builds the summary table and interpretation. Failures are
+#' recorded as a skip reason rather than aborting, matching how the other
+#' publication-bias methods degrade.
+#' @param df *[data.frame]* Input data with effect, se, n_obs, and optionally
+#'   study_id.
+#' @param options *[list]* Resolved MAIVE options.
+#' @return *[list]* With `summary`, `interpretation`, `first_stage`, `raw`, and
+#'   `skipped`.
+run_maive <- function(df, options) {
+  validate(is.data.frame(df), is.list(options))
+
+  if (!"n_obs" %in% colnames(df)) {
+    return(list(
+      summary = NULL, interpretation = character(), first_stage = NULL, raw = NULL,
+      skipped = "requires the 'n_obs' column, which is absent from the data"
+    ))
+  }
+
+  maive_data <- prepare_maive_data(df)
+  first_stage <- resolve_maive_first_stage(options$first_stage %||% 0L, maive_data$Ns)
+
+  if (identical(as.integer(options$se %||% 1L), 3L)) {
+    cli::cli_alert_info("Running MAIVE with wild cluster bootstrap (this may take a moment)...")
+  }
+
+  self_env <- environment()
+  failure_reason <- NULL
+  raw <- tryCatch(
+    maive(
+      dat = maive_data,
+      method = options$method,
+      weight = options$weight,
+      instrument = options$instrument,
+      studylevel = options$studylevel,
+      SE = options$se,
+      AR = options$ar,
+      first_stage = first_stage$value,
+      seed = options$seed
+    ),
+    # conditionMessage(), not e$message: the latter keeps only the cli header,
+    # dropping the bullets that carry the install and upgrade hints the user
+    # needs to act on the skip.
+    error = function(e) {
+      self_env$failure_reason <- conditionMessage(e)
+      NULL
+    }
+  )
+
+  if (!is.null(failure_reason)) {
+    return(list(
+      summary = NULL, interpretation = character(), first_stage = first_stage, raw = NULL,
+      skipped = failure_reason
+    ))
+  }
+
+  data_info <- list(
+    n_obs = nrow(df),
+    n_studies = if ("study_id" %in% colnames(df)) length(unique(df$study_id)) else NULL
+  )
+
+  tryCatch(
+    list(
+      summary = build_maive_summary(raw, options, data_info, first_stage),
+      interpretation = build_maive_interpretation(raw, options, first_stage),
+      first_stage = first_stage,
+      raw = raw,
+      skipped = NULL
+    ),
+    error = function(e) {
+      list(
+        summary = NULL, interpretation = character(), first_stage = first_stage, raw = raw,
+        skipped = paste("MAIVE result formatting failed:", conditionMessage(e))
+      )
+    }
+  )
+}
+
+box::export(
+  ar_ci_verdict,
+  build_maive_interpretation,
+  build_maive_summary,
+  ci_excludes_zero,
+  hausman_rejects,
+  instrument_strength,
+  maive_ci,
+  maive_first_stage_f,
+  maive_first_stage_is_weak,
+  maive_first_stage_spec,
+  maive_instrument_label,
+  maive_method_label,
+  maive_p_from_coef,
+  maive_se_label,
+  maive_studylevel_label,
+  maive_weight_label,
+  prepare_maive_data,
+  resolve_maive_first_stage,
+  run_maive
+)

--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -1,8 +1,8 @@
 #' @title P-hacking test helpers
 #' @description
 #' Helper functions for comprehensive p-hacking detection tests.
-#' Includes Caliper tests (Gerber & Malhotra, 2008), Elliott tests (2022),
-#' and MAIVE estimator (Irsova et al., 2023).
+#' Includes Caliper tests (Gerber & Malhotra, 2008) and Elliott tests (2022).
+#' The MAIVE estimator lives in its own module (`artma/econometric/maive`).
 NULL
 
 box::use(
@@ -22,9 +22,7 @@ box::use(
     cox_shi_test,
     skipped_result
   ],
-  artma / calc / methods / elliott_cache[simulate_cdfs_cached],
-  artma / calc / methods / maive[maive],
-  artma / libs / core / utils[get_verbosity]
+  artma / calc / methods / elliott_cache[simulate_cdfs_cached]
 )
 
 #' @title Extract the skip reason attached to a `skipped_result()` value
@@ -407,210 +405,6 @@ caliper_direction_label <- function(direction) {
   )
 }
 
-# MAIVE utilities ----------------------------------------------------------
-
-# Stock-Yogo rule of thumb: a first-stage F below this leaves the instrumented
-# SE too noisy to identify the MAIVE intercept.
-MAIVE_WEAK_F_THRESHOLD <- 10
-
-# maive_first_stage = 2 asks artma to pick the functional form. The levels first
-# stage regresses SE^2 on 1/N; once sample sizes span this many orders of
-# magnitude, 1/N is numerically indistinguishable from zero for most of the
-# sample and the regression is identified off the few smallest studies alone.
-MAIVE_AUTO_FIRST_STAGE <- 2L
-MAIVE_AUTO_ORDERS_THRESHOLD <- 3
-
-#' @title Prepare data for MAIVE
-#' @param df *[data.frame]* Input data with effect, se, n_obs, study_id.
-#' @return *[data.frame]* Data formatted for MAIVE (bs, sebs, Ns, studyid).
-prepare_maive_data <- function(df) {
-  validate(is.data.frame(df))
-
-  required_cols <- c("effect", "se", "n_obs")
-  validate(all(required_cols %in% colnames(df)))
-
-  maive_data <- data.frame(
-    bs = df$effect,
-    sebs = df$se,
-    Ns = df$n_obs,
-    stringsAsFactors = FALSE
-  )
-
-  if ("study_id" %in% colnames(df)) {
-    maive_data$studyid <- df$study_id
-  }
-
-  maive_data
-}
-
-#' @title Format MAIVE results
-#' @param maive_output *[list]* Output from maive() function.
-#' @param options *[list]* Options.
-#' @param first_stage *[list, optional]* The resolved first stage, as returned
-#'   by `resolve_maive_first_stage()`. When supplied, the functional form used
-#'   is recorded in the table so the exported result documents its own
-#'   specification.
-#' @return *[data.frame]* Formatted MAIVE summary.
-format_maive_results <- function(maive_output, options, first_stage = NULL) {
-  if (is.null(maive_output)) {
-    return(data.frame(
-      Statistic = "Error",
-      Value = "MAIVE estimation failed",
-      stringsAsFactors = FALSE
-    ))
-  }
-
-  rd <- options$round_to
-  rows <- list()
-  self_env <- environment()
-  add <- function(stat, val) {
-    self_env$rows[[length(self_env$rows) + 1L]] <- list(stat = stat, val = val)
-  }
-  sep <- function() add("", "")
-
-  # --- Estimates ---
-  beta_p <- maive_p_from_coef(maive_output$beta, maive_output$SE)
-  add("MAIVE coefficient", paste0(format_number(maive_output$beta, rd), significance_mark(beta_p)))
-  add("  Std. error", format_se(maive_output$SE, rd))
-
-  selected <- maive_output$petpeese_selected
-  if (!is.null(selected) && !is.na(selected)) {
-    add("Model selected", selected)
-  }
-
-  # --- Publication bias ---
-  sep()
-  pub_p <- maive_output$`pub bias p-value`
-  if (is.numeric(pub_p) && is.finite(pub_p)) {
-    add("Pub. bias p-value", paste0(format_number(pub_p, rd), significance_mark(pub_p)))
-  } else {
-    add("Pub. bias p-value", "NA")
-  }
-
-  add("Egger coefficient", format_number(maive_output$egger_coef, rd))
-  add("  Std. error", format_se(maive_output$egger_se, rd))
-
-  boot_ci <- maive_output$egger_boot_ci
-  if (is.numeric(boot_ci) && length(boot_ci) == 2L && all(is.finite(boot_ci))) {
-    add("  95% CI (bootstrap)", format_ci(boot_ci[1L], boot_ci[2L], rd))
-  }
-
-  # PEESE SE^2 details (only when PEESE is the selected model)
-  peese_coef <- maive_output$peese_se2_coef
-  if (is.numeric(peese_coef) && is.finite(peese_coef)) {
-    add("PEESE SE^2 coefficient", format_number(peese_coef, rd))
-    peese_se <- maive_output$peese_se2_se
-    if (is.numeric(peese_se) && is.finite(peese_se)) {
-      add("  Std. error", format_se(peese_se, rd))
-    }
-  }
-
-  # --- Diagnostics ---
-  sep()
-  ftest <- maive_first_stage_f(maive_output)
-  ftest_val <- if (is.na(ftest)) "NA" else format_number(ftest, rd)
-  if (is.list(first_stage) && !is.null(first_stage$value)) {
-    form <- c("levels", "log")[first_stage$value + 1L]
-    add("1st stage form", if (isTRUE(first_stage$automatic)) paste(form, "(auto)") else form)
-  }
-
-  add("F-test (1st stage IV)", ftest_val)
-  if (maive_first_stage_is_weak(ftest)) {
-    add("  Instrument strength", sprintf("weak (F < %s)", MAIVE_WEAK_F_THRESHOLD))
-  }
-
-  add("Hausman test", format_number(maive_output$Hausman, rd))
-  add("  Chi-sq. crit. (alpha=0.05)", format_number(maive_output$Chi2, rd))
-
-  ar_ci <- maive_output$AR_CI
-  if (is.numeric(ar_ci) && length(ar_ci) == 2L && all(is.finite(ar_ci))) {
-    add("AR 95% CI", format_ci(ar_ci[1L], ar_ci[2L], rd))
-  }
-
-  # Build data frame
-  stats <- vapply(rows, `[[`, "", "stat")
-  vals <- vapply(rows, `[[`, "", "val")
-
-  data.frame(
-    Statistic = stats,
-    Value = vals,
-    stringsAsFactors = FALSE,
-    check.names = FALSE
-  )
-}
-
-#' @title Choose the MAIVE first-stage functional form
-#' @description
-#' Resolves `maive_first_stage`. Values 0 (levels) and 1 (log) pass straight
-#' through; 2 asks artma to decide.
-#'
-#' The decision reads the sample-size column and nothing else. It never looks
-#' at the effects, the standard errors, or any fitted statistic, so it cannot
-#' become a search over specifications for a preferred coefficient: `N` is the
-#' instrument and is taken as exogenous, which makes its own spread a
-#' legitimate basis for a functional-form choice, in the same way a skewed
-#' regressor justifies a log scale. Selecting instead on the first-stage F
-#' would be a different thing entirely, since MAIVE's premise is that the
-#' standard error is endogenous with respect to the effect.
-#' @param first_stage *[numeric]* The configured value: 0, 1, or 2.
-#' @param n_obs *[numeric]* Per-observation sample sizes (MAIVE's `Ns`).
-#' @return *[list]* `value` (0 or 1), `automatic` (was it resolved here), and
-#'   `orders` (orders of magnitude spanned by `n_obs`, `NA` when undecidable).
-resolve_maive_first_stage <- function(first_stage, n_obs) {
-  passthrough <- function(value) {
-    list(value = as.integer(value), automatic = FALSE, orders = NA_real_)
-  }
-
-  if (!isTRUE(as.integer(first_stage) == MAIVE_AUTO_FIRST_STAGE)) {
-    return(passthrough(first_stage))
-  }
-
-  usable <- n_obs[is.finite(n_obs) & n_obs > 0]
-  if (length(usable) < 2L) {
-    # Nothing to measure a spread over: keep MAIVE's own default.
-    return(list(value = 0L, automatic = TRUE, orders = NA_real_))
-  }
-
-  orders <- log10(max(usable) / min(usable))
-  list(
-    value = if (orders >= MAIVE_AUTO_ORDERS_THRESHOLD) 1L else 0L,
-    automatic = TRUE,
-    orders = orders
-  )
-}
-
-#' @title Extract the first-stage F statistic from MAIVE output
-#' @description MAIVE reports the statistic as the literal string "NA" when
-#'   instrumenting is switched off, so a plain `as.numeric()` is not enough.
-#' @param maive_output *[list]* Output from `maive()`.
-#' @return *[numeric]* The F statistic, or `NA_real_` when unavailable.
-maive_first_stage_f <- function(maive_output) {
-  raw <- maive_output$`F-test`
-  if (is.null(raw) || length(raw) != 1L || identical(raw, "NA")) {
-    return(NA_real_)
-  }
-  val <- suppressWarnings(as.numeric(raw))
-  if (!is.finite(val)) NA_real_ else val
-}
-
-#' @title Flag a weak MAIVE first stage
-#' @param ftest *[numeric]* First-stage F statistic.
-#' @return *[logical]* TRUE when the instrument is weak by the Stock-Yogo rule of thumb.
-maive_first_stage_is_weak <- function(ftest) {
-  is.numeric(ftest) && length(ftest) == 1L && is.finite(ftest) && ftest < MAIVE_WEAK_F_THRESHOLD
-}
-
-#' @title Compute two-sided p-value from coefficient and SE
-#' @param beta *[numeric]* Coefficient.
-#' @param se *[numeric]* Standard error.
-#' @return *[numeric]* P-value, or NA if inputs are not finite.
-maive_p_from_coef <- function(beta, se) {
-  if (!is.numeric(beta) || !is.numeric(se) || !is.finite(beta) || !is.finite(se) || se <= 0) {
-    return(NA_real_)
-  }
-  2 * stats::pnorm(-abs(beta / se))
-}
-
 # P-value utilities --------------------------------------------------------
 
 #' @title Compute p-values from effect and se
@@ -806,8 +600,8 @@ run_cox_shi <- function(pvalues, study_id = NULL, p_min, p_max, n_bins = 10L,
 #' @title Run suite of p-hacking tests
 #' @description
 #' Executes comprehensive p-hacking detection tests: Caliper (Gerber & Malhotra, 2008),
-#' Elliott et al. (2022), and MAIVE (Irsova et al., 2023).
-#' @param df *[data.frame]* Input data with effect, se, study_id, n_obs columns.
+#' Elliott et al. (2022).
+#' @param df *[data.frame]* Input data with effect, se, and study_id columns.
 #' @param options *[list]* Options containing test parameters.
 #' @return *[list]* Contains test results and formatted summaries.
 run_p_hacking_tests <- function(df, options) {
@@ -947,79 +741,6 @@ run_p_hacking_tests <- function(df, options) {
     output$elliott <- build_elliott_summary(elliott_tests, pvalues, options)
   }
 
-  # 3. MAIVE Estimator
-  if (options$include_maive) {
-    if ("n_obs" %in% colnames(df)) {
-      maive_data <- prepare_maive_data(df)
-
-      if (options$maive_se == 3L) {
-        cli::cli_alert_info("Running MAIVE with wild cluster bootstrap (this may take a moment)...")
-      }
-
-      first_stage <- resolve_maive_first_stage(options$maive_first_stage, maive_data$Ns)
-      if (first_stage$automatic && get_verbosity() >= 3) {
-        cli::cli_alert_info(c(
-          "MAIVE first stage selected automatically: {c('levels', 'log')[first_stage$value + 1L]}",
-          if (is.na(first_stage$orders)) {
-            " (sample sizes carry no usable spread)."
-          } else {
-            " (sample sizes span {round(first_stage$orders, 1)} orders of magnitude, threshold {MAIVE_AUTO_ORDERS_THRESHOLD})."
-          }
-        ))
-      }
-
-      maive_results <- tryCatch(
-        {
-          maive(
-            dat = maive_data,
-            method = options$maive_method,
-            weight = options$maive_weight,
-            instrument = options$maive_instrument,
-            studylevel = options$maive_studylevel,
-            SE = options$maive_se,
-            AR = options$maive_ar,
-            first_stage = first_stage$value,
-            seed = options$maive_seed
-          )
-        },
-        error = function(e) {
-          # conditionMessage(), not e$message: the latter keeps only the cli
-          # header, dropping the bullets that carry the install and upgrade
-          # hints the user needs to act on the skip.
-          skipped[["maive"]] <<- conditionMessage(e)
-          NULL
-        }
-      )
-      if (!is.null(maive_results) && get_verbosity() >= 2) {
-        maive_f <- maive_first_stage_f(maive_results)
-        if (maive_first_stage_is_weak(maive_f)) {
-          cli::cli_alert_warning(c(
-            "MAIVE first-stage F is {round(maive_f, 3)}, below {MAIVE_WEAK_F_THRESHOLD}: ",
-            "the sample-size instrument is weak and the MAIVE estimate is unreliable."
-          ))
-          cli::cli_alert_info(
-            "Try {.code maive_first_stage: 1} (log first stage), which fits data whose sample sizes span orders of magnitude."
-          )
-        }
-      }
-
-      output$maive <- if (is.null(maive_results)) {
-        NULL
-      } else {
-        tryCatch(
-          format_maive_results(maive_results, options, first_stage),
-          error = function(e) {
-            skipped[["maive"]] <<- paste("MAIVE result formatting failed:", e$message)
-            NULL
-          }
-        )
-      }
-    } else {
-      skipped[["maive"]] <- "requires the 'n_obs' column, which is absent from the data"
-      output$maive <- NULL
-    }
-  }
-
   output$n_pvalues <- length(pvalues)
   output$n_significant_005 <- sum(pvalues <= 0.05, na.rm = TRUE)
   output$n_significant_010 <- sum(pvalues <= 0.10, na.rm = TRUE)
@@ -1077,12 +798,6 @@ box::export(
   build_caliper_summary,
   compute_pvalues,
   resolve_t_stats,
-  prepare_maive_data,
-  maive_p_from_coef,
-  maive_first_stage_f,
-  maive_first_stage_is_weak,
-  resolve_maive_first_stage,
-  format_maive_results,
   run_binomial,
   run_lcm,
   run_discontinuity,

--- a/inst/artma/libs/formatting/results.R
+++ b/inst/artma/libs/formatting/results.R
@@ -104,6 +104,125 @@ print_summary_table <- function(summary) {
     print(summary, row.names = !duplicated_metric) # nolint: undesirable_function_linter.
   )
   cli::cli_verbatim(lines)
+  invisible(lines)
+}
+
+#' Pick the cli style function for a verdict tone
+#'
+#' @param tone *\[character\]* One of `"good"`, `"bad"`, or anything else for
+#'   unstyled output.
+#' @return *\[function\]* A string-to-string styling function.
+#' @keywords internal
+tone_style <- function(tone) {
+  switch(tone %||% "",
+    good = cli::col_green,
+    bad = cli::col_red,
+    identity
+  )
+}
+
+#' Print a sectioned key/value summary table through cli
+#'
+#' @description
+#' Renders a tidy `Section` / `Statistic` / `Value` (/ `Note`) frame as
+#' left-aligned key/value rows under underlined section headings. Unlike
+#' `print.data.frame`, which right-aligns character columns and so destroys any
+#' label hierarchy, this keeps labels flush left and right-aligns only the value
+#' column, so numbers line up and sub-rows stay readable.
+#'
+#' Verdict notes are colourised from a `tone` attribute on the frame (a
+#' character vector, one entry per row, of `"good"`, `"bad"`, or `""`). The
+#' attribute is deliberately not a column, so the exported CSV stays free of
+#' presentation-only data.
+#'
+#' Falls back to [print_summary_table()] when the expected columns are absent.
+#'
+#' @param summary *\[data.frame\]* The summary table to print.
+#' @param section_col *\[character\]* Name of the section column.
+#' @param label_col *\[character\]* Name of the label column.
+#' @param value_col *\[character\]* Name of the value column.
+#' @param note_col *\[character\]* Name of the (optional) verdict column.
+#' @param indent *\[character\]* Prefix placed before every non-heading row.
+#' @keywords internal
+print_sectioned_table <- function(summary,
+                                  section_col = "Section",
+                                  label_col = "Statistic",
+                                  value_col = "Value",
+                                  note_col = "Note",
+                                  indent = "  ") {
+  if (!is.data.frame(summary) || nrow(summary) == 0L) {
+    return(invisible(character()))
+  }
+  if (!all(c(section_col, label_col, value_col) %in% names(summary))) {
+    return(print_summary_table(summary))
+  }
+
+  as_chr <- function(x, empty = "") {
+    out <- as.character(x)
+    out[is.na(out)] <- empty
+    out
+  }
+
+  sections <- as_chr(summary[[section_col]])
+  labels <- as_chr(summary[[label_col]])
+  values <- as_chr(summary[[value_col]], empty = "NA")
+  notes <- if (note_col %in% names(summary)) as_chr(summary[[note_col]]) else rep("", nrow(summary))
+
+  tones <- attr(summary, "tone")
+  if (length(tones) != nrow(summary)) {
+    tones <- rep("", nrow(summary))
+  }
+  tones <- as_chr(tones)
+
+  label_width <- max(nchar(labels))
+  value_width <- max(nchar(values))
+
+  lines <- character()
+  current_section <- NULL
+  for (i in seq_along(labels)) {
+    if (!identical(sections[[i]], current_section)) {
+      current_section <- sections[[i]]
+      if (nzchar(current_section)) {
+        if (length(lines) > 0L) {
+          lines <- c(lines, "")
+        }
+        lines <- c(lines, current_section, strrep("-", nchar(current_section)))
+      }
+    }
+
+    line <- sprintf("%s%-*s  %*s", indent, label_width, labels[[i]], value_width, values[[i]])
+    if (nzchar(notes[[i]])) {
+      line <- paste0(line, "   ", tone_style(tones[[i]])(notes[[i]]))
+    }
+    lines <- c(lines, line)
+  }
+
+  # cli_verbatim() silently drops empty strings, so the blank line separating
+  # two sections has to go out through cli_text().
+  for (line in lines) {
+    if (nzchar(line)) cli::cli_verbatim(line) else cli::cli_text("")
+  }
+
+  invisible(lines)
+}
+
+#' Print a wrapped paragraph of generated prose through cli
+#'
+#' @description
+#' Wraps and prints sentences via `cli_verbatim` (so cached runs replay the
+#' output verbatim, which `cli_text`'s glue interpolation would not survive).
+#'
+#' @param sentences *\[character\]* Sentences to join into one paragraph.
+#' @param width *\[integer\]* Wrap width.
+#' @keywords internal
+print_paragraph <- function(sentences, width = 88L) {
+  sentences <- sentences[nzchar(sentences)]
+  if (length(sentences) == 0L) {
+    return(invisible(character()))
+  }
+  lines <- strwrap(paste(sentences, collapse = " "), width = width)
+  cli::cli_verbatim(lines)
+  invisible(lines)
 }
 
 box::export(
@@ -111,5 +230,8 @@ box::export(
   format_number,
   format_se,
   format_ci,
-  print_summary_table
+  print_summary_table,
+  print_sectioned_table,
+  print_paragraph,
+  tone_style
 )

--- a/inst/artma/methods/maive.R
+++ b/inst/artma/methods/maive.R
@@ -1,0 +1,137 @@
+#' @title MAIVE estimator
+#' @description
+#' Meta-Analysis Instrumental Variable Estimator (Irsova et al., Nature
+#' Communications, 2025). MAIVE corrects the mean effect for publication bias,
+#' p-hacking, and spurious precision by instrumenting reported variances with
+#' the inverse sample size, then plugging the fitted variances into a funnel
+#' model (PET, PEESE, PET-PEESE, or the endogenous kink).
+maive_estimator <- function(df) {
+  box::use(
+    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / formatting / results[print_sectioned_table, print_paragraph],
+    artma / econometric / maive[maive_first_stage_f, maive_first_stage_is_weak, run_maive],
+    artma / modules / runtime_methods[new_method_result],
+    artma / options / index[get_option_group],
+    artma / options / significance_marks[resolve_add_significance_marks]
+  )
+
+  validate(is.data.frame(df))
+  validate_columns(df, c("effect", "se", "n_obs"))
+
+  opt <- get_option_group("artma.methods.maive")
+
+  method <- opt$method %||% 3L
+  weight <- opt$weight %||% 0L
+  instrument <- opt$instrument %||% 1L
+  studylevel <- opt$studylevel %||% 2L
+  se <- opt$se %||% 1L
+  ar <- opt$ar %||% 0L
+  first_stage <- opt$first_stage %||% 0L
+  seed <- opt$seed %||% 123L
+  show_interpretation <- opt$show_interpretation %||% TRUE
+
+  add_significance_marks <- resolve_add_significance_marks()
+  round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
+
+  validate(
+    is.numeric(method),
+    is.numeric(weight),
+    is.numeric(instrument),
+    is.numeric(studylevel),
+    is.numeric(se),
+    is.numeric(ar),
+    is.numeric(first_stage),
+    is.numeric(seed),
+    is.logical(show_interpretation),
+    is.logical(add_significance_marks),
+    is.numeric(round_to)
+  )
+
+  assert(method %in% c(1, 2, 3, 4), "maive method must be 1, 2, 3, or 4")
+  assert(weight %in% c(0, 1, 2), "maive weight must be 0, 1, or 2")
+  assert(instrument %in% c(0, 1), "maive instrument must be 0 or 1")
+  assert(studylevel %in% c(0, 1, 2), "maive studylevel must be 0, 1, or 2")
+  assert(se %in% c(1, 2, 3, 4, 5), "maive se must be 1, 2, 3, 4, or 5")
+  assert(ar %in% c(0, 1), "maive ar must be 0 or 1")
+  assert(first_stage %in% c(0, 1, 2), "maive first_stage must be 0, 1, or 2")
+  assert(round_to >= 0, "Number of decimals must be non-negative")
+
+  resolved_options <- list(
+    method = as.integer(method),
+    weight = as.integer(weight),
+    instrument = as.integer(instrument),
+    studylevel = as.integer(studylevel),
+    se = as.integer(se),
+    ar = as.integer(ar),
+    first_stage = as.integer(first_stage),
+    seed = as.integer(seed),
+    add_significance_marks = add_significance_marks,
+    round_to = round_to
+  )
+
+  result <- run_maive(df, resolved_options)
+
+  if (get_verbosity() >= 1) {
+    cli::cli_h2("MAIVE estimator")
+
+    if (is.null(result$summary)) {
+      cli::cli_alert_warning("MAIVE was skipped: {result$skipped}")
+    } else {
+      print_sectioned_table(result$summary)
+
+      # The weak-instrument note in the table is easy to skim past, and it is
+      # the one diagnostic that invalidates the headline number, so it also
+      # gets an alert one verbosity level below the interpretation paragraph.
+      maive_f <- maive_first_stage_f(result$raw)
+      if (get_verbosity() >= 2 && instrument == 1 && maive_first_stage_is_weak(maive_f)) {
+        cli::cli_text("")
+        cli::cli_alert_warning(c(
+          "First-stage F is {round(maive_f, 3)}, below 10: the sample-size instrument ",
+          "is weak and the MAIVE estimate is unreliable."
+        ))
+        if (!identical(result$first_stage$value, 1L)) {
+          cli::cli_alert_info(
+            "Try {.code first_stage: 1} (log first stage), which fits data whose sample sizes span orders of magnitude."
+          )
+        }
+      }
+
+      if (isTRUE(show_interpretation) && length(result$interpretation) > 0 && get_verbosity() >= 3) {
+        cli::cli_text("")
+        cli::cli_verbatim("Interpretation")
+        print_paragraph(result$interpretation)
+      }
+
+      cli::cli_text("")
+      if (add_significance_marks) {
+        cli::cli_text("Significance marks: * p <= 0.1, ** p <= 0.05, *** p <= 0.01")
+      }
+      cli::cli_text("Method: Irsova, Bom, Havranek & Rachinger, Nature Communications, 2025.")
+    }
+  }
+
+  invisible(new_method_result(
+    tables = list(summary = result$summary),
+    meta = list(
+      maive = result$raw,
+      interpretation = result$interpretation,
+      first_stage = result$first_stage,
+      options = resolved_options,
+      skipped = result$skipped
+    )
+  ))
+}
+
+box::use(
+  artma / modules / runtime_methods[register_runtime_method]
+)
+
+run <- register_runtime_method(
+  maive_estimator,
+  stage = "maive",
+  required_columns = c("effect", "se", "n_obs"),
+  suggests = "MAIVE"
+)
+
+box::export(maive_estimator, run)

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -4,7 +4,9 @@
 #' p-hacking and selective reporting. Tests include:
 #' - Caliper tests (Gerber & Malhotra, 2008)
 #' - Elliott et al. (2022) tests (Binomial, LCM, Fisher, Discontinuity, Cox-Shi)
-#' - MAIVE estimator (Irsova et al., 2023)
+#'
+#' The MAIVE estimator has its own method (`maive`); it is an estimator rather
+#' than a test, and its diagnostics do not read as p-hacking p-values.
 p_hacking_tests <- function(df) {
   box::use(
     artma / libs / core / validation[assert, validate, validate_columns],
@@ -47,17 +49,6 @@ p_hacking_tests <- function(df) {
   cox_shi_order <- opt$cox_shi_order %||% 2L
   cox_shi_bounds <- opt$cox_shi_bounds %||% 1L
 
-  # MAIVE options
-  include_maive <- opt$include_maive %||% TRUE
-  maive_method <- opt$maive_method %||% 3L
-  maive_weight <- opt$maive_weight %||% 0L
-  maive_instrument <- opt$maive_instrument %||% 1L
-  maive_studylevel <- opt$maive_studylevel %||% 2L
-  maive_se <- opt$maive_se %||% 1L
-  maive_ar <- opt$maive_ar %||% 0L
-  maive_first_stage <- opt$maive_first_stage %||% 0L
-  maive_seed <- opt$maive_seed %||% 123L
-
   # General options
   add_significance_marks <- resolve_add_significance_marks()
   round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
@@ -80,15 +71,6 @@ p_hacking_tests <- function(df) {
     is.numeric(cox_shi_bins),
     is.numeric(cox_shi_order),
     is.numeric(cox_shi_bounds),
-    is.logical(include_maive),
-    is.numeric(maive_method),
-    is.numeric(maive_weight),
-    is.numeric(maive_instrument),
-    is.numeric(maive_studylevel),
-    is.numeric(maive_se),
-    is.numeric(maive_ar),
-    is.numeric(maive_first_stage),
-    is.numeric(maive_seed),
     is.logical(add_significance_marks),
     is.numeric(round_to)
   )
@@ -109,13 +91,6 @@ p_hacking_tests <- function(df) {
   assert(cox_shi_bins > 0, "cox_shi_bins must be positive")
   assert(cox_shi_order >= 0, "cox_shi_order must be non-negative")
   assert(cox_shi_bounds %in% c(0, 1), "cox_shi_bounds must be 0 or 1")
-  assert(maive_method %in% c(1, 2, 3, 4), "maive_method must be 1, 2, 3, or 4")
-  assert(maive_weight %in% c(0, 1, 2), "maive_weight must be 0, 1, or 2")
-  assert(maive_instrument %in% c(0, 1), "maive_instrument must be 0 or 1")
-  assert(maive_studylevel %in% c(0, 1, 2), "maive_studylevel must be 0, 1, or 2")
-  assert(maive_se %in% c(1, 2, 3, 4, 5), "maive_se must be 1, 2, 3, 4, or 5")
-  assert(maive_ar %in% c(0, 1), "maive_ar must be 0 or 1")
-  assert(maive_first_stage %in% c(0, 1, 2), "maive_first_stage must be 0, 1, or 2")
   assert(round_to >= 0, "Number of decimals must be non-negative")
 
   resolved_options <- list(
@@ -136,15 +111,6 @@ p_hacking_tests <- function(df) {
     cox_shi_bins = as.integer(cox_shi_bins),
     cox_shi_order = as.integer(cox_shi_order),
     cox_shi_bounds = as.integer(cox_shi_bounds),
-    include_maive = include_maive,
-    maive_method = as.integer(maive_method),
-    maive_weight = as.integer(maive_weight),
-    maive_instrument = as.integer(maive_instrument),
-    maive_studylevel = as.integer(maive_studylevel),
-    maive_se = as.integer(maive_se),
-    maive_ar = as.integer(maive_ar),
-    maive_first_stage = as.integer(maive_first_stage),
-    maive_seed = as.integer(maive_seed),
     add_significance_marks = add_significance_marks,
     round_to = round_to
   )
@@ -196,19 +162,8 @@ p_hacking_tests <- function(df) {
       cli::cli_text("")
     }
 
-    # MAIVE estimator (Irsova et al., 2023)
-    if (!is.null(results$maive) && nrow(results$maive) > 0) {
-      cli::cli_h3("MAIVE estimator (Irsova et al., 2023)")
-
-      maive_lines <- utils::capture.output(
-        print(results$maive, row.names = FALSE) # nolint: undesirable_function_linter.
-      )
-      cli::cli_verbatim(maive_lines)
-      cli::cli_text("")
-    }
-
     # Overall note
-    if (!is.null(results$caliper) || !is.null(results$elliott) || !is.null(results$maive)) {
+    if (!is.null(results$caliper) || !is.null(results$elliott)) {
       cli::cli_text("Note: Low p-values indicate potential p-hacking or selective reporting.")
       cli::cli_text("Significance marks: * p <= 0.1, ** p <= 0.05, *** p <= 0.01")
     } else {
@@ -225,8 +180,7 @@ p_hacking_tests <- function(df) {
   invisible(new_method_result(
     tables = list(
       caliper = results$caliper,
-      elliott = results$elliott,
-      maive = results$maive
+      elliott = results$elliott
     ),
     meta = list(skipped = results$skipped)
   ))

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -782,99 +782,101 @@ methods:
         Whether to use theoretical bounds in Cox-Shi tests (1 = yes, 0 = no).
         Bounds account for the two-sided nature of t-tests.
 
-    include_maive:
-      type: "logical"
-      default: true
-      help: |
-        If `TRUE`, include MAIVE estimator (Irsova et al., 2023) for publication
-        bias correction using instrumental variables.
-
-    maive_method:
+  maive:
+    method:
       type: "integer"
       default: 3
       help: |
-        MAIVE method selection:
+        Funnel model plugged with the instrumented variances:
           1 = FAT-PET
           2 = PEESE
           3 = PET-PEESE (default)
           4 = Endogenous Kink (EK)
 
-    maive_weight:
+    weight:
       type: "integer"
       default: 0
       help: |
-        MAIVE weighting scheme:
+        Weighting scheme:
           0 = No weights (default)
           1 = Standard weights
           2 = Adjusted weights
 
-    maive_instrument:
+    instrument:
       type: "integer"
       default: 1
       help: |
-        MAIVE instrumenting:
-          0 = No instrumenting
+        Whether reported variances are instrumented with the inverse sample
+        size (the correction that makes MAIVE MAIVE):
+          0 = No instrumenting; the output reduces to the standard funnel model
           1 = Use instrumental variables (default)
 
-    maive_studylevel:
+    studylevel:
       type: "integer"
       default: 2
       help: |
-        MAIVE study-level correlation structure:
+        Study-level correlation structure:
           0 = None
           1 = Fixed effects
           2 = Cluster-robust (default)
 
-    maive_se:
+    se:
       type: "integer"
       default: 1
       help: |
-        MAIVE standard error estimation method:
+        Standard error estimation method:
           1 = Asymptotic (default)
           2 = Pairs cluster bootstrap
           3 = Wild bootstrap
           4 = Wild cluster bootstrap
           5 = Pairs bootstrap
 
-    maive_ar:
+    ar:
       type: "integer"
       default: 0
       help: |
-        MAIVE Anderson-Rubin confidence interval:
+        Anderson-Rubin confidence interval, which stays valid when the
+        first-stage instrument is weak:
           0 = Do not compute (default)
           1 = Compute
 
-    maive_first_stage:
+    first_stage:
       type: "integer"
       default: 0
       help: |
-        Functional form of the MAIVE first stage, which instruments the
-        squared standard error with sample size:
+        Functional form of the first stage, which instruments the squared
+        standard error with sample size:
           0 = levels, regress SE^2 on 1/N (default)
-          1 = log, regress log(SE^2) on log(N)
+          1 = log, regress log(SE^2) on log(N), with Duan smearing
           2 = automatic, choose from the spread of sample sizes
 
         Use the log form when sample sizes span orders of magnitude. With a
         wide N range, 1/N is numerically near zero for most observations, so
         the levels first stage is identified off the few smallest studies and
         collapses into a weak instrument (F below 10), which leaves the MAIVE
-        coefficient unreliable. Check the "F-test (1st stage IV)" row of the
-        MAIVE output: if it is flagged as weak, switch to 1.
+        coefficient unreliable. Check the "First-stage F" row of the MAIVE
+        output: if it is flagged as weak, switch to 1.
 
         Setting 2 makes that call for you: the log form is used when sample
         sizes span at least 3 orders of magnitude. The rule reads the sample
         size column only, never the effects, the standard errors, or any
         fitted statistic, so it cannot turn into a search for a preferred
-        coefficient. The form actually used is reported in the "1st stage
-        form" row and announced during the run.
+        coefficient. The form actually used is reported in the "First-stage
+        specification" row.
 
-    maive_seed:
+    seed:
       type: "integer"
       default: 123
       help: |
-        RNG seed passed to MAIVE's bootstrap standard error modes
-        (maive_se = 2..5), so repeated runs on the same data reproduce
-        identical results.
+        RNG seed passed to the bootstrap standard error modes (se = 2..5), so
+        repeated runs on the same data reproduce identical results.
+
+    show_interpretation:
+      type: "logical"
+      default: true
+      help: |
+        If `TRUE`, print a short plain-language reading of the results below
+        the tables (shown at verbosity 3 and above).
 
 data:
   source_path:

--- a/tests/testthat/test-econometric-maive.R
+++ b/tests/testthat/test-econometric-maive.R
@@ -1,0 +1,481 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_match,
+    expect_no_match,
+    expect_true,
+    skip_if_not_installed,
+    test_that
+  ],
+  withr[local_options],
+  artma / econometric / maive[
+    ar_ci_verdict,
+    build_maive_interpretation,
+    build_maive_summary,
+    ci_excludes_zero,
+    hausman_rejects,
+    instrument_strength,
+    maive_ci,
+    maive_first_stage_f,
+    maive_first_stage_is_weak,
+    maive_first_stage_spec,
+    maive_method_label,
+    maive_p_from_coef,
+    prepare_maive_data,
+    resolve_maive_first_stage,
+    run_maive
+  ]
+)
+
+base_maive_options <- function(...) {
+  defaults <- list(
+    method = 3L,
+    weight = 0L,
+    instrument = 1L,
+    studylevel = 2L,
+    se = 1L,
+    ar = 0L,
+    first_stage = 0L,
+    seed = 123L,
+    add_significance_marks = TRUE,
+    round_to = 3L
+  )
+  utils::modifyList(defaults, list(...))
+}
+
+make_maive_output <- function(...) {
+  defaults <- list(
+    beta = 0.2,
+    SE = 0.05,
+    `F-test` = 24,
+    beta_standard = 0.31,
+    SE_standard = 0.03,
+    Hausman = 6.2,
+    Chi2 = 3.841,
+    AR_CI = c(0.05, 0.35),
+    `pub bias p-value` = 0.004,
+    egger_coef = 1.8,
+    egger_se = 0.5,
+    egger_boot_ci = c(0.8, 2.8),
+    petpeese_selected = "PEESE",
+    peese_se2_coef = -2.3,
+    peese_se2_se = 0.9
+  )
+  utils::modifyList(defaults, list(...))
+}
+
+make_maive_df <- function(seed = 9, n = 40) {
+  set.seed(seed)
+  # Standard errors track 1/sqrt(N) so the first stage has something to find;
+  # drawing them independently yields a very weak instrument and a MAIVE warning.
+  n_obs <- sample(50:400, n, replace = TRUE)
+  data.frame(
+    effect = rnorm(n, 0.3, 0.1),
+    se = 3 / sqrt(n_obs) + abs(rnorm(n, 0, 0.01)),
+    n_obs = n_obs,
+    study_id = rep(seq_len(8), length.out = n)
+  )
+}
+
+# maive_p_from_coef ---------------------------------------------------------
+
+test_that("maive_p_from_coef matches the two-sided normal p-value", {
+  expect_equal(maive_p_from_coef(1.96, 1), 0.0499957902964409, tolerance = 1e-12)
+  expect_equal(maive_p_from_coef(0, 2), 1, tolerance = 1e-12)
+})
+
+test_that("maive_p_from_coef returns NA for degenerate inputs", {
+  expect_true(is.na(maive_p_from_coef(1, 0)))
+  expect_true(is.na(maive_p_from_coef(1, -1)))
+  expect_true(is.na(maive_p_from_coef(Inf, 1)))
+  expect_true(is.na(maive_p_from_coef(1, NA_real_)))
+})
+
+# maive_ci ------------------------------------------------------------------
+
+test_that("maive_ci returns the normal-approximation interval", {
+  expect_equal(maive_ci(0, 1), c(-1.95996398454005, 1.95996398454005), tolerance = 1e-10)
+})
+
+test_that("maive_ci returns NAs for degenerate inputs", {
+  expect_true(all(is.na(maive_ci(1, 0))))
+  expect_true(all(is.na(maive_ci(NA_real_, 1))))
+})
+
+# prepare_maive_data --------------------------------------------------------
+
+test_that("prepare_maive_data renames columns to the MAIVE contract", {
+  df <- data.frame(
+    effect = c(0.1, 0.2, 0.3),
+    se = c(0.05, 0.06, 0.07),
+    n_obs = c(100, 200, 300),
+    study_id = c(1, 1, 2)
+  )
+
+  out <- prepare_maive_data(df)
+
+  expect_equal(colnames(out), c("bs", "sebs", "Ns", "studyid"))
+  expect_equal(out$bs, df$effect)
+  expect_equal(out$sebs, df$se)
+  expect_equal(out$Ns, df$n_obs)
+  expect_equal(out$studyid, df$study_id)
+})
+
+test_that("prepare_maive_data omits studyid when study_id is absent", {
+  df <- data.frame(effect = 1, se = 0.1, n_obs = 10)
+  expect_equal(colnames(prepare_maive_data(df)), c("bs", "sebs", "Ns"))
+})
+
+test_that("prepare_maive_data errors when required columns are missing", {
+  expect_error(prepare_maive_data(data.frame(effect = 1, se = 0.1)))
+})
+
+# Verdicts ------------------------------------------------------------------
+
+test_that("instrument_strength splits at the conventional F of 10", {
+  expect_equal(instrument_strength(10), "strong")
+  expect_equal(instrument_strength(9.99), "weak")
+  expect_equal(instrument_strength(NA_real_), "unknown")
+  expect_equal(instrument_strength("NA"), "unknown")
+})
+
+test_that("hausman_rejects compares the statistic against its critical value", {
+  expect_true(hausman_rejects(6.2, 3.841))
+  expect_false(hausman_rejects(1.1, 3.841))
+  expect_true(is.na(hausman_rejects(NaN, 3.841)))
+  expect_true(is.na(hausman_rejects(6.2, NULL)))
+})
+
+test_that("ci_excludes_zero recognises intervals on either side of zero", {
+  expect_true(ci_excludes_zero(c(0.1, 0.4)))
+  expect_true(ci_excludes_zero(c(-0.4, -0.1)))
+  expect_false(ci_excludes_zero(c(-0.1, 0.4)))
+  expect_true(is.na(ci_excludes_zero(c(NA, 0.4))))
+})
+
+test_that("ar_ci_verdict distinguishes disabled, unusable, and very wide intervals", {
+  expect_equal(ar_ci_verdict(c(0, 1), computed = FALSE)$value, "not computed")
+  expect_equal(ar_ci_verdict("NA", computed = TRUE)$tone, "bad")
+  expect_match(ar_ci_verdict(c(-200, 200), computed = TRUE)$note, "weak identification")
+  expect_match(ar_ci_verdict(c(0, 1), computed = TRUE)$note, "weak-instrument robust")
+})
+
+test_that("maive_first_stage_spec names the regression that produced the F", {
+  expect_equal(maive_first_stage_spec(0L)$spec, "SE^2 ~ 1/N")
+  expect_match(maive_first_stage_spec(1L)$spec, "log N")
+  expect_match(maive_first_stage_spec(1L)$f_label, "gamma1")
+})
+
+# First stage --------------------------------------------------------------
+
+test_that("maive_first_stage_f reads MAIVE's literal \"NA\" as missing", {
+  expect_equal(maive_first_stage_f(list(`F-test` = 80.935)), 80.935)
+  expect_true(is.na(maive_first_stage_f(list(`F-test` = "NA"))))
+  expect_true(is.na(maive_first_stage_f(list())))
+  expect_true(is.na(maive_first_stage_f(list(`F-test` = c(1, 2)))))
+})
+
+test_that("maive_first_stage_is_weak applies the F < 10 rule of thumb", {
+  expect_true(maive_first_stage_is_weak(9.999))
+  expect_false(maive_first_stage_is_weak(10))
+  expect_false(maive_first_stage_is_weak(NA_real_))
+})
+
+test_that("resolve_maive_first_stage passes explicit choices through untouched", {
+  wide <- c(100, 10^9)
+
+  # A wide N spread would trigger the log form under 2, but 0 stays 0.
+  levels_choice <- resolve_maive_first_stage(0, wide)
+  expect_equal(levels_choice$value, 0L)
+  expect_false(levels_choice$automatic)
+
+  log_choice <- resolve_maive_first_stage(1, c(100, 200))
+  expect_equal(log_choice$value, 1L)
+  expect_false(log_choice$automatic)
+})
+
+test_that("resolve_maive_first_stage picks log once N spans the threshold", {
+  # The master-thesis case: 135 to 14.7M, about 5 orders of magnitude.
+  res <- resolve_maive_first_stage(2, c(135, 14746755))
+
+  expect_equal(res$value, 1L)
+  expect_true(res$automatic)
+  expect_equal(res$orders, 5.038, tolerance = 1e-3)
+})
+
+test_that("resolve_maive_first_stage keeps levels for a narrow N spread", {
+  res <- resolve_maive_first_stage(2, c(500, 900, 4000))
+
+  expect_equal(res$value, 0L)
+  expect_true(res$automatic)
+  expect_true(res$orders < 3)
+})
+
+test_that("resolve_maive_first_stage decides on the threshold boundary", {
+  # Exactly 3 orders of magnitude counts as wide.
+  expect_equal(resolve_maive_first_stage(2, c(10, 10000))$value, 1L)
+  # Just under does not.
+  expect_equal(resolve_maive_first_stage(2, c(10, 9999))$value, 0L)
+})
+
+test_that("resolve_maive_first_stage ignores unusable sample sizes", {
+  # Zero, negative, and non-finite N cannot enter a ratio.
+  res <- resolve_maive_first_stage(2, c(0, -5, NA, Inf, 100, 10^6))
+  expect_equal(res$value, 1L)
+  expect_equal(res$orders, 4)
+})
+
+test_that("resolve_maive_first_stage falls back to levels without a usable spread", {
+  for (degenerate in list(numeric(0), c(NA_real_, NA_real_), 1000, c(0, -1))) {
+    res <- resolve_maive_first_stage(2, degenerate)
+    expect_equal(res$value, 0L)
+    expect_true(res$automatic)
+    expect_true(is.na(res$orders))
+  }
+})
+
+test_that("resolve_maive_first_stage never reads anything but sample size", {
+  expect_equal(names(formals(resolve_maive_first_stage)), c("first_stage", "n_obs"))
+})
+
+test_that("maive_method_label falls back to the raw value for unknown codes", {
+  expect_equal(maive_method_label(3L), "PET-PEESE")
+  expect_equal(maive_method_label(99L), "99")
+})
+
+# build_maive_summary -------------------------------------------------------
+
+test_that("build_maive_summary returns a tidy sectioned frame with no blank rows", {
+  summary <- build_maive_summary(make_maive_output(), base_maive_options())
+
+  expect_equal(names(summary), c("Section", "Statistic", "Value", "Note"))
+  expect_false(any(!nzchar(summary$Section)))
+  expect_false(any(!nzchar(summary$Statistic)))
+  expect_equal(
+    unique(summary$Section),
+    c("Specification", "Corrected mean estimate", "Publication bias and p-hacking", "Diagnostics")
+  )
+  expect_equal(length(attr(summary, "tone")), nrow(summary))
+})
+
+test_that("build_maive_summary echoes the specification the run used", {
+  summary <- build_maive_summary(
+    make_maive_output(),
+    base_maive_options(method = 4L, first_stage = 1L, se = 4L)
+  )
+  spec <- summary[summary$Section == "Specification", ]
+
+  expect_equal(spec$Value[spec$Statistic == "Model"], "Endogenous kink (EK)")
+  expect_equal(spec$Value[spec$Statistic == "Standard errors"], "wild cluster bootstrap")
+  expect_match(spec$Value[spec$Statistic == "First-stage specification"], "log N")
+})
+
+test_that("build_maive_summary records an automatically chosen first stage", {
+  auto_log <- build_maive_summary(
+    make_maive_output(), base_maive_options(first_stage = 2L), list(),
+    list(value = 1L, automatic = TRUE, orders = 5.04)
+  )
+  spec_row <- auto_log[auto_log$Statistic == "First-stage specification", ]
+  expect_match(spec_row$Value, "log N")
+  expect_match(spec_row$Note, "chosen automatically \\(N spans 5\\.0 orders")
+
+  # The F label follows the form actually used, not the configured one.
+  expect_true("First-stage F (gamma1)" %in% auto_log$Statistic)
+
+  no_spread <- build_maive_summary(
+    make_maive_output(), base_maive_options(first_stage = 2L), list(),
+    list(value = 0L, automatic = TRUE, orders = NA_real_)
+  )
+  expect_match(
+    no_spread$Note[no_spread$Statistic == "First-stage specification"],
+    "no usable spread"
+  )
+
+  # An explicit choice is not annotated.
+  explicit <- build_maive_summary(make_maive_output(), base_maive_options())
+  expect_equal(explicit$Note[explicit$Statistic == "First-stage specification"], "")
+})
+
+test_that("build_maive_summary flags a weak instrument and a rejecting Hausman test", {
+  summary <- build_maive_summary(make_maive_output(`F-test` = 4.5), base_maive_options())
+
+  f_row <- summary[summary$Statistic == "First-stage F", ]
+  expect_match(f_row$Note, "weak instrument")
+  expect_equal(attr(summary, "tone")[summary$Statistic == "First-stage F"], "bad")
+
+  hausman_row <- summary[summary$Statistic == "Hausman statistic", ]
+  expect_match(hausman_row$Note, "rejects OLS = IV")
+})
+
+test_that("build_maive_summary reports an uninformative Hausman test rather than NA", {
+  summary <- build_maive_summary(make_maive_output(Hausman = NaN), base_maive_options())
+  hausman_row <- summary[summary$Statistic == "Hausman statistic", ]
+
+  expect_match(hausman_row$Note, "uninformative")
+})
+
+test_that("build_maive_summary drops IV diagnostics when instrumenting is off", {
+  summary <- build_maive_summary(make_maive_output(), base_maive_options(instrument = 0L))
+
+  expect_false("Diagnostics" %in% summary$Section)
+  expect_false("First-stage specification" %in% summary$Statistic)
+})
+
+test_that("build_maive_summary drops the Hausman rows under study fixed effects", {
+  summary <- build_maive_summary(make_maive_output(), base_maive_options(studylevel = 1L))
+
+  expect_true("First-stage F" %in% summary$Statistic)
+  expect_false("Hausman statistic" %in% summary$Statistic)
+})
+
+test_that("build_maive_summary marks an uncomputed Anderson-Rubin interval", {
+  summary <- build_maive_summary(make_maive_output(), base_maive_options(ar = 0L))
+  ar_row <- summary[summary$Statistic == "Anderson-Rubin 95% CI", ][1, ]
+
+  expect_equal(ar_row$Value, "not computed")
+})
+
+test_that("build_maive_summary honours the significance-marks switch", {
+  with_marks <- build_maive_summary(make_maive_output(), base_maive_options())
+  without <- build_maive_summary(
+    make_maive_output(),
+    base_maive_options(add_significance_marks = FALSE)
+  )
+
+  expect_match(with_marks$Value[with_marks$Statistic == "MAIVE estimate"], "\\*")
+  expect_no_match(without$Value[without$Statistic == "MAIVE estimate"], "\\*")
+})
+
+test_that("build_maive_summary survives an all-NA MAIVE result", {
+  summary <- build_maive_summary(
+    list(beta = NA_real_, SE = NA_real_, egger_coef = NA_real_, egger_se = NA_real_),
+    base_maive_options()
+  )
+
+  expect_true(is.data.frame(summary))
+  expect_equal(summary$Value[summary$Statistic == "MAIVE estimate"], "NA")
+})
+
+# build_maive_interpretation ------------------------------------------------
+
+test_that("build_maive_interpretation reads out the effect, bias, and diagnostics", {
+  text <- paste(build_maive_interpretation(make_maive_output(), base_maive_options()), collapse = " ")
+
+  expect_match(text, "bias-corrected mean effect is 0\\.2")
+  expect_match(text, "statistically different from zero")
+  expect_match(text, "without the IV correction gives 0\\.31")
+  expect_match(text, "find evidence of substantial publication bias or p-hacking")
+  expect_match(text, "The instrument is strong")
+  expect_match(text, "rejects equality of OLS and IV")
+})
+
+test_that("build_maive_interpretation recommends logs only for a low F in levels", {
+  low_f <- make_maive_output(`F-test` = 4.5)
+
+  levels_text <- paste(build_maive_interpretation(low_f, base_maive_options()), collapse = " ")
+  logs_text <- paste(
+    build_maive_interpretation(low_f, base_maive_options(first_stage = 1L)),
+    collapse = " "
+  )
+  strong_text <- paste(build_maive_interpretation(make_maive_output(`F-test` = 45), base_maive_options()), collapse = " ")
+
+  expect_match(levels_text, "running the first stage in logs")
+  expect_no_match(logs_text, "running the first stage in logs")
+  expect_no_match(strong_text, "running the first stage in logs")
+})
+
+test_that("build_maive_interpretation skips IV sentences when instrumenting is off", {
+  text <- paste(
+    build_maive_interpretation(make_maive_output(), base_maive_options(instrument = 0L)),
+    collapse = " "
+  )
+
+  expect_no_match(text, "instrument is")
+  expect_no_match(text, "Hausman")
+  expect_match(text, "evidence of substantial publication bias \\(")
+})
+
+test_that("build_maive_interpretation reports an insignificant effect as such", {
+  text <- paste(
+    build_maive_interpretation(make_maive_output(beta = 0.01, SE = 0.5), base_maive_options()),
+    collapse = " "
+  )
+
+  expect_match(text, "not different from zero")
+})
+
+# run_maive -----------------------------------------------------------------
+
+test_that("run_maive skips with a reason when n_obs is absent", {
+  df <- make_maive_df()
+  df$n_obs <- NULL
+
+  result <- run_maive(df, base_maive_options())
+
+  expect_match(result$skipped, "n_obs")
+  expect_true(is.null(result$summary))
+})
+
+test_that("run_maive keeps the install hint when the MAIVE package is absent", {
+  local_pretend_packages_absent("MAIVE")
+
+  result <- run_maive(make_maive_df(), base_maive_options())
+
+  expect_true(is.null(result$summary))
+  # The actionable half lives in a cli bullet, which e$message would drop.
+  expect_match(result$skipped, "install.packages")
+})
+
+test_that("run_maive reports the installed version when it is too old", {
+  # Without the package the absence check fires first and never reaches the
+  # version branch under test.
+  skip_if_not_installed("MAIVE")
+  local_pretend_package_version("MAIVE", "0.0.2.11")
+
+  result <- run_maive(make_maive_df(), base_maive_options())
+
+  expect_true(is.null(result$summary))
+  expect_match(result$skipped, "0\\.2\\.4 or higher")
+  expect_match(result$skipped, "0\\.0\\.2\\.11")
+})
+
+test_that("run_maive builds a summary and interpretation from real MAIVE output", {
+  skip_if_not_installed("MAIVE")
+  local_options(artma.verbose = 1)
+
+  result <- run_maive(make_maive_df(), base_maive_options())
+
+  expect_true(is.null(result$skipped))
+  expect_true(is.data.frame(result$summary))
+  expect_true(length(result$interpretation) > 0)
+  expect_true(is.list(result$raw))
+})
+
+test_that("run_maive resolves the first stage from the data and reports it", {
+  skip_if_not_installed("MAIVE")
+  local_options(artma.verbose = 1)
+
+  df <- make_maive_df()
+  # Sample sizes spanning six orders of magnitude, the case the log form exists
+  # for; the SEs track them so the first stage stays estimable.
+  df$n_obs <- round(seq(100, 100e6, length.out = nrow(df)))
+  df$se <- 3 / sqrt(df$n_obs) + abs(rnorm(nrow(df), 0, 1e-4))
+
+  result <- run_maive(df, base_maive_options(first_stage = 2L))
+
+  expect_equal(result$first_stage$value, 1L)
+  expect_true(result$first_stage$automatic)
+})
+
+test_that("run_maive is reproducible across two bootstrap runs", {
+  skip_if_not_installed("MAIVE")
+  local_options(artma.verbose = 1)
+  opts <- base_maive_options(se = 3L) # Wild bootstrap: needs the threaded seed.
+
+  expect_equal(
+    run_maive(make_maive_df(), opts)$summary,
+    run_maive(make_maive_df(), opts)$summary
+  )
+})

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -5,19 +5,12 @@ box::use(
     expect_false,
     expect_match,
     expect_true,
-    skip_if_not_installed,
     test_that
   ],
   withr[local_options],
   artma / econometric / p_hacking[
     compute_pvalues,
     resolve_t_stats,
-    maive_p_from_coef,
-    maive_first_stage_f,
-    maive_first_stage_is_weak,
-    resolve_maive_first_stage,
-    format_maive_results,
-    prepare_maive_data,
     run_single_caliper,
     run_binomial,
     run_lcm,
@@ -74,188 +67,6 @@ test_that("resolve_t_stats prefers a reported t_stat over effect / se", {
   df <- data.frame(effect = c(1, 2), se = c(1, 1), t_stat = c(5, NA))
   # Row 1 uses the reported 5 (not effect/se = 1); row 2 falls back to 2/1 = 2.
   expect_equal(resolve_t_stats(df), c(5, 2))
-})
-
-# maive_p_from_coef ---------------------------------------------------------
-
-test_that("maive_p_from_coef matches the two-sided normal p-value", {
-  expect_equal(maive_p_from_coef(1.96, 1), 0.0499957902964409, tolerance = 1e-12)
-  expect_equal(maive_p_from_coef(0, 2), 1, tolerance = 1e-12)
-})
-
-test_that("maive_p_from_coef returns NA for degenerate inputs", {
-  expect_true(is.na(maive_p_from_coef(1, 0)))
-  expect_true(is.na(maive_p_from_coef(1, -1)))
-  expect_true(is.na(maive_p_from_coef(Inf, 1)))
-  expect_true(is.na(maive_p_from_coef(1, NA_real_)))
-})
-
-# maive_first_stage_f -------------------------------------------------------
-
-test_that("maive_first_stage_f reads the statistic MAIVE reports", {
-  expect_equal(maive_first_stage_f(list(`F-test` = 4.549)), 4.549)
-  expect_equal(maive_first_stage_f(list(`F-test` = "80.935")), 80.935)
-})
-
-test_that("maive_first_stage_f returns NA when instrumenting is off", {
-  # MAIVE sets the field to the literal string "NA" when instrument = 0.
-  expect_true(is.na(maive_first_stage_f(list(`F-test` = "NA"))))
-  expect_true(is.na(maive_first_stage_f(list())))
-  expect_true(is.na(maive_first_stage_f(list(`F-test` = Inf))))
-})
-
-# maive_first_stage_is_weak -------------------------------------------------
-
-test_that("maive_first_stage_is_weak applies the F < 10 rule of thumb", {
-  expect_true(maive_first_stage_is_weak(4.549))
-  expect_false(maive_first_stage_is_weak(10))
-  expect_false(maive_first_stage_is_weak(80.935))
-  expect_false(maive_first_stage_is_weak(NA_real_))
-})
-
-# resolve_maive_first_stage -------------------------------------------------
-
-test_that("resolve_maive_first_stage passes explicit choices through untouched", {
-  wide <- c(100, 10^9)
-
-  # A wide N spread would trigger the log form under 2, but 0 stays 0.
-  levels_choice <- resolve_maive_first_stage(0, wide)
-  expect_equal(levels_choice$value, 0L)
-  expect_false(levels_choice$automatic)
-
-  log_choice <- resolve_maive_first_stage(1, c(100, 200))
-  expect_equal(log_choice$value, 1L)
-  expect_false(log_choice$automatic)
-})
-
-test_that("resolve_maive_first_stage picks log once N spans the threshold", {
-  # The master-thesis case: 135 to 14.7M, about 5 orders of magnitude.
-  res <- resolve_maive_first_stage(2, c(135, 14746755))
-
-  expect_equal(res$value, 1L)
-  expect_true(res$automatic)
-  expect_equal(res$orders, 5.038, tolerance = 1e-3)
-})
-
-test_that("resolve_maive_first_stage keeps levels for a narrow N spread", {
-  res <- resolve_maive_first_stage(2, c(500, 900, 4000))
-
-  expect_equal(res$value, 0L)
-  expect_true(res$automatic)
-  expect_true(res$orders < 3)
-})
-
-test_that("resolve_maive_first_stage decides on the threshold boundary", {
-  # Exactly 3 orders of magnitude counts as wide.
-  expect_equal(resolve_maive_first_stage(2, c(10, 10000))$value, 1L)
-  # Just under does not.
-  expect_equal(resolve_maive_first_stage(2, c(10, 9999))$value, 0L)
-})
-
-test_that("resolve_maive_first_stage ignores unusable sample sizes", {
-  # Zero, negative, and non-finite N cannot enter a ratio.
-  res <- resolve_maive_first_stage(2, c(0, -5, NA, Inf, 100, 10^6))
-  expect_equal(res$value, 1L)
-  expect_equal(res$orders, 4)
-})
-
-test_that("resolve_maive_first_stage falls back to levels without a usable spread", {
-  for (degenerate in list(numeric(0), c(NA_real_, NA_real_), 1000, c(0, -1))) {
-    res <- resolve_maive_first_stage(2, degenerate)
-    expect_equal(res$value, 0L)
-    expect_true(res$automatic)
-    expect_true(is.na(res$orders))
-  }
-})
-
-test_that("resolve_maive_first_stage never reads anything but sample size", {
-  # Same N, wildly different effects and SEs: the choice must not move.
-  a <- resolve_maive_first_stage(2, c(135, 14746755))
-  b <- resolve_maive_first_stage(2, c(135, 14746755))
-  expect_equal(a, b)
-  expect_equal(names(formals(resolve_maive_first_stage)), c("first_stage", "n_obs"))
-})
-
-# format_maive_results ------------------------------------------------------
-
-test_that("format_maive_results flags a weak first stage", {
-  out <- format_maive_results(
-    list(
-      beta = 3.095, SE = 3.612, `pub bias p-value` = 0.241,
-      egger_coef = 2.078, egger_se = 1.771,
-      `F-test` = 4.549, Hausman = 0.847, Chi2 = 3.841
-    ),
-    list(round_to = 3)
-  )
-
-  expect_true("  Instrument strength" %in% out$Statistic)
-  expect_match(out$Value[out$Statistic == "  Instrument strength"], "weak")
-})
-
-test_that("format_maive_results leaves a strong first stage unflagged", {
-  out <- format_maive_results(
-    list(
-      beta = 6.993, SE = 0.393, `pub bias p-value` = 0.241,
-      egger_coef = 2.078, egger_se = 1.771,
-      `F-test` = 80.935, Hausman = 0.847, Chi2 = 3.841
-    ),
-    list(round_to = 3)
-  )
-
-  expect_false("  Instrument strength" %in% out$Statistic)
-  expect_equal(out$Value[out$Statistic == "F-test (1st stage IV)"], "80.935")
-})
-
-test_that("format_maive_results records the first stage form when given one", {
-  output <- list(
-    beta = 6.993, SE = 0.393, `pub bias p-value` = 0.241,
-    egger_coef = 2.078, egger_se = 1.771,
-    `F-test` = 80.935, Hausman = 0.847, Chi2 = 3.841
-  )
-
-  auto <- format_maive_results(
-    output, list(round_to = 3),
-    list(value = 1L, automatic = TRUE, orders = 5.04)
-  )
-  expect_equal(auto$Value[auto$Statistic == "1st stage form"], "log (auto)")
-
-  explicit <- format_maive_results(
-    output, list(round_to = 3),
-    list(value = 0L, automatic = FALSE, orders = NA_real_)
-  )
-  expect_equal(explicit$Value[explicit$Statistic == "1st stage form"], "levels")
-
-  # Omitting it keeps the table exactly as it was before this row existed.
-  expect_false("1st stage form" %in% format_maive_results(output, list(round_to = 3))$Statistic)
-})
-
-# prepare_maive_data --------------------------------------------------------
-
-test_that("prepare_maive_data renames columns to the MAIVE contract", {
-  df <- data.frame(
-    effect = c(0.1, 0.2, 0.3),
-    se = c(0.05, 0.06, 0.07),
-    n_obs = c(100, 200, 300),
-    study_id = c(1, 1, 2)
-  )
-
-  out <- prepare_maive_data(df)
-
-  expect_equal(colnames(out), c("bs", "sebs", "Ns", "studyid"))
-  expect_equal(out$bs, df$effect)
-  expect_equal(out$sebs, df$se)
-  expect_equal(out$Ns, df$n_obs)
-  expect_equal(out$studyid, df$study_id)
-})
-
-test_that("prepare_maive_data omits studyid when study_id is absent", {
-  df <- data.frame(effect = 1, se = 0.1, n_obs = 10)
-  out <- prepare_maive_data(df)
-  expect_equal(colnames(out), c("bs", "sebs", "Ns"))
-})
-
-test_that("prepare_maive_data errors when required columns are missing", {
-  expect_error(prepare_maive_data(data.frame(effect = 1, se = 0.1)))
 })
 
 # run_single_caliper --------------------------------------------------------
@@ -545,15 +356,6 @@ base_p_hacking_options <- function(...) {
     cox_shi_bins = 20L,
     cox_shi_order = 2L,
     cox_shi_bounds = 1L,
-    include_maive = FALSE,
-    maive_method = 3L,
-    maive_weight = 0L,
-    maive_instrument = 1L,
-    maive_studylevel = 2L,
-    maive_se = 1L,
-    maive_ar = 0L,
-    maive_first_stage = 0L,
-    maive_seed = 123L,
     add_significance_marks = TRUE,
     round_to = 3L
   )
@@ -671,52 +473,6 @@ test_that("run_p_hacking_tests records a skip reason for a singular Cox-Shi cova
   expect_match(result$skipped$cox_shi_005, "singular")
 })
 
-test_that("run_p_hacking_tests records a skip reason when MAIVE lacks n_obs", {
-  local_options(artma.verbose = 1)
-  df <- make_p_hacking_df()
-  df$n_obs <- NULL
-
-  result <- run_p_hacking_tests(
-    df,
-    base_p_hacking_options(include_caliper = FALSE, include_maive = TRUE)
-  )
-
-  expect_match(result$skipped$maive, "n_obs")
-  expect_true(is.null(result$maive))
-})
-
-test_that("the MAIVE skip reason keeps the install hint when the package is absent", {
-  local_options(artma.verbose = 1)
-  local_pretend_packages_absent("MAIVE")
-
-  result <- run_p_hacking_tests(
-    make_p_hacking_df(),
-    base_p_hacking_options(include_caliper = FALSE, include_maive = TRUE)
-  )
-
-  expect_true(is.null(result$maive))
-  expect_match(result$skipped$maive, "MAIVE")
-  # The actionable half lives in a cli bullet, which e$message would drop.
-  expect_match(result$skipped$maive, "install.packages")
-})
-
-test_that("the MAIVE skip reason reports the installed version when it is too old", {
-  # Without the package the absence check fires first and never reaches the
-  # version branch under test.
-  skip_if_not_installed("MAIVE")
-  local_options(artma.verbose = 1)
-  local_pretend_package_version("MAIVE", "0.0.2.11")
-
-  result <- run_p_hacking_tests(
-    make_p_hacking_df(),
-    base_p_hacking_options(include_caliper = FALSE, include_maive = TRUE)
-  )
-
-  expect_true(is.null(result$maive))
-  expect_match(result$skipped$maive, "0\\.2\\.4 or higher")
-  expect_match(result$skipped$maive, "0\\.0\\.2\\.11")
-})
-
 test_that("run_lcm skips with a reason instead of failing silently", {
   local_pretend_packages_absent("fdrtool")
 
@@ -726,7 +482,7 @@ test_that("run_lcm skips with a reason instead of failing silently", {
   expect_match(attr(result, "reason"), "fdrtool")
 })
 
-# LCM / MAIVE reproducibility --------------------------------------------
+# LCM reproducibility -----------------------------------------------------
 
 test_that("simulate_cdfs_parallel is reproducible when seed is passed explicitly", {
   res_a <- simulate_cdfs_parallel(iterations = 20, grid_points = 30, seed = 123, show_progress = FALSE)
@@ -751,22 +507,6 @@ test_that("run_p_hacking_tests produces identical LCM p-values across two runs",
   lcm_a <- result_a$elliott[grepl("^LCM", result_a$elliott$Test), "P-value"]
   lcm_b <- result_b$elliott[grepl("^LCM", result_b$elliott$Test), "P-value"]
   expect_equal(lcm_a, lcm_b)
-})
-
-test_that("run_p_hacking_tests produces identical MAIVE bootstrap results across two runs", {
-  skip_if_not_installed("MAIVE")
-  local_options(artma.verbose = 1)
-  df <- make_p_hacking_df()
-  opts <- base_p_hacking_options(
-    include_caliper = FALSE,
-    include_maive = TRUE,
-    maive_se = 3L # Wild bootstrap: irreproducible without a threaded seed.
-  )
-
-  result_a <- run_p_hacking_tests(df, opts)
-  result_b <- run_p_hacking_tests(df, opts)
-
-  expect_equal(result_a$maive, result_b$maive)
 })
 
 # Discontinuity alignment -----------------------------------------------------

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -22,7 +22,6 @@ local_caliper_only_options <- function(.local_envir = parent.frame()) {
     artma.methods.p_hacking_tests.include_elliott = FALSE,
     artma.methods.p_hacking_tests.include_discontinuity = FALSE,
     artma.methods.p_hacking_tests.include_cox_shi = FALSE,
-    artma.methods.p_hacking_tests.include_maive = FALSE,
     .local_envir = .local_envir
   )
 }

--- a/tests/testthat/test-result-formatters.R
+++ b/tests/testthat/test-result-formatters.R
@@ -27,3 +27,77 @@ test_that("significance_mark preserves input names", {
 test_that("significance_mark returns empty vector for empty input", {
   expect_identical(significance_mark(numeric(0)), character(0))
 })
+
+# print_sectioned_table -----------------------------------------------------
+
+box::use(
+  testthat[expect_match, expect_true],
+  artma / libs / formatting / results[print_sectioned_table, print_paragraph]
+)
+
+sectioned_fixture <- function() {
+  out <- data.frame(
+    Section = c("Estimate", "Estimate", "Diagnostics"),
+    Statistic = c("MAIVE estimate", "Std. error", "First-stage F"),
+    Value = c("0.123", "(0.045)", "4.512"),
+    Note = c("significant at 5%", "", "weak instrument"),
+    stringsAsFactors = FALSE
+  )
+  attr(out, "tone") <- c("good", "", "bad")
+  out
+}
+
+# The printer returns the exact lines it emitted, so assertions can read them
+# without fighting cli's output connection.
+capture_sectioned <- function(x, ...) {
+  withr::with_options(
+    list(cli.num_colors = 1),
+    utils::capture.output(lines <- print_sectioned_table(x, ...))
+  )
+  lines
+}
+
+test_that("print_sectioned_table underlines every section heading", {
+  lines <- capture_sectioned(sectioned_fixture())
+
+  expect_true("Estimate" %in% lines)
+  expect_true(strrep("-", nchar("Estimate")) %in% lines)
+  expect_true("Diagnostics" %in% lines)
+})
+
+test_that("print_sectioned_table left-aligns labels and right-aligns values", {
+  lines <- capture_sectioned(sectioned_fixture())
+  rows <- grep("^  \\S", lines, value = TRUE)
+
+  # Labels all start in the same column; print.data.frame would right-align them.
+  expect_identical(substring(rows, 1, 3), c("  M", "  S", "  F"))
+  # Values share a right edge, so the decimal points line up.
+  value_ends <- regexpr("0\\.045\\)|0\\.123|4\\.512", rows) +
+    attr(regexpr("0\\.045\\)|0\\.123|4\\.512", rows), "match.length")
+  expect_equal(length(unique(value_ends)), 1L)
+})
+
+test_that("print_sectioned_table emits no blank separator rows inside a section", {
+  lines <- capture_sectioned(sectioned_fixture())
+  # One blank line only, between the two sections.
+  expect_equal(sum(!nzchar(lines)), 1L)
+})
+
+test_that("print_sectioned_table falls back to the plain printer without a Section column", {
+  plain <- data.frame(Statistic = "a", Value = "1", stringsAsFactors = FALSE)
+
+  expect_true(any(grepl("Statistic", capture_sectioned(plain))))
+})
+
+test_that("print_sectioned_table ignores an empty table", {
+  expect_equal(capture_sectioned(sectioned_fixture()[0, ]), character(0))
+})
+
+test_that("print_paragraph wraps sentences and drops empty ones", {
+  utils::capture.output(
+    lines <- print_paragraph(c("One sentence.", "", "Another sentence."), width = 20)
+  )
+
+  expect_true(length(lines) > 1)
+  expect_match(paste(lines, collapse = " "), "One sentence\\. Another sentence\\.")
+})

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -83,6 +83,7 @@ Methods are the analytical functions that perform specific meta-analysis tasks. 
 - `nonlinear_tests` - Test nonlinear relationships
 - `exogeneity_tests` - Test for endogeneity
 - `p_hacking_tests` - Detect p-hacking patterns
+- `maive` - MAIVE estimator, correcting for publication bias, p-hacking, and spurious precision
 - `variable_summary_stats` - Summary statistics for variables
 
 You can run one method, multiple methods, or all methods in a single call. For a full description of every method, see the [Methods Overview](methods-overview.html) vignette.

--- a/vignettes/methods-overview.Rmd
+++ b/vignettes/methods-overview.Rmd
@@ -49,9 +49,10 @@ These methods test for publication bias and selective reporting; none depend on 
 | `linear_tests` | Linear funnel-asymmetry regressions of effect on standard error (FAT-PET): OLS, panel Fixed/Between/Random Effects, and study-size/precision-weighted variants | `effect`, `se`, `study_id` |
 | `nonlinear_tests` | Non-linear publication-bias corrections: WAAP, Top10, STEM (funnel and MSE variants), a hierarchical Bayesian model, a selection-model (p-uniform-style) estimator, and the endogenous kink test | `effect`, `se`, `study_id` |
 | `exogeneity_tests` | Diagnostics that relax the exogeneity assumption: instrumental-variable regression and the p-uniform* test | `effect`, `se`, `study_id`, `n_obs`, `study_size` |
-| `p_hacking_tests` | Caliper tests around significance thresholds, the Elliott et al. (2022) battery, and the MAIVE estimator | `effect`, `se`, `t_stat`, `study_id` |
+| `p_hacking_tests` | Caliper tests around significance thresholds and the Elliott et al. (2022) battery | `effect`, `se`, `t_stat`, `study_id` |
+| `maive` | The MAIVE estimator: corrects the mean effect for publication bias, p-hacking, and spurious precision by instrumenting reported variances with the inverse sample size | `effect`, `se`, `n_obs` |
 
-`exogeneity_tests` needs the `AER` and `ivmodel` packages; the others in this group work with the package's own dependencies.
+`exogeneity_tests` needs the `AER` and `ivmodel` packages and `maive` needs the `MAIVE` package (>= 0.2.4); the others in this group work with the package's own dependencies.
 
 ## Moderator and heterogeneity analysis
 

--- a/vignettes/options-files.Rmd
+++ b/vignettes/options-files.Rmd
@@ -119,6 +119,17 @@ Method-specific parameters for each analysis method:
 - `include_elliott`: Whether to include Elliott et al. tests
 - `lcm_iterations`: Number of simulations for LCM test
 
+#### `maive`
+
+- `method`: Funnel model plugged with the instrumented variances (1 = FAT-PET, 2 = PEESE, 3 = PET-PEESE, 4 = EK)
+- `instrument`: Whether reported variances are instrumented with the inverse sample size
+- `weight`: Weighting scheme
+- `studylevel`: Study-level correlation structure
+- `se`: Standard error estimation method (asymptotic or one of four bootstraps)
+- `ar`: Whether to compute the weak-instrument-robust Anderson-Rubin interval
+- `first_stage`: First-stage functional form (0 = levels, 1 = logs, 2 = chosen automatically from the spread of sample sizes)
+- `show_interpretation`: Whether to print the plain-language reading of the results
+
 ### 5. `output`
 
 Controls output formatting:
@@ -369,6 +380,11 @@ methods:
     include_caliper: true
     caliper_thresholds: [1.645, 1.96, 2.58]
     include_elliott: true
+
+  maive:
+    method: 3
+    instrument: 1
+    ar: 1
 
 verbose:
   level: 3


### PR DESCRIPTION
Makes the MAIVE output readable, taking cues from the maive.eu UI (`PetrCala/maive-ui`).

## The problem

MAIVE was rendered as a flat two-column frame printed with `print.data.frame`:

```
                    Statistic           Value
            MAIVE coefficient         0.123**
                   Std. error         (0.045)
               Model selected           PEESE

            Pub. bias p-value        0.003***
            Egger coefficient           1.842
...
        F-test (1st stage IV)           4.512
                 Hausman test           6.201
   Chi-sq. crit. (alpha=0.05)           3.841
```

- `print.data.frame` right-aligns character columns, so the `"  Std. error"` indentation encoding "belongs to the row above" was eaten; sub-rows read as peers.
- Section breaks were literal blank rows, unlabelled, and they survived into the exported CSV as empty records.
- Everything was raw numbers. `F-test 4.512` gave no signal that it is below the weak-instrument threshold of 10; `Hausman 6.201` vs `Chi2 3.841` left the comparison to the reader.
- No specification echo: which funnel model, which weights, whether instrumenting was on, levels vs log first stage. All of it changes how the numbers should be read.
- MAIVE sat under the shared `"Note: low p-values indicate potential p-hacking"` footer of `p_hacking_tests`, which is false for the F-test and the Hausman statistic.

## The output now

```
Specification
-------------
  Model                                 PET-PEESE
  Instrument                  on (1/N instrument)
  Weights                                    none
  Study-level structure            cluster-robust
  Standard errors                      asymptotic
  First-stage specification            SE^2 ~ 1/N
  Observations                                 60
  Studies                                      12

Corrected mean estimate
-----------------------
  MAIVE estimate                         0.309***   significant at 5%
  Std. error                              (0.008)
  95% CI                           [0.293, 0.325]
  Anderson-Rubin 95% CI              not computed   enable the ar option to compute it
  Model selected                            PEESE   chosen by the PET-PEESE rule
  Unadjusted estimate                       0.309   same model without the IV correction
  Std. error                              (0.008)

Publication bias and p-hacking
------------------------------
  Egger coefficient                      1.522***   bias detected at 5%
  Std. error                              (0.045)
  p-value                                   0.000
  95% CI (bootstrap)               [1.434, 1.609]   excludes 0
  Coefficient on SE^2                       3.696
  Std. error                              (0.269)

Diagnostics
-----------
  First-stage F                             8.512   weak instrument (< 10)
  Hausman statistic                         6.201   rejects OLS = IV at 5%
  Chi-sq. critical value (5%)               3.841

Interpretation
Using MAIVE (PET-PEESE), the bias-corrected mean effect is 0.31 (95% CI 0.29, 0.32),
statistically different from zero at the 5% level. The same model without the IV
correction gives 0.31. We find evidence of substantial publication bias or p-hacking
(Egger 95% CI excludes 0). The instrument is weak (first-stage F = 8.51), so the
Anderson-Rubin interval is the one to report. The Hausman test rejects equality of OLS
and IV, so evidence of spurious precision is strong. Because the first-stage F is below
30, running the first stage in logs (first_stage = 1) is recommended.
```

Verdict notes are green/red in a colour terminal.

## What changed

**New sectioned printer** (`inst/artma/libs/formatting/results.R`). `print_sectioned_table()` renders a `Section` / `Statistic` / `Value` / `Note` frame with labels flush left and only the value column right-aligned, under underlined headings. Colours come from a `tone` attribute rather than a column, so the CSV stays free of presentation data. Falls back to `print_summary_table()` when the columns aren't there. `print_paragraph()` wraps generated prose. Both return the lines they emitted, which is what the tests read.

**New module** `inst/artma/econometric/maive.R`, holding what moved out of `p_hacking.R` (`prepare_maive_data`, `maive_p_from_coef`) plus:

- option labels (`maive_method_label` and friends) so the specification block reads in words
- `maive_first_stage_spec()`, which names the regression that produced the F and relabels it `First-stage F (gamma1)` in log mode
- verdicts: `instrument_strength()` (the `>= 10` rule), `hausman_rejects()`, `ci_excludes_zero()`, `ar_ci_verdict()` (disabled / no acceptance region / very wide)
- `build_maive_summary()` and `build_maive_interpretation()`, the latter a port of maive-ui's `interpretationTextGenerator.ts`, including the two actionable sentences we did not surface at all: report the AR interval when F < 10, and try the log first stage when F < 30
- `run_maive()`, which degrades to a skip reason rather than aborting

**New runtime method** `inst/artma/methods/maive.R` (`stage = "maive"`, `required_columns = c("effect", "se", "n_obs")`, `suggests = "MAIVE"`). MAIVE is an estimator, not a p-hacking test, so it gets its own `cli_h2`, its own citation line, and no longer inherits a footer that misdescribes half its rows. It exports to `maive.csv` instead of `p_hacking_tests_maive.csv`.

**Rows the UI has and we lacked**: a 95% CI on the MAIVE estimate, an explicit significance verdict, the Egger p-value as its own row, the Egger Anderson-Rubin interval, the first-stage specification, and the unadjusted `beta_standard` / `SE_standard` counterpart so the size of the correction is visible.

**Options** move from `methods.p_hacking_tests.maive_*` to their own `methods.maive` group (`method`, `weight`, `instrument`, `studylevel`, `se`, `ar`, `first_stage`, `seed`, `show_interpretation`), dropping the redundant prefix. Option parsing iterates over template definitions, so stale keys in existing user files are ignored rather than erroring. `include_maive` is gone: the method is enabled or not like any other.

## Rebase note

Two sibling MAIVE commits landed on master while this was open (`c88d526` weak-instrument flagging, `e6f74bd` automatic first-stage selection), both touching the code this PR moved. Their behaviour is carried over into the new module rather than reverted:

- `maive_first_stage_f()` and `maive_first_stage_is_weak()` moved into `econometric/maive.R`, with `maive_first_stage_is_weak()` now expressed in terms of `instrument_strength()` so there is one threshold, not two.
- `resolve_maive_first_stage()` moved over intact, so `first_stage: 2` still picks the functional form from the spread of sample sizes. The choice is threaded through to the model call, the summary table, and the interpretation, so the F row is labelled `First-stage F (gamma1)` and the specification row reads e.g. `log(SE^2) ~ log N (Duan smearing)   chosen automatically (N spans 4.9 orders of magnitude)`. Master's separate "1st stage form" row is folded into the Specification section.
- The weak-instrument `cli_alert_warning` plus the `first_stage: 1` hint survive at verbosity >= 2, one level below the interpretation paragraph, since it is the one diagnostic that invalidates the headline number. The hint is suppressed when the log form is already in use.
- Master's option help for `maive_first_stage` (including value 2) carried over to `methods.maive.first_stage`, and its tests moved into `test-econometric-maive.R`.

## Notes

- The funnel-plot overlay from maive.eu is deliberately not included.
- `make test` passes (0 failures, 2069 assertions); `make lint` is clean. The 3 remaining warnings are pre-existing.
