### PR TITLE
fix(data): abort on colliding column-rename targets

### DIFF
--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -75,7 +75,7 @@ get_number_of_studies <- function(df) {
 #' @return *\[data.frame\]* The standardized data frame
 standardize_column_names <- function(df, auto_detect = TRUE) {
   box::use(
-    artma / libs / core / validation[validate],
+    artma / libs / core / validation[validate, assert],
     artma / libs / core / utils[get_verbosity]
   )
 
@@ -160,12 +160,45 @@ standardize_column_names <- function(df, auto_detect = TRUE) {
 
   # Rename columns to standardized names - only when present in the data frame
   reverse_map <- stats::setNames(names(map), unlist(map))
+  rename_from <- names(df)[names(df) %in% names(reverse_map)]
+  rename_to <- unname(reverse_map[rename_from])
+
+  # A rename target already occupied by a different column would otherwise
+  # silently produce two columns sharing a name; `df$<name>` would then return
+  # whichever comes first, ignoring the user's explicit mapping. Detect this
+  # before renaming and abort, except for the two cases where no collision
+  # actually results: an identity mapping (source == target, a no-op), or the
+  # occupying column being renamed away itself in this same pass.
+  for (i in seq_along(rename_from)) {
+    source_col <- rename_from[[i]]
+    target_col <- rename_to[[i]]
+
+    if (identical(source_col, target_col)) next
+    if (!target_col %in% names(df)) next
+    if (target_col %in% rename_from) next
+
+    if (identical(df[[source_col]], df[[target_col]])) {
+      # Byte-identical duplicate: drop the stale column quietly and proceed.
+      df[[target_col]] <- NULL
+      next
+    }
+
+    cli::cli_abort(c(
+      "x" = "Cannot map {.val {source_col}} to standard column {.val {target_col}}: the data frame already has a different column named {.val {target_col}}.",
+      "i" = "Resolve this by remapping {.val {target_col}} to a different source column, removing that mapping (e.g. via {.code artma::config.set()} or your options file), or renaming the raw {.val {target_col}} column in your data."
+    ))
+  }
+
   names(df)[names(df) %in% names(reverse_map)] <- reverse_map[names(df)[names(df) %in% names(reverse_map)]]
 
   missing_required <- setdiff(required_colnames, colnames(df))
   if (length(missing_required)) {
     cli::cli_abort("Failed to standardize the following columns: {.val {missing_required}}")
   }
+
+  assert(!anyDuplicated(names(df)), cli::format_inline(
+    "Standardization produced duplicated column names: {.val {names(df)[duplicated(names(df))]}}"
+  ))
 
   df
 }

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -1,5 +1,5 @@
 box::use(
-  testthat[expect_error, expect_true, test_that]
+  testthat[expect_equal, expect_error, expect_false, expect_true, test_that]
 )
 
 box::use(
@@ -163,4 +163,91 @@ test_that("standardize_column_names passes when all required columns are present
     NA,
     info = "Standardizing column names should pass when all required columns are present"
   )
+})
+
+# -- Rename-target collision --
+#
+# Reproduces a real bug: a role mapping (e.g. study_id -> study_name) targets a
+# standard name that the data frame already has under a *different* column.
+# Renaming used to silently produce two columns named "study_id", so
+# `df$study_id` returned whichever came first in column order regardless of
+# the user's mapping. standardize_column_names() must abort instead.
+
+#' Build a synthetic data frame with the required columns plus one extra
+#' column that can collide with a rename target.
+#' @keywords internal
+build_collision_df <- function(extra_col_name, extra_col_values) {
+  df <- data.frame(
+    study_id = 1:5,
+    effect = c(0.1, 0.2, 0.3, 0.4, 0.5),
+    se = c(0.01, 0.02, 0.03, 0.04, 0.05),
+    n_obs = c(50L, 60L, 70L, 80L, 90L)
+  )
+  df[[extra_col_name]] <- extra_col_values
+  df
+}
+
+test_that("standardize_column_names aborts when a rename target is already occupied", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  # study_id is mapped to study_name, but the data frame already has its own,
+  # different study_id column.
+  mock_df <- build_collision_df("study_name", paste("Study", 1:5))
+
+  withr::with_options(
+    list("artma.data.columns" = list(study_id = list(source_name = "study_name"))),
+    {
+      expect_error(
+        standardize_column_names(mock_df, auto_detect = FALSE),
+        "already has a different column named"
+      )
+    }
+  )
+})
+
+test_that("standardize_column_names allows an identity mapping through quietly", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  mock_df <- build_collision_df("study_size", 1:5)
+
+  withr::with_options(
+    list("artma.data.columns" = list(study_id = list(source_name = "study_id"))),
+    {
+      standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+      expect_equal(anyDuplicated(colnames(standardized_df)), 0)
+      expect_true("study_id" %in% colnames(standardized_df))
+    }
+  )
+})
+
+test_that("standardize_column_names drops a byte-identical duplicate target column quietly", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  # study_name is byte-identical to study_id, so the collision is safe to
+  # resolve without user input: the stale duplicate is dropped.
+  mock_df <- build_collision_df("study_name", 1:5)
+
+  withr::with_options(
+    list("artma.data.columns" = list(study_id = list(source_name = "study_name"))),
+    {
+      standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+      expect_equal(sum(colnames(standardized_df) == "study_id"), 1)
+      expect_equal(standardized_df$study_id, 1:5)
+    }
+  )
+})
+
+test_that("standardize_column_names still performs normal renames without collision", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  mock_colnames <- MOCKS$create_mock_options_colnames(
+    colnames = list(study_id = "study_id_raw")
+  )
+  FIXTURES$with_custom_colnames(mock_colnames)
+  mock_df <- MOCKS$create_mock_df(colnames_map = mock_colnames)
+
+  standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+  expect_equal(anyDuplicated(colnames(standardized_df)), 0)
+  expect_true("study_id" %in% colnames(standardized_df))
+  expect_false("study_id_raw" %in% colnames(standardized_df))
 })


