### PR TITLE
refactor(options): one option type registry for coerce and validate

### DIFF
--- a/inst/artma/options/template.R
+++ b/inst/artma/options/template.R
@@ -346,7 +346,7 @@ coerce_option_value <- function(val, opt) {
   box::use(
     artma / const[CONST],
     artma / libs / core / utils[get_verbosity],
-    artma / options / utils[parse_template_enum_value]
+    artma / options / type_registry[get_option_type_spec]
   )
 
   # If the value is NULL, there's nothing to coerce
@@ -354,61 +354,24 @@ coerce_option_value <- function(val, opt) {
     return(val)
   }
 
-  if (length(val) == 1 && is.na(val) && isTRUE(opt$allow_na)) {
+  spec <- get_option_type_spec(opt$type)
+  na_allowed <- isTRUE(opt$allow_na) && isTRUE(spec$allows_na)
+
+  if (length(val) == 1 && is.na(val) && na_allowed) {
     return(val)
   }
 
   enforce_na_allowed <- function(v) {
-    if (any(is.na(v)) && !isTRUE(opt$allow_na)) {
+    if (any(is.na(v)) && !na_allowed) {
       cli::cli_abort("Option {CONST$STYLES$OPTIONS$NAME(opt$name)} does not allow NA values.")
     }
   }
 
-  abort_coercion <- function(expected_type) {
-    cli::cli_abort(c(
-      "Cannot coerce option {CONST$STYLES$OPTIONS$NAME(opt$name)} to {CONST$STYLES$OPTIONS$TYPE(expected_type)}.",
-      "x" = "Raw value: {CONST$STYLES$OPTIONS$VALUE(val)}."
-    ))
-  }
-
   enforce_na_allowed(val)
 
-  # Enumerations, e.g. "enum: red|blue|green": coerce to character and validate membership.
-  if (startsWith(opt$type, "enum:")) {
-    coerced_val <- as.character(val)
-    valid_values <- parse_template_enum_value(opt$type)
-    if (!all(coerced_val %in% valid_values)) {
-      cli::cli_abort(c(
-        "Option {CONST$STYLES$OPTIONS$NAME(opt$name)} must be one of {.emph {toString(valid_values)}}.",
-        "x" = "Got: {CONST$STYLES$OPTIONS$VALUE(val)}."
-      ))
-    }
-    return(coerced_val)
-  }
-
-  coerce_numeric <- function(expected_type, as_fun) {
-    coerced <- suppressWarnings(as_fun(val))
-    # Coercion that manufactures NA out of a non-NA value is a failure, not a
-    # silent downgrade: surface it with the option name and raw value.
-    if (any(is.na(coerced) & !is.na(val))) {
-      abort_coercion(expected_type)
-    }
-    coerced
-  }
-
-  coerced_val <- switch(opt$type,
-    character = as.character(val),
-    integer = {
-      if (!is.numeric(val)) abort_coercion("integer")
-      non_na <- val[!is.na(val)]
-      if (any(non_na != as.integer(non_na))) abort_coercion("integer")
-      as.integer(val)
-    },
-    logical = coerce_numeric("logical", as.logical),
-    numeric = coerce_numeric("numeric", as.numeric),
-    list = as.list(val),
-    val
-  )
+  # Per-type coercion (character/integer/logical/numeric/list/enum) lives in the
+  # option type registry, shared with validate_option_value.
+  coerced_val <- spec$coerce(val, opt)
 
   if (isTRUE(opt$standardize) && opt$type == "character") {
     standard_val <- make.names(coerced_val)

--- a/inst/artma/options/type_registry.R
+++ b/inst/artma/options/type_registry.R
@@ -1,0 +1,157 @@
+#' @title Option type registry
+#' @description Single source of truth mapping each option type name to its
+#'   coercion, validation, and NA capability. Both `coerce_option_value`
+#'   (options/template.R) and `validate_option_value` (options/utils.R) resolve a
+#'   type spec from here instead of carrying their own parallel `switch`, so the
+#'   two paths cannot drift apart.
+#'
+#'   A spec is a list with three fields:
+#'   \itemize{
+#'     \item `coerce(val, opt)`: return the value cast to the type, aborting
+#'       (fail-loud) when the raw value cannot be represented.
+#'     \item `validate(val, opt_name, opt_type)`: return an error string when the
+#'       value does not match the type, or `NULL` when it does.
+#'     \item `allows_na`: whether the type can hold `NA` at all. Combined with the
+#'       option-level `allow_na` flag by the callers, so NA is permitted only when
+#'       both agree. Every current type allows NA, keeping the option-level flag
+#'       the effective gate.
+#'   }
+#'
+#'   The coerce and validate paths are intentionally asymmetric for some types
+#'   (e.g. `logical` coerces strings via `as.logical` but validation demands an
+#'   already-logical value); the registry captures those asymmetries per field
+#'   rather than smoothing them over.
+
+box::use(
+  artma / const[CONST]
+)
+
+# Abort helper shared by the numeric-family coercers.
+abort_option_coercion <- function(opt, expected_type, val) {
+  cli::cli_abort(c(
+    "Cannot coerce option {CONST$STYLES$OPTIONS$NAME(opt$name)} to {CONST$STYLES$OPTIONS$TYPE(expected_type)}.",
+    "x" = "Raw value: {CONST$STYLES$OPTIONS$VALUE(val)}."
+  ))
+}
+
+# Cast via `as_fun`, treating "manufactured NA out of a non-NA value" as a
+# failure rather than a silent downgrade.
+coerce_via_cast <- function(val, opt, expected_type, as_fun) {
+  coerced <- suppressWarnings(as_fun(val))
+  if (any(is.na(coerced) & !is.na(val))) {
+    abort_option_coercion(opt, expected_type, val)
+  }
+  coerced
+}
+
+# Uniform validation-error formatter.
+format_type_error <- function(opt_name, expected_type, val) {
+  cli::format_inline("Option {CONST$STYLES$OPTIONS$NAME(opt_name)} must be {CONST$STYLES$OPTIONS$TYPE(expected_type)}, got: {CONST$STYLES$OPTIONS$VALUE(val)}")
+}
+
+option_type_registry <- list(
+  character = list(
+    allows_na = TRUE,
+    coerce = function(val, opt) as.character(val),
+    validate = function(val, opt_name, opt_type) {
+      if (!is.character(val)) format_type_error(opt_name, "character", val)
+    }
+  ),
+  integer = list(
+    allows_na = TRUE,
+    coerce = function(val, opt) {
+      if (!is.numeric(val)) abort_option_coercion(opt, "integer", val)
+      non_na <- val[!is.na(val)]
+      if (any(non_na != as.integer(non_na))) abort_option_coercion(opt, "integer", val)
+      as.integer(val)
+    },
+    validate = function(val, opt_name, opt_type) {
+      if (!is.numeric(val) || any(val != as.integer(val), na.rm = TRUE)) {
+        format_type_error(opt_name, "integer", val)
+      }
+    }
+  ),
+  logical = list(
+    allows_na = TRUE,
+    coerce = function(val, opt) coerce_via_cast(val, opt, "logical", as.logical),
+    validate = function(val, opt_name, opt_type) {
+      if (!is.logical(val)) format_type_error(opt_name, "logical", val)
+    }
+  ),
+  numeric = list(
+    allows_na = TRUE,
+    coerce = function(val, opt) coerce_via_cast(val, opt, "numeric", as.numeric),
+    validate = function(val, opt_name, opt_type) {
+      if (!is.numeric(val)) format_type_error(opt_name, "numeric", val)
+    }
+  ),
+  list = list(
+    allows_na = TRUE,
+    coerce = function(val, opt) as.list(val),
+    validate = function(val, opt_name, opt_type) NULL
+  ),
+  enum = list(
+    allows_na = TRUE,
+    coerce = function(val, opt) {
+      box::use(artma / options / utils[parse_template_enum_value])
+      coerced_val <- as.character(val)
+      valid_values <- parse_template_enum_value(opt$type)
+      if (!all(coerced_val %in% valid_values)) {
+        cli::cli_abort(c(
+          "Option {CONST$STYLES$OPTIONS$NAME(opt$name)} must be one of {.emph {toString(valid_values)}}.",
+          "x" = "Got: {CONST$STYLES$OPTIONS$VALUE(val)}."
+        ))
+      }
+      coerced_val
+    },
+    validate = function(val, opt_name, opt_type) {
+      box::use(artma / options / utils[parse_template_enum_value])
+      valid_values <- parse_template_enum_value(opt_type)
+      if (!val %in% valid_values) {
+        cli::format_inline(
+          "Option {CONST$STYLES$OPTIONS$NAME(opt_name)} must be one of {.emph {toString(valid_values)}}; got {CONST$STYLES$OPTIONS$VALUE(val)}."
+        )
+      }
+    }
+  )
+)
+
+# Spec used for any type name not in the registry: pass the value through
+# unchanged on coerce and treat it as always valid, matching the historical
+# `switch` default arms in both callers.
+passthrough_type_spec <- list(
+  allows_na = TRUE,
+  coerce = function(val, opt) val,
+  validate = function(val, opt_name, opt_type) NULL
+)
+
+#' @title Resolve the registry key for an option type
+#' @description Normalize a template type string to a registry key. Every
+#'   `enum: a|b|c` collapses to the single `enum` key; all other types map to
+#'   themselves.
+#' @param opt_type *\[character\]* The template-declared option type.
+#' @return *\[character\]* The registry key.
+resolve_option_type_key <- function(opt_type) {
+  if (startsWith(opt_type, "enum:")) {
+    return("enum")
+  }
+  opt_type
+}
+
+#' @title Get the type spec for an option type
+#' @description Return the `{coerce, validate, allows_na}` spec for a template
+#'   type string, falling back to a pass-through spec for unknown types.
+#' @param opt_type *\[character\]* The template-declared option type.
+#' @return *\[list\]* The type spec.
+get_option_type_spec <- function(opt_type) {
+  spec <- option_type_registry[[resolve_option_type_key(opt_type)]]
+  if (is.null(spec)) {
+    return(passthrough_type_spec)
+  }
+  spec
+}
+
+box::export(
+  get_option_type_spec,
+  resolve_option_type_key
+)

--- a/inst/artma/options/utils.R
+++ b/inst/artma/options/utils.R
@@ -152,43 +152,26 @@ get_expected_type <- function(opt_def) {
 validate_option_value <- function(val, opt_type, opt_name, allow_na = FALSE) {
   box::use(
     artma / const[CONST],
-    artma / libs / core / validation[validate]
+    artma / libs / core / validation[validate],
+    artma / options / type_registry[get_option_type_spec]
   )
 
   validate(is.character(opt_type), is.character(opt_name)) # 'allow_na' can be NULL
 
-  # Helper function for uniform error formatting:
-  format_error <- function(opt_name, expected_type, val) {
-    cli::format_inline("Option {CONST$STYLES$OPTIONS$NAME(opt_name)} must be {CONST$STYLES$OPTIONS$TYPE(expected_type)}, got: {CONST$STYLES$OPTIONS$VALUE(val)}")
-  }
+  spec <- get_option_type_spec(opt_type)
+  na_allowed <- isTRUE(allow_na) && isTRUE(spec$allows_na)
 
   if (is.null(val) || (length(val) == 1 && is.na(val))) {
-    if (!isTRUE(allow_na)) {
+    if (!na_allowed) {
       return(cli::format_inline("Option {CONST$STYLES$OPTIONS$NAME(opt_name)} cannot be NULL or NA."))
     }
     return(NULL) # NA/NULL is allowed
   }
 
-  # Handle enumerations, e.g. "enum: red|blue|green"
-  if (startsWith(opt_type, "enum:")) {
-    valid_values <- parse_template_enum_value(opt_type)
-    if (!val %in% valid_values) {
-      return(
-        cli::format_inline(
-          "Option {CONST$STYLES$OPTIONS$NAME(opt_name)} must be one of {.emph {toString(valid_values)}}; got {CONST$STYLES$OPTIONS$VALUE(val)}."
-        )
-      )
-    }
-    return(NULL)
-  }
-
-  switch(opt_type,
-    character = if (!is.character(val)) format_error(opt_name, "character", val),
-    integer = if (!is.numeric(val) || any(val != as.integer(val), na.rm = TRUE)) format_error(opt_name, "integer", val),
-    logical = if (!is.logical(val)) format_error(opt_name, "logical", val),
-    numeric = if (!is.numeric(val)) format_error(opt_name, "numeric", val),
-    NULL
-  )
+  # Per-type validation (character/integer/logical/numeric/enum, pass-through for
+  # anything else) lives in the option type registry, shared with
+  # coerce_option_value.
+  spec$validate(val, opt_name, opt_type)
 }
 
 #' @title Validate user input

--- a/tests/testthat/test-options-type-registry.R
+++ b/tests/testthat/test-options-type-registry.R
@@ -1,0 +1,186 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_identical,
+    expect_null,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
+  artma / options / template[coerce_option_value],
+  artma / options / utils[validate_option_value],
+  artma / options / type_registry[get_option_type_spec, resolve_option_type_key]
+)
+
+# Build a minimal option definition for the coerce path.
+opt_def <- function(type, allow_na = FALSE, name = "test.option", ...) {
+  list(name = name, type = type, allow_na = allow_na, ...)
+}
+
+test_that("resolve_option_type_key collapses enum and passes others through", {
+  expect_equal(resolve_option_type_key("enum: a|b|c"), "enum")
+  expect_equal(resolve_option_type_key("character"), "character")
+  expect_equal(resolve_option_type_key("mystery"), "mystery")
+})
+
+test_that("get_option_type_spec returns a spec for known types and pass-through otherwise", {
+  for (type in c("character", "integer", "logical", "numeric", "list", "enum: a|b")) {
+    spec <- get_option_type_spec(type)
+    expect_true(is.function(spec$coerce))
+    expect_true(is.function(spec$validate))
+    expect_true(isTRUE(spec$allows_na))
+  }
+  passthrough <- get_option_type_spec("unknown_type")
+  expect_equal(passthrough$coerce(42, opt_def("unknown_type")), 42)
+  expect_null(passthrough$validate(42, "test.option", "unknown_type"))
+})
+
+# ---- character ----
+
+test_that("character type: valid / invalid / NA / NULL through both paths", {
+  # valid
+  expect_equal(coerce_option_value("hello", opt_def("character")), "hello")
+  expect_null(validate_option_value("hello", "character", "test.option"))
+  # coerce is permissive (casts), validate is strict about the incoming type
+  expect_equal(coerce_option_value(5, opt_def("character")), "5")
+  expect_false(is.null(validate_option_value(5, "character", "test.option")))
+  # NA
+  expect_error(coerce_option_value(NA, opt_def("character")), "does not allow NA")
+  expect_equal(coerce_option_value(NA, opt_def("character", allow_na = TRUE)), NA)
+  expect_false(is.null(validate_option_value(NA, "character", "test.option")))
+  expect_null(validate_option_value(NA, "character", "test.option", allow_na = TRUE))
+  # NULL
+  expect_null(coerce_option_value(NULL, opt_def("character")))
+  expect_false(is.null(validate_option_value(NULL, "character", "test.option")))
+  expect_null(validate_option_value(NULL, "character", "test.option", allow_na = TRUE))
+})
+
+# ---- integer ----
+
+test_that("integer type: valid / invalid / NA / NULL through both paths", {
+  expect_identical(coerce_option_value(3, opt_def("integer")), 3L)
+  expect_null(validate_option_value(3L, "integer", "test.option"))
+  expect_null(validate_option_value(3, "integer", "test.option"))
+  # fractional is invalid on both paths
+  expect_error(coerce_option_value(3.7, opt_def("integer")), "integer")
+  expect_false(is.null(validate_option_value(3.7, "integer", "test.option")))
+  # non-numeric is invalid on both paths
+  expect_error(coerce_option_value("x", opt_def("integer")), "integer")
+  expect_false(is.null(validate_option_value("x", "integer", "test.option")))
+  # NA
+  expect_error(coerce_option_value(NA, opt_def("integer")), "does not allow NA")
+  expect_equal(coerce_option_value(NA, opt_def("integer", allow_na = TRUE)), NA)
+  expect_false(is.null(validate_option_value(NA, "integer", "test.option")))
+  expect_null(validate_option_value(NA, "integer", "test.option", allow_na = TRUE))
+  # NULL
+  expect_null(coerce_option_value(NULL, opt_def("integer")))
+  expect_false(is.null(validate_option_value(NULL, "integer", "test.option")))
+})
+
+# ---- logical ----
+
+test_that("logical type: valid / invalid / NA / NULL through both paths", {
+  expect_true(coerce_option_value(TRUE, opt_def("logical")))
+  expect_null(validate_option_value(TRUE, "logical", "test.option"))
+  # coerce casts a string via as.logical; validate demands an actual logical
+  expect_true(coerce_option_value("TRUE", opt_def("logical")))
+  expect_false(is.null(validate_option_value("TRUE", "logical", "test.option")))
+  # a string that as.logical cannot parse fails the coerce path (manufactured NA)
+  expect_error(coerce_option_value("notlogical", opt_def("logical")), "logical")
+  expect_false(is.null(validate_option_value(5, "logical", "test.option")))
+  # NA
+  expect_error(coerce_option_value(NA, opt_def("logical")), "does not allow NA")
+  expect_equal(coerce_option_value(NA, opt_def("logical", allow_na = TRUE)), NA)
+  expect_false(is.null(validate_option_value(NA, "logical", "test.option")))
+  expect_null(validate_option_value(NA, "logical", "test.option", allow_na = TRUE))
+  # NULL
+  expect_null(coerce_option_value(NULL, opt_def("logical")))
+  expect_false(is.null(validate_option_value(NULL, "logical", "test.option")))
+})
+
+# ---- numeric ----
+
+test_that("numeric type: valid / invalid / NA / NULL through both paths", {
+  expect_equal(coerce_option_value("3.5", opt_def("numeric")), 3.5)
+  expect_equal(coerce_option_value(3.5, opt_def("numeric")), 3.5)
+  expect_null(validate_option_value(3.5, "numeric", "test.option"))
+  # coerce parses a numeric string; validate rejects the string type
+  expect_false(is.null(validate_option_value("3.5", "numeric", "test.option")))
+  # non-numeric string fails coerce (manufactured NA)
+  expect_error(coerce_option_value("abc", opt_def("numeric")), "numeric")
+  expect_false(is.null(validate_option_value("abc", "numeric", "test.option")))
+  # NA
+  expect_error(coerce_option_value(NA, opt_def("numeric")), "does not allow NA")
+  expect_equal(coerce_option_value(NA, opt_def("numeric", allow_na = TRUE)), NA)
+  expect_false(is.null(validate_option_value(NA, "numeric", "test.option")))
+  expect_null(validate_option_value(NA, "numeric", "test.option", allow_na = TRUE))
+  # NULL
+  expect_null(coerce_option_value(NULL, opt_def("numeric")))
+  expect_false(is.null(validate_option_value(NULL, "numeric", "test.option")))
+})
+
+# ---- list ----
+
+test_that("list type: coerce casts, validate always passes non-NA values", {
+  expect_equal(coerce_option_value(c(1, 2), opt_def("list")), list(1, 2))
+  # validate has no list arm and treats any non-NA value as valid
+  expect_null(validate_option_value(list(1, 2), "list", "test.option"))
+  expect_null(validate_option_value(5, "list", "test.option"))
+  # NA
+  expect_error(coerce_option_value(NA, opt_def("list")), "does not allow NA")
+  expect_equal(coerce_option_value(NA, opt_def("list", allow_na = TRUE)), NA)
+  expect_false(is.null(validate_option_value(NA, "list", "test.option")))
+  # NULL
+  expect_null(coerce_option_value(NULL, opt_def("list")))
+  expect_false(is.null(validate_option_value(NULL, "list", "test.option")))
+})
+
+# ---- enum ----
+
+test_that("enum type: valid / invalid / NA / NULL through both paths", {
+  enum_type <- "enum: ask|auto|strict"
+  expect_equal(coerce_option_value("auto", opt_def(enum_type)), "auto")
+  expect_null(validate_option_value("auto", enum_type, "test.option"))
+  # invalid membership fails both paths with the "must be one of" message
+  expect_error(coerce_option_value("nonsense", opt_def(enum_type)), "must be one of")
+  expect_false(is.null(validate_option_value("nonsense", enum_type, "test.option")))
+  # NA
+  expect_error(coerce_option_value(NA, opt_def(enum_type)), "does not allow NA")
+  expect_false(is.null(validate_option_value(NA, enum_type, "test.option")))
+  expect_null(validate_option_value(NA, enum_type, "test.option", allow_na = TRUE))
+  # NULL
+  expect_null(coerce_option_value(NULL, opt_def(enum_type)))
+  expect_false(is.null(validate_option_value(NULL, enum_type, "test.option")))
+})
+
+# ---- unknown type (pass-through) ----
+
+test_that("unknown type passes through coerce and validate", {
+  expect_equal(coerce_option_value("anything", opt_def("date")), "anything")
+  expect_null(validate_option_value("anything", "date", "test.option"))
+  expect_error(coerce_option_value(NA, opt_def("date")), "does not allow NA")
+  expect_null(coerce_option_value(NULL, opt_def("date")))
+})
+
+# ---- vector NA handling (guards the #321 / #323 regression) ----
+
+test_that("vector-valued options honor allow_na without the length-1 coercion error", {
+  # A vector containing NA is rejected when NA is not allowed.
+  expect_error(
+    coerce_option_value(c(1, NA), opt_def("numeric")),
+    "does not allow NA"
+  )
+  # When NA is allowed the vector passes through intact (no length-3 coercion crash).
+  expect_equal(
+    coerce_option_value(c(1, NA), opt_def("numeric", allow_na = TRUE)),
+    c(1, NA)
+  )
+  expect_equal(
+    coerce_option_value(c(1L, 2L, 3L), opt_def("integer")),
+    c(1L, 2L, 3L)
+  )
+})


### PR DESCRIPTION
## What moved

Introduces `inst/artma/options/type_registry.R`: a single registry mapping each option type name to `{coerce, validate, allows_na}`. Both option paths now resolve their per-type behavior from it:

- `coerce_option_value` (`inst/artma/options/template.R`) dropped its inline `enum:` branch and `switch(opt$type, ...)` over character/integer/logical/numeric/list; it now calls `spec$coerce(val, opt)`.
- `validate_option_value` (`inst/artma/options/utils.R`) dropped its inline `enum:` branch and `switch(opt_type, ...)`; it now calls `spec$validate(val, opt_name, opt_type)`.

The two `switch` statements previously duplicated the type list and could drift; there is now one source of truth. Unknown types keep their historical pass-through behavior (coerce returns the value unchanged, validate returns `NULL`) via a shared pass-through spec.

## What changed behavior

Nothing. The registry preserves every existing asymmetry between the two paths on purpose:

- `logical` coerces strings through `as.logical` but validation still requires an already-logical value.
- `numeric` coerces numeric strings but validation still rejects the string type.
- `list` coerces via `as.list` while validation has no list arm (any non-NA value is valid).
- `enum` coerces to a validated character while validation only returns an error or `NULL`.

NA/NULL prologue logic (the #321 bug 1 area fixed in #323) stays in each caller unchanged: coerce still filters vector-internal NA via `enforce_na_allowed` using `any(is.na(...))`, and the length-1 scalar-NA early return is retained, so vector-valued options (e.g. caliper thresholds) do not regress. The registry `allows_na` field is TRUE for every current type, so effective NA permission remains driven by the option-level `allow_na` flag.

## Tests that pin the outputs

New `tests/testthat/test-options-type-registry.R` runs the full matrix: every type (character, integer, logical, numeric, list, enum, and an unknown pass-through type) crossed with {valid value, invalid value, NA, NULL} through both the coerce and validate paths, plus a vector-NA case guarding the #321/#323 fix. Existing `test-options-strict.R` coerce/validate assertions still pass unchanged.

Refs #322 (item B4).