### PR TITLE
perf(p_hacking_tests): narrow disk cache for LCM critical-value simulation

### DIFF
--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -602,6 +602,7 @@ cox_shi_test <- function(Q, ind, p_min, p_max, J, K, use_bounds) {
 box::export(
   format_decimal,
   linspace,
+  simulate_cdfs_block_cpp,
   simulate_cdfs_parallel,
   binomial_test,
   lcm_test,

--- a/inst/artma/calc/methods/elliott_cache.R
+++ b/inst/artma/calc/methods/elliott_cache.R
@@ -1,0 +1,187 @@
+#' @title Disk cache for the Elliott LCM critical-value simulation
+#' @description
+#' The LCM p-hacking test compares its statistic against quantiles of a
+#' simulated null distribution produced by `simulate_cdfs_parallel()`. That
+#' table depends only on the iteration count, the grid size, the seed, the
+#' RNG kind, and the simulation implementation itself, never on the analysed
+#' data. The method-level cache from `register_runtime_method()` keys on the
+#' data source and the whole user option group, so any data or option change
+#' would re-run the simulation. This module caches the table under its own
+#' narrow key instead.
+NULL
+
+box::use(
+  artma / calc / methods / elliott[simulate_cdfs_block_cpp, simulate_cdfs_parallel],
+  artma / libs / infrastructure / cache[cache_cli],
+  artma / libs / infrastructure / source_fingerprint[hash_source_files],
+  artma / paths[PATHS]
+)
+
+STAGE <- "lcm_critical_values"
+
+# Resolved at module load time: the directory holding this module and the
+# simulation implementation it fingerprints.
+MODULE_DIR <- box::file()
+
+#' @title Decide whether the compiled simulation backend will run
+#' @description Mirror the backend selection inside
+#'   `simulate_cdfs_parallel()`, without its fallback warning: the option gate
+#'   first, then a probe of the compiled routine. The C++ path and the R
+#'   fallback can differ per draw, so the resolved backend has to be part of
+#'   the cache key.
+#' @return *\[logical\]* `TRUE` when the C++ implementation will run.
+#' @keywords internal
+uses_cpp_backend <- function() {
+  if (!isTRUE(getOption("artma.methods.p_hacking_tests.simulate_cdfs.use_cpp", TRUE))) {
+    return(FALSE)
+  }
+  tryCatch(
+    {
+      simulate_cdfs_block_cpp(matrix(0, nrow = 1, ncol = 1))
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+}
+
+#' @title Fingerprint the simulation implementation
+#' @description Hash the two source files that define the simulation (the R
+#'   module and the C++ kernel) together with the package version, so a fix to
+#'   the simulation invalidates previously cached tables. Each file is hashed
+#'   against its own directory, keeping the fingerprint independent of the
+#'   checkout location. The C++ source does not ship with installed packages;
+#'   the package version stands in for it there.
+#' @return *\[list\]* Named hash components for the cache key.
+#' @keywords internal
+implementation_fingerprint <- function() {
+  r_source <- file.path(MODULE_DIR, "elliott.R")
+  cpp_source <- file.path(dirname(PATHS$PACKAGE_PATH), "src", "elliott_cdfs.cpp")
+  list(
+    r = hash_source_files(r_source, root = dirname(r_source)),
+    cpp = if (file.exists(cpp_source)) {
+      hash_source_files(cpp_source, root = dirname(cpp_source))
+    } else {
+      NA_character_
+    },
+    package_version = as.character(utils::packageVersion("artma"))
+  )
+}
+
+#' @title Read the session RNG state
+#' @return *\[integer|NULL\]* The current `.Random.seed`, or `NULL` when the
+#'   session has not used the RNG yet.
+#' @keywords internal
+current_rng_state <- function() {
+  if (!exists(".Random.seed", envir = globalenv(), inherits = FALSE)) {
+    return(NULL)
+  }
+  get(".Random.seed", envir = globalenv(), inherits = FALSE)
+}
+
+#' @title Restore a previously captured session RNG state
+#' @param state *\[integer|NULL\]* A `.Random.seed` vector, or `NULL` to leave
+#'   the session state untouched.
+#' @return `NULL`, invisibly.
+#' @keywords internal
+restore_rng_state <- function(state) {
+  if (!is.null(state)) {
+    assign(".Random.seed", state, envir = globalenv()) # nolint: object_name_linter.
+  }
+  invisible(NULL)
+}
+
+#' @title Build a cached variant of `simulate_cdfs_parallel()`
+#' @description
+#' Wrap `sim_fun` in a disk cache keyed narrowly on the inputs that determine
+#' the simulated table: iteration count, grid size, seed, RNG kind, the
+#' resolved backend, and the implementation fingerprint. Scheduling arguments
+#' (workers, block size, progress display) cannot change the result, so they
+#' stay out of the key and are forwarded out of band.
+#'
+#' A `NULL` seed deliberately consumes the caller's RNG state and is never
+#' cached. `options(artma.cache.use_cache = FALSE)` bypasses the cache like
+#' everywhere else in the cache layer; `cache_cli()` reads it on every call.
+#'
+#' A cold run stores, next to the simulated values, the RNG state the
+#' simulation left behind; a cache hit restores that state. Downstream draws
+#' therefore do not depend on whether the cache was warm.
+#' @param cache *\[cachem cache, optional\]* Cache to store results in.
+#'   Defaults to the shared filesystem cache under `PATHS$DIR_USR_CACHE`.
+#' @param sim_fun *\[function, optional\]* The simulation implementation,
+#'   injectable for tests. Defaults to `simulate_cdfs_parallel`.
+#' @return *\[function\]* A drop-in replacement for
+#'   `simulate_cdfs_parallel()`.
+make_simulate_cdfs_cached <- function(cache = NULL, sim_fun = simulate_cdfs_parallel) {
+  # Scheduling arguments travel to the worker through this environment rather
+  # than as arguments: `memoise` hashes every argument of the memoised call,
+  # and these must not fragment the cache key.
+  scheduling <- new.env(parent = emptyenv())
+
+  simulate_for_key <- function(key) {
+    values <- sim_fun(
+      iterations = key$iterations,
+      grid_points = key$grid_points,
+      workers = scheduling$workers,
+      block_size = scheduling$block_size,
+      show_progress = scheduling$show_progress,
+      seed = key$seed
+    )
+    list(values = values, rng_state = current_rng_state())
+  }
+
+  cached_simulate <- cache_cli(
+    simulate_for_key,
+    extra_keys = list(stage = STAGE),
+    cache = cache,
+    # The key covers every input the result depends on, so the TTL backstop
+    # for silently edited data files does not apply here.
+    max_age = Inf
+  )
+
+  function(iterations = 10000,
+           grid_points = 10000,
+           workers = NULL,
+           block_size = 256L,
+           show_progress = TRUE,
+           seed = NULL) {
+    if (is.null(seed)) {
+      # A NULL seed consumes the caller's RNG state; serving those draws from
+      # cache would silently repeat them.
+      return(sim_fun(
+        iterations = iterations,
+        grid_points = grid_points,
+        workers = workers,
+        block_size = block_size,
+        show_progress = show_progress,
+        seed = NULL
+      ))
+    }
+
+    scheduling$workers <- workers
+    scheduling$block_size <- block_size
+    scheduling$show_progress <- show_progress
+
+    key <- list(
+      stage = STAGE,
+      iterations = as.integer(iterations),
+      grid_points = as.integer(grid_points),
+      seed = as.integer(seed),
+      rng_kind = RNGkind(),
+      use_cpp = uses_cpp_backend(),
+      implementation = implementation_fingerprint()
+    )
+
+    result <- cached_simulate(key)
+    restore_rng_state(result$rng_state)
+    result$values
+  }
+}
+
+# The production instance backing `run_p_hacking_tests()`, built once at
+# module load so the memoised layer persists for the session.
+simulate_cdfs_cached <- make_simulate_cdfs_cached()
+
+box::export(
+  make_simulate_cdfs_cached,
+  simulate_cdfs_cached
+)

--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -15,7 +15,6 @@ box::use(
     significance_mark
   ],
   artma / calc / methods / elliott[
-    simulate_cdfs_parallel,
     binomial_test,
     lcm_test,
     fisher_test,
@@ -23,6 +22,7 @@ box::use(
     cox_shi_test,
     skipped_result
   ],
+  artma / calc / methods / elliott_cache[simulate_cdfs_cached],
   artma / calc / methods / maive[maive],
   artma / libs / core / utils[get_verbosity]
 )
@@ -853,10 +853,11 @@ run_p_hacking_tests <- function(df, options) {
   if (options$include_elliott) {
     elliott_tests <- list()
 
-    # Pre-simulate CDFs for LCM test
+    # Pre-simulate CDFs for the LCM test; with a fixed seed the table is
+    # served from its own narrow disk cache (see elliott_cache.R)
     cdfs_reason <- NULL
     cdfs <- tryCatch(
-      simulate_cdfs_parallel(
+      simulate_cdfs_cached(
         iterations = options$lcm_iterations,
         grid_points = options$lcm_grid_points,
         block_size = options$simulate_cdfs_chunk_size,

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -603,6 +603,7 @@ test_that("run_p_hacking_tests dedupes duplicated caliper thresholds/widths with
 test_that("run_p_hacking_tests runs the Elliott suite when requested", {
   local_options(
     artma.verbose = 1,
+    artma.cache.use_cache = FALSE,
     artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
   )
   set.seed(202)
@@ -623,7 +624,7 @@ test_that("run_p_hacking_tests runs the Elliott suite when requested", {
 # Skip reasons ---------------------------------------------------------------
 
 test_that("run_p_hacking_tests records a skip reason when the CDF simulation yields no draws", {
-  local_options(artma.verbose = 1)
+  local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
   df <- make_p_hacking_df()
 
   result <- run_p_hacking_tests(
@@ -643,7 +644,7 @@ test_that("run_p_hacking_tests records a skip reason when the CDF simulation yie
 })
 
 test_that("run_p_hacking_tests records a skip reason for a singular Cox-Shi covariance", {
-  local_options(artma.verbose = 1)
+  local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
   set.seed(404, kind = "Mersenne-Twister", normal.kind = "Inversion")
   t_stats <- abs(stats::rnorm(300, mean = 1, sd = 1))
   df <- data.frame(effect = t_stats, se = rep(1, length(t_stats)))
@@ -726,7 +727,7 @@ test_that("simulate_cdfs_parallel is reproducible when seed is passed explicitly
 })
 
 test_that("run_p_hacking_tests produces identical LCM p-values across two runs", {
-  local_options(artma.verbose = 1)
+  local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
   df <- make_p_hacking_df()
   opts <- base_p_hacking_options(
     include_caliper = FALSE,
@@ -924,6 +925,7 @@ test_that("run_cox_shi preserves the skip reason for the caller to record", {
 test_that("run_p_hacking_tests reports numeric Cox-Shi rows on clustered data", {
   local_options(
     artma.verbose = 1,
+    artma.cache.use_cache = FALSE,
     artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
   )
   panel <- cox_shi_panel(202)

--- a/tests/testthat/test-elliott-cdfs-cache.R
+++ b/tests/testthat/test-elliott-cdfs-cache.R
@@ -1,0 +1,140 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_identical,
+    expect_length,
+    expect_true,
+    skip_if_not,
+    test_that
+  ],
+  withr[local_options, local_tempdir],
+  artma / calc / methods / elliott[simulate_cdfs_block_cpp, simulate_cdfs_parallel],
+  artma / calc / methods / elliott_cache[make_simulate_cdfs_cached]
+)
+
+# Deterministic, quiet defaults for every test: the R fallback keeps results
+# identical across platforms, and caching stays on unless a test disables it.
+local_sim_options <- function(env = parent.frame()) {
+  local_options(
+    list(
+      artma.verbose = 1,
+      artma.cache.use_cache = TRUE,
+      artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
+    ),
+    .local_envir = env
+  )
+}
+
+# A cached instance backed by an ephemeral disk cache, with a wrapper that
+# counts how many times the real simulation runs.
+new_cached_instance <- function(env = parent.frame()) {
+  counter <- new.env(parent = emptyenv())
+  counter$calls <- 0L
+  counting_sim <- function(...) {
+    counter$calls <- counter$calls + 1L
+    simulate_cdfs_parallel(...)
+  }
+  cache <- memoise::cache_filesystem(local_tempdir(.local_envir = env))
+  list(
+    simulate = make_simulate_cdfs_cached(cache = cache, sim_fun = counting_sim),
+    calls = function() counter$calls,
+    cache = cache
+  )
+}
+
+test_that("a warm cache returns the identical vector without re-simulating", {
+  local_sim_options()
+  inst <- new_cached_instance()
+
+  cold <- inst$simulate(iterations = 4, grid_points = 24, show_progress = FALSE, seed = 123)
+  expect_equal(inst$calls(), 1L)
+  expect_length(inst$cache$keys(), 1L)
+
+  warm <- inst$simulate(iterations = 4, grid_points = 24, show_progress = FALSE, seed = 123)
+  expect_equal(inst$calls(), 1L)
+  expect_identical(warm, cold)
+  expect_length(inst$cache$keys(), 1L)
+})
+
+test_that("a cache hit leaves the session RNG where a cold run would", {
+  local_sim_options()
+  inst <- new_cached_instance()
+
+  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 42)
+  after_cold <- stats::rnorm(2)
+
+  # Scramble the session RNG so only the restored state can line the draws up.
+  set.seed(999)
+  stats::runif(5)
+
+  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 42)
+  expect_equal(inst$calls(), 1L)
+  after_warm <- stats::rnorm(2)
+
+  expect_identical(after_warm, after_cold)
+})
+
+test_that("seed = NULL bypasses the cache and consumes the caller's RNG state", {
+  local_sim_options()
+  inst <- new_cached_instance()
+
+  set.seed(7)
+  first <- inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE)
+  second <- inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE)
+
+  expect_equal(inst$calls(), 2L)
+  expect_length(inst$cache$keys(), 0L)
+  expect_true(any(first != second))
+})
+
+test_that("disabling artma.cache.use_cache bypasses the cache at call time", {
+  local_sim_options()
+  inst <- new_cached_instance()
+
+  local_options(list(artma.cache.use_cache = FALSE))
+  first <- inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
+  second <- inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
+
+  expect_equal(inst$calls(), 2L)
+  expect_length(inst$cache$keys(), 0L)
+  expect_identical(first, second)
+})
+
+test_that("the cache key separates seeds, iteration counts, and grid sizes", {
+  local_sim_options()
+  inst <- new_cached_instance()
+
+  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
+  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 124)
+  inst$simulate(iterations = 4, grid_points = 20, show_progress = FALSE, seed = 123)
+  inst$simulate(iterations = 3, grid_points = 24, show_progress = FALSE, seed = 123)
+
+  expect_equal(inst$calls(), 4L)
+  expect_length(inst$cache$keys(), 4L)
+
+  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
+  expect_equal(inst$calls(), 4L)
+})
+
+test_that("the cache key separates the compiled backend from the R fallback", {
+  cpp_available <- tryCatch(
+    {
+      simulate_cdfs_block_cpp(matrix(0, nrow = 1, ncol = 1))
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+  skip_if_not(cpp_available, "compiled simulate_cdfs backend is unavailable")
+
+  local_options(list(artma.verbose = 1, artma.cache.use_cache = TRUE))
+  inst <- new_cached_instance()
+
+  local_options(list(artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = TRUE))
+  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
+  expect_equal(inst$calls(), 1L)
+
+  local_options(list(artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE))
+  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
+  expect_equal(inst$calls(), 2L)
+  expect_length(inst$cache$keys(), 2L)
+})


### PR DESCRIPTION
## Summary

`simulate_cdfs_parallel()` simulates the null distribution behind the LCM p-hacking test. Its result depends only on the iteration count, grid size, seed, RNG kind, and the simulation implementation, never on the data. Until now it was cached only through the method-level cache, whose signature includes the data source path and mtime, the data config, and the whole `artma.*` option group, so any data or unrelated option change re-ran the whole simulation.

This PR gives the simulated table its own disk cache keyed on exactly the inputs that determine it.

## Design

- New module `inst/artma/calc/methods/elliott_cache.R` wraps the simulation in the existing `cache_cli()` layer with `max_age = Inf` (the key covers every input, so the TTL backstop for silently edited data files does not apply here).
- Cache key: iterations, grid points, seed, `RNGkind()`, the resolved backend (C++ vs R fallback, which can differ per draw), and an implementation fingerprint: a hash of `elliott.R`, a hash of `src/elliott_cdfs.cpp` when present, and the package version (the C++ source does not ship in installed packages, so the version stands in for it there).
- Scheduling arguments (workers, block size, progress display) cannot change the result and stay out of the key; they reach the worker out of band.
- `seed = NULL` deliberately consumes the caller's RNG state and always bypasses the cache. `options(artma.cache.use_cache = FALSE)` is honored at call time like the rest of the cache layer.
- A cold run stores the RNG state the simulation leaves behind; a cache hit restores it. Downstream draws (for example Cox-Shi optimisation restarts) therefore do not depend on whether the cache was warm.
- `run_p_hacking_tests()` now calls the cached wrapper. `simulate_cdfs_parallel()` itself is untouched apart from one added export line, kept additive on purpose so the pending fix to the R fallback's knot indexing merges cleanly whichever lands first.

## Tests

- New `test-elliott-cdfs-cache.R`: a warm hit returns the identical vector without re-simulating (counted via an injected simulation function and an ephemeral disk cache), `seed = NULL` bypass, `use_cache = FALSE` bypass, key sensitivity across seed, iterations, and grid points, C++ vs R fallback key split, and RNG state parity between warm and cold runs.
- The Elliott-enabled integration tests now set `artma.cache.use_cache = FALSE` so unit tests never touch the real user cache.
- `make lint` clean; full suite `FAIL 0 | PASS 2020` (the 9 warnings are the pre-existing clubSandwich ones in the MAIVE tests).

## Measured effect

On this machine, compiled path: 3000x3000 cold 0.8s, 10000x10000 cold 7.5s; warm hits take about 10ms at both sizes and return bit-identical values.

## Note for the maintainer

With this cache in place, raising the `lcm_iterations` / `lcm_grid_points` defaults from 3000 toward the canonical 10000x10000 of Elliott et al. (2022) becomes a one-time cost per seed and implementation (about 7s compiled here) instead of a per-run cost. Defaults are left unchanged in this PR; that call is yours.