### PR DESCRIPTION
## Summary

`standardize_column_names()` renamed source columns onto standard names with no collision check. When a mapping (e.g. `study_id: {source_name: study_name}`) targets a standard name the data frame already has under a different column, the rename silently produced two columns sharing a name. `df$study_id` then returned whichever came first in column order, ignoring the mapping entirely, with no warning.

## Changes

- `standardize_column_names()` (inst/artma/data/utils.R) now detects a rename target already occupied by a different column and aborts with a clear message naming both columns and how to resolve it, except:
  - identity mappings (source == target): no-op, passes through
  - byte-identical duplicate columns: the stale duplicate is dropped quietly
- Added a final invariant asserting no duplicated column names survive standardization (defense in depth).
- Audited every other path that assigns column names in the data pipeline (schema_reconcile.R, interactive_mapping.R, smart_detection.R, column_recognition.R): all renames ultimately funnel through this one chokepoint, so no other fix was needed.
- Added tests: collision aborts, identity mapping passes, byte-identical duplicate resolves quietly, normal renames still work with no duplicated names.

## For the user

Your `master-thesis.yaml` options file maps `study_id` to `source_name: study_name` while your xlsm data has both a `study_id` and a `study_name` column. After this fix, that run will abort instead of silently using the wrong column. To fix it, either:
- remove the `source_name: study_name` line under `study_id` in the yaml (keep the existing `study_id` column as-is), or
- rename/drop the raw `study_id` column in your data if you want `study_name` used as the study identifier instead.

## Test plan

- [x] `make test-file FILE=test-data-utils.R` passes (30/30)
- [x] `make test` passes (2009 passed, 0 failed; pre-existing MAIVE warnings unrelated to this change)
- [x] `make lint` passes with no lints
- [x] Manually reproduced against the user's real options file + xlsm data: confirmed it now aborts with the expected message instead of silently mis-mapping