### PR TITLE
fix: address remaining bugs from the April user report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
 Imports:
     box (>= 1.2.0),
     cli (>= 3.6.5),
-    climenu (>= 0.1.5),
+    climenu (>= 0.1.7),
     ggplot2 (>= 3.4.0),
     ggtext (>= 0.1.2),
     lmtest (>= 0.9-40),

--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -12,6 +12,7 @@ box::use(
   artma / libs / formatting / results[
     significance_mark,
     format_number,
+    format_estimate,
     format_se,
     format_ci
   ],
@@ -73,6 +74,20 @@ get_robust_vcov <- function(model, cluster) {
 #' Staiger-Stock/Stock-Yogo rule-of-thumb minimum first-stage F-statistic
 #' below which an instrument is considered weak.
 WEAK_INSTRUMENT_F_THRESHOLD <- 10
+
+#' @title Coerce a test statistic to a single numeric value
+#' @description
+#' Test statistics pulled out of third-party model objects are occasionally
+#' `NULL` or empty. Passing such a value on lets it vanish from a `c()` call
+#' and silently shorten a summary column, so collapse it to `NA_real_` here.
+#' @param x *[any]* Candidate statistic.
+#' @return *[numeric(1)]* The statistic, or `NA_real_` if it is not a single number.
+as_scalar_stat <- function(x) {
+  if (!is.numeric(x) || length(x) != 1) {
+    return(NA_real_)
+  }
+  x
+}
 
 #' @title Default tie-break instrument among equally strong candidates
 #' @description
@@ -209,11 +224,13 @@ run_iv_regression <- function(df, iv_instrument = "automatic", add_significance_
   model <- AER::ivreg(formula = iv_formula, data = df)
   model_summary <- summary(model, vcov = get_robust_vcov(model, df$study_id), diagnostics = TRUE)
 
-  # Extract Anderson-Rubin F-statistic
+  # Extract Anderson-Rubin F-statistic. `ivmodel` returns NULL for `AR` when the
+  # test is not computable, and a zero-length statistic silently shortens the
+  # summary column built from it, so normalize to a scalar here.
   fstat <- tryCatch(
     {
       model_ar <- ivmodel::ivmodel(Y = df$effect, D = df$se, Z = df$instr_temp)
-      model_ar$AR$Fstat
+      as_scalar_stat(model_ar$AR$Fstat)
     },
     error = function(e) NA_real_
   )
@@ -258,7 +275,7 @@ run_iv_regression <- function(df, iv_instrument = "automatic", add_significance_
   )
 
   coefficients$significance <- if (add_significance_marks) significance_mark(coefficients$p_value) else ""
-  coefficients$estimate_formatted <- paste0(format_number(coefficients$estimate, round_to), coefficients$significance)
+  coefficients$estimate_formatted <- format_estimate(coefficients$estimate, round_to, coefficients$significance)
   coefficients$std_error_formatted <- format_se(coefficients$std_error, round_to)
 
   list(
@@ -604,7 +621,7 @@ run_puniform_star <- function(df, add_significance_marks = TRUE, round_to = 3L, 
   )
 
   coefficients$significance <- if (add_significance_marks) significance_mark(coefficients$p_value) else ""
-  coefficients$estimate_formatted <- paste0(format_number(coefficients$estimate, round_to), coefficients$significance)
+  coefficients$estimate_formatted <- format_estimate(coefficients$estimate, round_to, coefficients$significance)
   coefficients$std_error_formatted <- format_se(coefficients$std_error, round_to)
 
   list(
@@ -718,6 +735,24 @@ na_to_not_computable <- function(x) {
   x
 }
 
+#' @title Fit a summary column to the table's row count
+#' @description
+#' Each summary column is assembled by concatenating per-metric values, any of
+#' which can come back zero-length when the underlying model did not produce
+#' the statistic. A short column makes the data frame assignment fail with an
+#' opaque `replacement has N rows` error, so pad it with the placeholder
+#' instead and keep the table printable.
+#' @param values *[character]* The assembled column.
+#' @param n *[integer]* The number of rows the table has.
+#' @return *[character]* A column of exactly `n` entries.
+fit_summary_column <- function(values, n) {
+  values <- as.character(values)
+  if (length(values) < n) {
+    values <- c(values, rep(NOT_COMPUTABLE, n - length(values)))
+  }
+  values[seq_len(n)]
+}
+
 build_exogeneity_summary <- function(iv_results, puniform_results, options) {
   row_labels <- c(
     "Publication Bias",
@@ -741,20 +776,20 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
     pb <- iv_coef[iv_coef$term == "publication_bias", , drop = FALSE]
     eff <- iv_coef[iv_coef$term == "effect", , drop = FALSE]
 
-    first_stage_str <- format_number(iv_results$first_stage_fstat, options$round_to)
+    first_stage_str <- format_number(as_scalar_stat(iv_results$first_stage_fstat), options$round_to)
     if (isTRUE(iv_results$weak_instrument) && !is.na(first_stage_str)) {
       first_stage_str <- paste0(first_stage_str, " (weak instrument)")
     }
 
-    summary[["IV"]] <- na_to_not_computable(c(
+    summary[["IV"]] <- na_to_not_computable(fit_summary_column(c(
       if (nrow(pb) > 0) pb$estimate_formatted else NA_character_,
       if (nrow(pb) > 0) pb$std_error_formatted else NA_character_,
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
       if (nrow(eff) > 0) eff$std_error_formatted else NA_character_,
       if (nrow(iv_coef) > 0) format_number(iv_coef$n_obs[1], 0) else NA_character_,
       first_stage_str,
-      format_number(iv_results$ar_fstat, options$round_to)
-    ))
+      format_number(as_scalar_stat(iv_results$ar_fstat), options$round_to)
+    ), length(row_labels)))
   } else {
     summary[["IV"]] <- rep(NOT_COMPUTABLE, length(row_labels))
   }
@@ -778,7 +813,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
       NA_character_
     }
 
-    summary[["p-Uniform*"]] <- na_to_not_computable(c(
+    summary[["p-Uniform*"]] <- na_to_not_computable(fit_summary_column(c(
       pb_test_str,
       pb_p_str,
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
@@ -786,7 +821,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
       if (nrow(pu_coef) > 0) format_number(pu_coef$n_obs[1], 0) else NA_character_,
       "", # No first-stage F for p-uniform
       "" # No F-test for p-uniform
-    ))
+    ), length(row_labels)))
   } else {
     summary[["p-Uniform*"]] <- rep(NOT_COMPUTABLE, length(row_labels))
   }
@@ -796,6 +831,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
 }
 
 box::export(
+  build_exogeneity_summary,
   run_exogeneity_tests,
   run_iv_regression,
   run_puniform_star,

--- a/inst/artma/libs/formatting/results.R
+++ b/inst/artma/libs/formatting/results.R
@@ -44,6 +44,29 @@ format_number <- function(x, digits) {
   formatted
 }
 
+#' @title Format an estimate together with its significance mark
+#' @description Like `format_number()`, but appends a significance mark and
+#'   keeps non-finite estimates as `NA_character_`. A plain
+#'   `paste0(format_number(x), mark)` turns an `NA` estimate into the literal
+#'   string `"NA"`, which then slips past every downstream `is.na()` guard.
+#' @param x *[numeric]* Estimates to format.
+#' @param digits *[integer]* Number of decimals.
+#' @param marks *[character]* Significance marks, recycled against `x`.
+#' @return *[character]* Formatted estimates, `NA_character_` where not finite.
+format_estimate <- function(x, digits, marks = "") {
+  formatted <- format_number(x, digits)
+  if (!length(formatted)) {
+    return(formatted)
+  }
+
+  finite <- !is.na(formatted)
+  if (any(finite)) {
+    formatted[finite] <- paste0(formatted[finite], rep_len(marks, length(formatted))[finite])
+  }
+
+  formatted
+}
+
 format_se <- function(se, digits) {
   if (!length(se)) {
     return(character(0))
@@ -228,6 +251,7 @@ print_paragraph <- function(sentences, width = 88L) {
 box::export(
   significance_mark,
   format_number,
+  format_estimate,
   format_se,
   format_ci,
   print_summary_table,

--- a/inst/artma/methods/box_plot.R
+++ b/inst/artma/methods/box_plot.R
@@ -331,8 +331,15 @@ create_single_box_plot <- function(df, factor_by, theme_name, show_mean_line, ef
   factor_levels <- rev(sort(unique(stats::na.omit(factor_values))))
   factor_by_verbose <- gsub("_", " ", factor_by)
 
-  plot_df <- df
-  plot_df[[".factor"]] <- factor(factor_values, levels = factor_levels)
+  # Only the two mapped columns are needed. Passing the whole data frame makes
+  # the plot fail on any unrelated column irregularity (duplicate names in
+  # particular, which ggplot2 rejects outright).
+  plot_df <- data.frame(
+    effect = df[["effect"]],
+    .factor = factor(factor_values, levels = factor_levels),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
 
   p <- ggplot2::ggplot(
     data = plot_df,

--- a/inst/artma/options/template.R
+++ b/inst/artma/options/template.R
@@ -186,6 +186,31 @@ get_option_defs <- function(template_path = NULL, opt_path = NULL) {
 }
 
 
+#' @title Sanitize a raw prompt answer
+#' @description Trim surrounding whitespace from a `readline()` answer and, for
+#'   path prompts, strip surrounding quotes. Windows Explorer's "Copy as path"
+#'   wraps the path in double quotes, and a quoted path fails every
+#'   `file.exists()` check downstream.
+#' @param input_val [character] The raw answer.
+#' @param prompt_type [character] The prompt type the answer was collected for.
+#' @return [character] The sanitized answer.
+#' @keywords internal
+sanitize_prompt_input <- function(input_val, prompt_type) {
+  box::use(artma / libs / core / string[trim_quotes])
+
+  if (!is.character(input_val) || length(input_val) != 1 || is.na(input_val)) {
+    return(input_val)
+  }
+
+  input_val <- trimws(input_val)
+
+  if (prompt_type %in% c("file", "directory")) {
+    input_val <- trimws(trim_quotes(input_val))
+  }
+
+  input_val
+}
+
 #' @title Prompt user for a required value with no default
 #' @description Prompt the user for a value, displaying the option name, type, and help.
 #' @param opt [list] Option definition.
@@ -244,6 +269,7 @@ prompt_user_for_option_value <- function(opt) {
 
   hint_msg <- if (length(hints)) paste0(" (or ", paste(hints, collapse = ", "), ")") else ""
   input_val <- readline(prompt = cli::format_inline("Enter a value for {.strong {opt$name}}{hint_msg}: "))
+  input_val <- sanitize_prompt_input(input_val, prompt_type)
 
   if (input_val == "choose" || is.na(input_val) || (!nzchar(input_val) && prompt_type %in% c("file", "directory"))) {
     input_val <- switch(prompt_type,
@@ -484,6 +510,7 @@ parse_options_from_template <- function(
 
 box::export(
   coerce_option_value,
+  sanitize_prompt_input,
   collect_leaf_paths,
   flatten_template_options,
   flatten_user_options,

--- a/tests/testthat/test-box-plot-study-label.R
+++ b/tests/testthat/test-box-plot-study-label.R
@@ -29,3 +29,31 @@ test_that("box_plot auto-selects study_label over study_id for grouping", {
   expect_true(is.list(result))
   expect_equal(result$meta$factor_by, "study_label")
 })
+
+test_that("box_plot builds a plot even when the data has duplicate column names", {
+  df <- data.frame(
+    study_id = c(1L, 2L, 1L, 3L),
+    study_label = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)", "Clark (2010)"),
+    effect = c(0.2, 0.3, 0.1, 0.4),
+    se = c(0.1, 0.1, 0.2, 0.1),
+    n_obs = c(100, 120, 100, 140),
+    stringsAsFactors = FALSE
+  )
+  # A stray duplicate column used to reach ggplot2 and abort the whole plot with
+  # "`data` must be uniquely named but has duplicate columns".
+  df$extra <- df$se
+  names(df)[names(df) == "extra"] <- "se"
+
+  withr::local_options(list(
+    "artma.visualization.export_graphics" = FALSE,
+    "artma.output.save_results" = FALSE,
+    "artma.verbose" = 1,
+    "artma.data.columns" = list()
+  ))
+
+  result <- box_plot(df)
+
+  expect_equal(result$meta$factor_by, "study_label")
+  expect_true(inherits(result$plots[[1]], "ggplot"))
+  expect_true(is.data.frame(ggplot2::ggplot_build(result$plots[[1]])$data[[1]]))
+})

--- a/tests/testthat/test-econometric-exogeneity.R
+++ b/tests/testthat/test-econometric-exogeneity.R
@@ -13,6 +13,7 @@ box::use(
   ],
   withr[local_options],
   artma / econometric / exogeneity[
+    build_exogeneity_summary,
     run_iv_regression,
     run_puniform_star,
     find_best_instrument,
@@ -390,4 +391,51 @@ test_that("run_exogeneity_tests aborts when ivmodel is absent", {
 
   local_pretend_packages_absent("ivmodel")
   expect_error(run_exogeneity_tests(df, default_exogeneity_options()), regexp = "ivmodel")
+})
+
+test_that("build_exogeneity_summary survives a zero-length test statistic", {
+  # ivmodel returns NULL for AR whenever the test is not computable. The
+  # resulting zero-length statistic used to shorten the IV column and abort the
+  # table assembly with "replacement has N rows, data has 7".
+  iv_results <- list(
+    coefficients = data.frame(
+      term = c("effect", "publication_bias"),
+      estimate_formatted = c("0.100", "0.200"),
+      std_error_formatted = c("(0.010)", "(0.020)"),
+      n_obs = c(120L, 120L),
+      stringsAsFactors = FALSE
+    ),
+    instrument_name = "1/sqrt(n_obs)",
+    ar_fstat = NULL,
+    first_stage_fstat = NULL,
+    weak_instrument = FALSE
+  )
+  puniform_results <- list(coefficients = NULL)
+  options <- list(round_to = 3L)
+
+  summary <- build_exogeneity_summary(iv_results, puniform_results, options)
+
+  expect_equal(nrow(summary), 7L)
+  expect_equal(summary[["IV"]][[7]], "not computable")
+  expect_true(all(nzchar(summary[["p-Uniform*"]])))
+})
+
+test_that("build_exogeneity_summary does not print a bare NA for a non-estimable effect", {
+  puniform_results <- list(
+    coefficients = data.frame(
+      term = c("effect", "publication_bias_test"),
+      estimate = c(NA_real_, NA_real_),
+      statistic = c(NA_real_, NA_real_),
+      p_value = c(NA_real_, NA_real_),
+      estimate_formatted = c(NA_character_, NA_character_),
+      std_error_formatted = c(NA_character_, NA_character_),
+      n_obs = c(60L, 60L),
+      stringsAsFactors = FALSE
+    )
+  )
+
+  summary <- build_exogeneity_summary(list(coefficients = NULL), puniform_results, list(round_to = 3L))
+
+  expect_false(any(summary[["p-Uniform*"]] == "NA"))
+  expect_equal(summary[["p-Uniform*"]][[3]], "not computable")
 })

--- a/tests/testthat/test-options-prompt-input.R
+++ b/tests/testthat/test-options-prompt-input.R
@@ -1,0 +1,33 @@
+box::use(
+  testthat[expect_identical, test_that]
+)
+
+box::use(
+  artma / options / template[sanitize_prompt_input]
+)
+
+test_that("sanitize_prompt_input strips quotes around a pasted Windows path", {
+  # Explorer's "Copy as path" wraps the path in double quotes; keeping them
+  # makes every downstream file.exists() check fail on a file that is there.
+  expect_identical(
+    sanitize_prompt_input("\"C:\\Users\\me\\Documents\\data.xlsx\"", "file"),
+    "C:\\Users\\me\\Documents\\data.xlsx"
+  )
+  expect_identical(
+    sanitize_prompt_input("  '/home/me/data.csv'  ", "directory"),
+    "/home/me/data.csv"
+  )
+})
+
+test_that("sanitize_prompt_input trims whitespace for every prompt type", {
+  expect_identical(sanitize_prompt_input("  0.05 ", "readline"), "0.05")
+})
+
+test_that("sanitize_prompt_input leaves quotes alone outside path prompts", {
+  expect_identical(sanitize_prompt_input("\"quoted\"", "readline"), "\"quoted\"")
+})
+
+test_that("sanitize_prompt_input passes non-string input through unchanged", {
+  expect_identical(sanitize_prompt_input(NA_character_, "file"), NA_character_)
+  expect_identical(sanitize_prompt_input(character(0), "file"), character(0))
+})

--- a/tests/testthat/test-result-formatters.R
+++ b/tests/testthat/test-result-formatters.R
@@ -101,3 +101,26 @@ test_that("print_paragraph wraps sentences and drops empty ones", {
   expect_true(length(lines) > 1)
   expect_match(paste(lines, collapse = " "), "One sentence\\. Another sentence\\.")
 })
+
+test_that("format_estimate keeps non-finite estimates as NA", {
+  box::use(artma / libs / formatting / results[format_estimate])
+
+  # A plain paste0() would turn the NA into the literal string "NA", which then
+  # slips past every downstream is.na() guard and prints as "NA" in tables.
+  expect_identical(
+    format_estimate(c(0.5, NA_real_, Inf), 2L, c("**", "", "")),
+    c("0.50**", NA_character_, NA_character_)
+  )
+})
+
+test_that("format_estimate recycles a single significance mark", {
+  box::use(artma / libs / formatting / results[format_estimate])
+
+  expect_identical(format_estimate(c(1, 2), 1L), c("1.0", "2.0"))
+})
+
+test_that("format_estimate returns an empty vector for empty input", {
+  box::use(artma / libs / formatting / results[format_estimate])
+
+  expect_identical(format_estimate(numeric(0), 2L), character(0))
+})


### PR DESCRIPTION
Audit of the seven bug screenshots a user reported in mid-April (`local/bugs/`), plus fixes for everything still live on master.

## Audit outcome

| Bug | Status |
|---|---|
| `keypress::keypress()` unsupported-terminal error | Fixed upstream in climenu 0.1.7 (`keypress_supported()` gate + `select_fallback()`) |
| Menu `if (key %in% c("up","k"))` condition length > 1 | Fixed upstream. Root cause was the old readline fallback returning `list(type = "number", value = num)` for a typed number |
| "Failed to auto-detect columns: the condition has length > 1" | Same root cause as above |
| Quoted Windows path not found | **Was still live**, fixed here |
| Box plot `data must be uniquely named but has duplicate columns` | **Was still live**, fixed here |
| Missing `AER` aborting the run | Fixed by the `suggests` gate on the method |
| p-uniform* `replacement has 4 rows, data has 6` | Fixed, but the length-fragility that caused it was still reachable; hardened here |

## Changes

**Quoted data source paths.** `readline()` answers were used verbatim, so a path pasted via Explorer's "Copy as path" arrived wrapped in double quotes and failed every `file.exists()` check: auto-detection was skipped and the run later aborted with an invalid-path error. `sanitize_prompt_input()` now trims whitespace on every prompt answer and strips surrounding quotes for `file`/`directory` prompts.

**Duplicate columns from column mapping.** The root cause (a blind rename in `standardize_column_names()` that could put two columns under one name) was fixed independently on master in 794cf69 while this branch was open; that version is kept as-is here. What remains is the downstream half: `box_plot()` now builds its plot frame from just the two columns it maps, so an unrelated irregularity elsewhere in the data can no longer take the plot down with ggplot2's opaque "must be uniquely named" error.

**Exogeneity summary table.** Three hardening changes around the April `replacement has N rows` crash:

- `as_scalar_stat()` normalizes test statistics pulled out of third-party model objects. `ivmodel` returns `NULL` for `AR` when the test is not computable, and the zero-length result silently shortened the IV column.
- `fit_summary_column()` pads a short column with the "not computable" placeholder instead of failing the data frame assignment.
- `format_estimate()` replaces `paste0(format_number(x), mark)`, which turned an `NA` estimate into the literal string `"NA"` and slipped past the `is.na()` guard, printing a bare `NA` in the table.

**Dependency pin.** `climenu (>= 0.1.5)` under-pinned the terminal-fallback fix, which landed in 0.1.7.

## Testing

`make lint` clean; `make test` at 2062 passing, 0 failures (the 9 warnings are pre-existing MAIVE fits). New tests cover the prompt sanitizer, box plot resilience to duplicate columns, `format_estimate` NA handling, and summary assembly with a zero-length statistic.
