### PR TITLE
fix(options): merge nested user_input safely and validate before overwrite

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -444,7 +444,7 @@ options.load <- function(
 #' @param options_file_name *\[character, optional\]* Name of the user options file to modify, including the suffix.
 #' @param options_dir *\[character, optional\]* Full path to the folder that contains user options files. If not provided, the default folder is chosen. Defaults to `NULL`.
 #' @param template_path *\[character, optional\]* Full path to the options template file. Defaults to `NULL`.
-#' @param user_input *\[list, optional\]* A named list of user-supplied values for these options. If `NULL` or missing entries exist, the function will prompt the user via `readline()` (for required entries) or use defaults (for optional ones).
+#' @param user_input *\[list, optional\]* A named list of user-supplied values for these options, using either flat dotted-path names (e.g. `list("data.source_path" = "...")`, matching what `options.load(load_with_prefix = FALSE)` returns) or nested lists that mirror the YAML structure (e.g. `list(data = list(source_path = "..."))`); both are flattened against the template before merging, so a partial edit to a list-type option (e.g. one entry of `data.columns`) is merged into the existing value instead of replacing it. If `NULL` or missing entries exist, the function will prompt the user via `readline()` (for required entries) or use defaults (for optional ones).
 #' @param should_validate *\[logical, optional\]* If TRUE, validate the modified options file against the template. Defaults to TRUE.
 #' @return `NULL`
 #' @export
@@ -461,6 +461,8 @@ options.modify <- function(
       ask_for_options_to_modify
     ],
     artma / libs / core / validation[assert, validate],
+    artma / options / files[resolve_template_path],
+    artma / options / template[collect_leaf_paths, flatten_user_options],
     artma / options / utils[validate_user_input]
   )
 
@@ -490,7 +492,15 @@ options.modify <- function(
 
   validate_user_input(user_input)
 
-  new_options <- utils::modifyList(current_options, user_input)
+  # current_options is keyed by flat dotted paths (options.load(load_with_prefix
+  # = FALSE)). Flattening user_input against the same leaf set turns either a
+  # nested user_input or an already-flat one into that representation, so
+  # modifyList() merges into the matching key instead of adding a sibling
+  # top-level key that later clobbers it (see flat_to_nested()).
+  leaf_set <- collect_leaf_paths(resolve_template_path(template_path))
+  flat_user_input <- flatten_user_options(user_options = user_input, leaf_set = leaf_set)
+
+  new_options <- utils::modifyList(current_options, flat_user_input)
 
   options.create(
     options_file_name = options_file_name,
@@ -814,7 +824,7 @@ options.fix <- function(
 #' @param options_file_name *\[character\]* Name of the new user options file, including the suffix.
 #' @param options_dir *\[character, optional\]* Full path to the folder that contains user options files. If not provided, the default folder is chosen. Defaults to `NULL`.
 #' @param template_path *\[character, optional\]* Full path to the options template file.
-#' @param user_input *\[list, optional\]* A named list of user-supplied values for these options. If `NULL` or missing entries exist, the function will prompt the user via `readline()` (for required entries) or use defaults (for optional ones).
+#' @param user_input *\[list, optional\]* A named list of user-supplied values for these options, using either flat dotted-path names (e.g. `list("data.source_path" = "...")`) or nested lists that mirror the YAML structure (e.g. `list(data = list(source_path = "..."))`). When overwriting an existing file, a partial edit to a list-type option (e.g. one entry of `data.columns`) is merged into the existing value instead of replacing it. If `NULL` or missing entries exist, the function will prompt the user via `readline()` (for required entries) or use defaults (for optional ones).
 #' @param should_validate *\[logical, optional\]* If TRUE, validate the new options file against the template. Defaults to TRUE.
 #' @param should_overwrite *\[logical, optional\]* If TRUE, overwrite the file if it already exists. Defaults to FALSE, in which case the user is prompted to confirm the overwrite.
 #' @param action_name *\[character, optional\]* A name for the action being performed. This is used for logging purposes. Defaults to "create".
@@ -897,23 +907,42 @@ options.create <- function(
     }
     leaf_set <- collect_leaf_paths(template_path)
     current_options <- flatten_user_options(user_options = read_options_file(options_path), leaf_set = leaf_set)
-    utils::modifyList(current_options, user_input)
+    # Flatten user_input against the same leaf set so a nested user_input (or
+    # a partial edit to a list-type option) merges into the matching flat key
+    # instead of adding a colliding sibling that flat_to_nested() later
+    # overwrites the flat entries with (see options.modify()).
+    flat_user_input <- flatten_user_options(user_options = user_input, leaf_set = leaf_set)
+    utils::modifyList(current_options, flat_user_input)
   }
 
   nested_options <- flat_to_nested(parsed_options)
 
-  write_options_file(options_path, nested_options)
-
   if (should_validate) {
+    # Validate a temporary copy before touching the real file: options.validate()
+    # can abort, and if it did after the real file was already overwritten, a
+    # previously valid options file would be left corrupted on disk with no
+    # way back.
+    tmp_path <- tempfile(
+      pattern = paste0(tools::file_path_sans_ext(options_file_name), "-"),
+      tmpdir = options_dir,
+      fileext = ".yaml"
+    )
+    write_options_file(tmp_path, nested_options)
+    on.exit(if (file.exists(tmp_path)) file.remove(tmp_path), add = TRUE)
+
     withr::with_options(
       list("artma.verbose" = min(get_verbosity(), 2)),
       options.validate(
-        options_file_name = options_file_name,
+        options_file_name = basename(tmp_path),
         options_dir = options_dir,
         template_path = template_path,
         failure_action = "abort_verbose"
       )
     )
+
+    file.copy(tmp_path, options_path, overwrite = TRUE)
+  } else {
+    write_options_file(options_path, nested_options)
   }
 
   if (get_verbosity() >= 3) {

--- a/man/options.create.Rd
+++ b/man/options.create.Rd
@@ -21,7 +21,7 @@ options.create(
 
 \item{template_path}{\emph{[character, optional]} Full path to the options template file.}
 
-\item{user_input}{\emph{[list, optional]} A named list of user-supplied values for these options. If \code{NULL} or missing entries exist, the function will prompt the user via \code{readline()} (for required entries) or use defaults (for optional ones).}
+\item{user_input}{\emph{[list, optional]} A named list of user-supplied values for these options, using either flat dotted-path names (e.g. \code{list("data.source_path" = "...")}) or nested lists that mirror the YAML structure (e.g. \code{list(data = list(source_path = "..."))}). When overwriting an existing file, a partial edit to a list-type option (e.g. one entry of \code{data.columns}) is merged into the existing value instead of replacing it. If \code{NULL} or missing entries exist, the function will prompt the user via \code{readline()} (for required entries) or use defaults (for optional ones).}
 
 \item{should_validate}{\emph{[logical, optional]} If TRUE, validate the new options file against the template. Defaults to TRUE.}
 

--- a/man/options.modify.Rd
+++ b/man/options.modify.Rd
@@ -19,7 +19,7 @@ options.modify(
 
 \item{template_path}{\emph{[character, optional]} Full path to the options template file. Defaults to \code{NULL}.}
 
-\item{user_input}{\emph{[list, optional]} A named list of user-supplied values for these options. If \code{NULL} or missing entries exist, the function will prompt the user via \code{readline()} (for required entries) or use defaults (for optional ones).}
+\item{user_input}{\emph{[list, optional]} A named list of user-supplied values for these options, using either flat dotted-path names (e.g. \code{list("data.source_path" = "...")}, matching what \code{options.load(load_with_prefix = FALSE)} returns) or nested lists that mirror the YAML structure (e.g. \code{list(data = list(source_path = "..."))}); both are flattened against the template before merging, so a partial edit to a list-type option (e.g. one entry of \code{data.columns}) is merged into the existing value instead of replacing it. If \code{NULL} or missing entries exist, the function will prompt the user via \code{readline()} (for required entries) or use defaults (for optional ones).}
 
 \item{should_validate}{\emph{[logical, optional]} If TRUE, validate the modified options file against the template. Defaults to TRUE.}
 }

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -399,6 +399,130 @@ test_that("options.load backfills defaults when loading without prefix", {
   expect_equal(loaded$data.winsorization_level, 0)
 })
 
+test_that("options.modify merges a nested user_input into a list-type option without dropping siblings", {
+  box::use(artma[options.modify])
+
+  tmp_dir <- withr::local_tempdir()
+  template_path <- file.path(tmp_dir, "template.yaml")
+
+  template <- list(
+    data = list(
+      source_path = list(
+        type = "character",
+        default = "",
+        help = "Path to the data source"
+      ),
+      na_handling = list(
+        type = "character",
+        default = "stop",
+        help = "How to handle missing values"
+      ),
+      columns = list(
+        type = "list",
+        default = NA,
+        allow_na = TRUE,
+        help = "Per-column configuration"
+      )
+    ),
+    methods = list(
+      p_hacking_tests = list(
+        caliper_tail = list(
+          type = "character",
+          default = "two_sided",
+          help = "Which tail to test"
+        ),
+        caliper_cluster = list(
+          type = "logical",
+          default = TRUE,
+          help = "Whether to cluster"
+        )
+      )
+    )
+  )
+  yaml::write_yaml(template, template_path)
+
+  original <- list(
+    data = list(
+      source_path = "old.csv",
+      na_handling = "stop",
+      columns = list(
+        a = list(source_name = "A"),
+        b = list(source_name = "B"),
+        c = list(source_name = "C")
+      )
+    ),
+    methods = list(
+      p_hacking_tests = list(
+        caliper_tail = "two_sided",
+        caliper_cluster = TRUE
+      )
+    )
+  )
+  yaml::write_yaml(original, file.path(tmp_dir, "user.yaml"))
+
+  options.modify(
+    options_file_name = "user.yaml",
+    options_dir = tmp_dir,
+    template_path = template_path,
+    user_input = list(
+      data = list(
+        source_path = "new.csv",
+        columns = list(a = list(source_name = "A2"))
+      )
+    ),
+    should_validate = TRUE
+  )
+
+  modified <- yaml::read_yaml(file.path(tmp_dir, "user.yaml"))
+
+  # The requested edits landed...
+  expect_equal(modified$data$source_path, "new.csv")
+  expect_equal(modified$data$columns$a$source_name, "A2")
+
+  # ...without dropping sibling data.* keys, other data.columns entries, or an
+  # unrelated top-level section.
+  expect_equal(modified$data$na_handling, "stop")
+  expect_equal(modified$data$columns$b$source_name, "B")
+  expect_equal(modified$data$columns$c$source_name, "C")
+  expect_equal(modified$methods$p_hacking_tests$caliper_tail, "two_sided")
+  expect_true(modified$methods$p_hacking_tests$caliper_cluster)
+})
+
+test_that("options.modify leaves the file untouched when the modified options fail validation", {
+  box::use(artma[options.modify])
+
+  tmp_dir <- withr::local_tempdir()
+  template_path <- file.path(tmp_dir, "template.yaml")
+
+  template <- list(
+    data = list(
+      threshold = list(
+        type = "integer",
+        default = 10L,
+        help = "Numeric threshold"
+      )
+    )
+  )
+  yaml::write_yaml(template, template_path)
+
+  original <- list(data = list(threshold = 4L))
+  options_path <- file.path(tmp_dir, "user.yaml")
+  yaml::write_yaml(original, options_path)
+  original_contents <- readLines(options_path)
+
+  expect_error(
+    options.modify(
+      options_file_name = "user.yaml",
+      options_dir = tmp_dir,
+      template_path = template_path,
+      user_input = list("data.threshold" = "not-a-number"),
+      should_validate = TRUE
+    )
+  )
+
+  expect_identical(readLines(options_path), original_contents)
+})
+
 test_that("options.list includes files with the .yml suffix", {
   box::use(artma[options.list])
 


### PR DESCRIPTION
## Summary
- `options.modify()`/`options.create()` merged raw `user_input` directly against the flat dotted-key list returned by `options.load(load_with_prefix = FALSE)`. A nested `user_input` (e.g. `list(data = list(source_path = "...", columns = list(effect = ...)))`) added a colliding top-level `data` key instead of merging into the existing `data.*` keys; `flat_to_nested()` then processed that plain `data` key last and overwrote everything built from the flat `data.*` entries, silently dropping sibling options (`data.na_handling`, other `data.columns` entries, unrelated `methods.*` keys, etc).
- Both functions now flatten `user_input` against the template's leaf set before merging, so nested and flat dotted-key `user_input` both work, and a partial edit to a list-type option (like one `data.columns` entry) merges into the existing value instead of replacing it.
- `options.create()` previously wrote the new YAML to disk *before* validating it, so a failed validation left a corrupted file with no way back. It now writes to a temp file, validates that, and only copies it over the real file once validation passes (or writes directly when `should_validate = FALSE`).
- Updated the `user_input` docs on both functions to describe the accepted formats.

## Test plan
- [x] Added a regression test reproducing the reported bug (nested `user_input` editing one `data.columns` entry) and asserting sibling `data.*` keys, other columns, and an unrelated `methods.*` section survive.
- [x] Added a regression test asserting a validation failure leaves the options file byte-for-byte untouched.
- [x] `make test` (2054 passed, 0 failed)
- [x] `make lint`
- [x] `styler::style_file()` on changed files