### PR TITLE
refactor(data): shared column profiler in data/profile.R

### DIFF
--- a/inst/artma/data/column_recognition.R
+++ b/inst/artma/data/column_recognition.R
@@ -1,3 +1,7 @@
+box::use(
+  artma / data / profile[profile_column]
+)
+
 #' Single home for every confidence threshold the column-matching engine uses.
 #' Both the recognition flow (options creation, auto-detection) and the schema
 #' reconciliation flow (rename proposals) read from this list, so the
@@ -240,69 +244,12 @@ match_column_name <- function(col_name, patterns) {
 
 
 #' @title Analyze column values to determine semantic type
-#' @description Analyzes actual data values to help discriminate between ambiguous column matches
+#' @description Analyzes actual data values to help discriminate between
+#'   ambiguous column matches. Thin re-export of the shared
+#'   `data/profile.R::profile_column` profiler.
 #' @param values *\[vector\]* Column values to analyze
 #' @return *\[list\]* Analysis results with various heuristics
-analyze_column_values <- function(values) {
-  # Remove NA values for analysis
-  values_clean <- values[!is.na(values)]
-
-  if (length(values_clean) == 0) {
-    return(list(
-      is_sequential = FALSE,
-      is_unique = FALSE,
-      is_numeric = FALSE,
-      uniqueness_ratio = 0,
-      mean = NA,
-      variance = NA,
-      min = NA,
-      max = NA
-    ))
-  }
-
-  # Check if numeric (coercible to numeric)
-  is_numeric <- is.numeric(values_clean) || !any(is.na(suppressWarnings(as.numeric(values_clean))))
-  numeric_values <- if (is_numeric) {
-    if (is.numeric(values_clean)) values_clean else as.numeric(values_clean)
-  } else {
-    numeric(0)
-  }
-
-  # Sequential pattern detection (like 1, 2, 3, 4, 5...)
-  is_sequential <- FALSE
-  if (is_numeric && length(numeric_values) >= 3) {
-    diffs <- diff(numeric_values)
-    # Check if differences are constant (allowing for some tolerance)
-    is_sequential <- all(abs(diffs - diffs[1]) < 1e-10) && abs(diffs[1] - 1) < 1e-10
-  }
-
-  # Uniqueness analysis
-  is_unique <- length(unique(values_clean)) == length(values_clean)
-  uniqueness_ratio <- length(unique(values_clean)) / length(values_clean)
-
-  # Statistical properties
-  stats <- if (is_numeric && length(numeric_values) > 0) {
-    list(
-      mean = mean(numeric_values, na.rm = TRUE),
-      variance = stats::var(numeric_values, na.rm = TRUE),
-      min = min(numeric_values, na.rm = TRUE),
-      max = max(numeric_values, na.rm = TRUE)
-    )
-  } else {
-    list(mean = NA, variance = NA, min = NA, max = NA)
-  }
-
-  list(
-    is_sequential = is_sequential,
-    is_unique = is_unique,
-    is_numeric = is_numeric,
-    uniqueness_ratio = uniqueness_ratio,
-    mean = stats$mean,
-    variance = stats$variance,
-    min = stats$min,
-    max = stats$max
-  )
-}
+analyze_column_values <- profile_column
 
 
 #' @title Detect if a column is likely a numeric identifier

--- a/inst/artma/data/na_handling.R
+++ b/inst/artma/data/na_handling.R
@@ -201,7 +201,7 @@ handle_na_interpolate <- function(df) {
 #' @return *\[data.frame\]* The data frame with imputed values
 #' @keywords internal
 handle_na_mice <- function(df) {
-  box::use(artma / variable / detection[detect_dummy_groups])
+  box::use(artma / data / profile[detect_dummy_groups])
 
   if (!requireNamespace("mice", quietly = TRUE)) {
     cli::cli_abort(c(

--- a/inst/artma/data/profile.R
+++ b/inst/artma/data/profile.R
@@ -1,0 +1,230 @@
+#' @title Shared column profiler
+#' @description
+#' Single home for the value-level column profiling primitives used across the
+#' package: numeric/uniqueness/variance/sequential profiling (`profile_column`),
+#' the binary-column predicate (`is_binary_column`), and the dummy-group
+#' detector (`detect_dummy_groups`). Living in `data/` lets both the data
+#' pipeline (`data/na_handling.R`, `data/column_recognition.R`) and the variable
+#' layer (`variable/detection.R`, `variable/suggestion.R`) share one
+#' implementation without the data layer importing from `variable/`.
+
+box::use(
+  artma / libs / core / validation[validate]
+)
+
+#' @title Profile column values to determine semantic properties
+#' @description Analyzes actual data values to help discriminate between
+#'   ambiguous column matches. Reports numeric-ness, sequential pattern,
+#'   uniqueness, and basic statistics.
+#' @param values *\[vector\]* Column values to analyze
+#' @return *\[list\]* Analysis results with various heuristics
+#' @export
+profile_column <- function(values) {
+  # Remove NA values for analysis
+  values_clean <- values[!is.na(values)]
+
+  if (length(values_clean) == 0) {
+    return(list(
+      is_sequential = FALSE,
+      is_unique = FALSE,
+      is_numeric = FALSE,
+      uniqueness_ratio = 0,
+      mean = NA,
+      variance = NA,
+      min = NA,
+      max = NA
+    ))
+  }
+
+  # Check if numeric (coercible to numeric)
+  is_numeric <- is.numeric(values_clean) || !any(is.na(suppressWarnings(as.numeric(values_clean))))
+  numeric_values <- if (is_numeric) {
+    if (is.numeric(values_clean)) values_clean else as.numeric(values_clean)
+  } else {
+    numeric(0)
+  }
+
+  # Sequential pattern detection (like 1, 2, 3, 4, 5...)
+  is_sequential <- FALSE
+  if (is_numeric && length(numeric_values) >= 3) {
+    diffs <- diff(numeric_values)
+    # Check if differences are constant (allowing for some tolerance)
+    is_sequential <- all(abs(diffs - diffs[1]) < 1e-10) && abs(diffs[1] - 1) < 1e-10
+  }
+
+  # Uniqueness analysis
+  is_unique <- length(unique(values_clean)) == length(values_clean)
+  uniqueness_ratio <- length(unique(values_clean)) / length(values_clean)
+
+  # Statistical properties
+  stats <- if (is_numeric && length(numeric_values) > 0) {
+    list(
+      mean = mean(numeric_values, na.rm = TRUE),
+      variance = stats::var(numeric_values, na.rm = TRUE),
+      min = min(numeric_values, na.rm = TRUE),
+      max = max(numeric_values, na.rm = TRUE)
+    )
+  } else {
+    list(mean = NA, variance = NA, min = NA, max = NA)
+  }
+
+  list(
+    is_sequential = is_sequential,
+    is_unique = is_unique,
+    is_numeric = is_numeric,
+    uniqueness_ratio = uniqueness_ratio,
+    mean = stats$mean,
+    variance = stats$variance,
+    min = stats$min,
+    max = stats$max
+  )
+}
+
+
+#' @title Detect if a column is a binary (0/1 or TRUE/FALSE) column
+#' @description A column is binary when it has exactly two distinct non-missing
+#'   values, both drawn from `{0, 1, TRUE, FALSE}`. On numeric input this is
+#'   equivalent to requiring both values to be in `{0, 1}` (the logical values
+#'   coerce to the same numerics), so it preserves the semantics of both the
+#'   dummy-group detector and the variable-suggestion binary branch.
+#' @param values *\[vector\]* Column values to test
+#' @return *\[logical\]* TRUE if the column is binary
+#' @export
+is_binary_column <- function(values) {
+  vals <- unique(values[!is.na(values)])
+  length(vals) == 2 && all(vals %in% c(0, 1, TRUE, FALSE))
+}
+
+
+#' Empty group-detection result skeleton
+#'
+#' @return Zero-row data frame with the group-detection columns
+#' @keywords internal
+#' @export
+empty_group_df <- function() {
+  data.frame(
+    var_name = character(0),
+    group_id = character(0),
+    group_type = character(0),
+    group_base = character(0),
+    is_reference = logical(0),
+    stringsAsFactors = FALSE
+  )
+}
+
+#' Build a single group-detection result row
+#'
+#' @keywords internal
+#' @export
+group_row <- function(var_name, group_id, group_type, group_base, is_reference) {
+  data.frame(
+    var_name = var_name,
+    group_id = group_id,
+    group_type = group_type,
+    group_base = group_base,
+    is_reference = is_reference,
+    stringsAsFactors = FALSE
+  )
+}
+
+#' Bind group-detection rows, returning the empty skeleton when there are none
+#'
+#' @keywords internal
+#' @export
+bind_group_rows <- function(results) {
+  if (length(results)) do.call(rbind, results) else empty_group_df()
+}
+
+
+#' Detect dummy variable groups
+#'
+#' @description
+#' Identifies groups of dummy (binary 0/1) variables that share a common prefix,
+#' suggesting they represent categories of the same underlying variable.
+#'
+#' @param var_names *\[character\]* Vector of variable names
+#' @param df *\[data.frame\]* Data frame to check if variables are binary
+#'
+#' @return Data frame with group information for dummy variables
+#'
+#' @keywords internal
+#' @export
+detect_dummy_groups <- function(var_names, df) {
+  validate(is.character(var_names), is.data.frame(df))
+
+  results <- list()
+
+  # Find variables with common prefixes
+  binary_vars <- var_names[vapply(var_names, function(var_name) {
+    if (!var_name %in% names(df)) {
+      return(FALSE)
+    }
+    is_binary_column(df[[var_name]])
+  }, logical(1))]
+
+  if (!length(binary_vars)) {
+    return(empty_group_df())
+  }
+
+  # Extract potential base names (everything before last underscore)
+  extract_base <- function(name) {
+    parts <- strsplit(name, "_")[[1]]
+    if (length(parts) > 1) {
+      paste(parts[-length(parts)], collapse = "_")
+    } else {
+      NA_character_
+    }
+  }
+
+  bases <- vapply(binary_vars, extract_base, character(1))
+  base_table <- table(bases[!is.na(bases)])
+
+  # Only consider groups with 2+ variables
+  valid_bases <- names(base_table)[base_table >= 2]
+
+  if (!length(valid_bases)) {
+    return(empty_group_df())
+  }
+
+  for (base in valid_bases) {
+    group_vars <- binary_vars[!is.na(bases) & bases == base]
+
+    # Try to detect reference variable (often has "other", "ref", "base" suffix)
+    ref_patterns <- c("other", "ref", "reference", "base", "baseline")
+    is_ref <- rep(FALSE, length(group_vars))
+
+    for (i in seq_along(group_vars)) {
+      suffix <- tolower(sub(paste0("^", base, "_"), "", group_vars[i]))
+      if (suffix %in% ref_patterns) {
+        is_ref[i] <- TRUE
+      }
+    }
+
+    # If no explicit reference, mark the first as reference
+    if (!any(is_ref) && length(group_vars) > 0) {
+      is_ref[1] <- TRUE
+    }
+
+    for (i in seq_along(group_vars)) {
+      results[[length(results) + 1]] <- group_row(
+        var_name = group_vars[i],
+        group_id = paste0("dummy_", base),
+        group_type = "dummy",
+        group_base = base,
+        is_reference = is_ref[i]
+      )
+    }
+  }
+
+  bind_group_rows(results)
+}
+
+
+box::export(
+  profile_column,
+  is_binary_column,
+  empty_group_df,
+  group_row,
+  bind_group_rows,
+  detect_dummy_groups
+)

--- a/inst/artma/variable/detection.R
+++ b/inst/artma/variable/detection.R
@@ -2,42 +2,19 @@
 #' @description
 #' Provides functionality to automatically detect variable groups in a dataset.
 #' Identifies patterns in data (dummy groups, transformations, etc.).
-
-#' Empty group-detection result skeleton
 #'
-#' @return Zero-row data frame with the group-detection columns
-#' @keywords internal
-empty_group_df <- function() {
-  data.frame(
-    var_name = character(0),
-    group_id = character(0),
-    group_type = character(0),
-    group_base = character(0),
-    is_reference = logical(0),
-    stringsAsFactors = FALSE
-  )
-}
+#' The column-profiling primitives (`empty_group_df`, `group_row`,
+#' `bind_group_rows`, `detect_dummy_groups`) live in `data/profile.R` so the
+#' data layer can reuse them without importing from `variable/`.
 
-#' Build a single group-detection result row
-#'
-#' @keywords internal
-group_row <- function(var_name, group_id, group_type, group_base, is_reference) {
-  data.frame(
-    var_name = var_name,
-    group_id = group_id,
-    group_type = group_type,
-    group_base = group_base,
-    is_reference = is_reference,
-    stringsAsFactors = FALSE
-  )
-}
-
-#' Bind group-detection rows, returning the empty skeleton when there are none
-#'
-#' @keywords internal
-bind_group_rows <- function(results) {
-  if (length(results)) do.call(rbind, results) else empty_group_df()
-}
+box::use(
+  artma / data / profile[
+    empty_group_df,
+    group_row,
+    bind_group_rows,
+    detect_dummy_groups
+  ]
+)
 
 #' Detect variable groups in a dataset
 #'
@@ -169,95 +146,6 @@ detect_variable_groups <- function(df, var_names = NULL, config = NULL) {
   }
 
   groups
-}
-
-
-#' Detect dummy variable groups
-#'
-#' @description
-#' Identifies groups of dummy (binary 0/1) variables that share a common prefix,
-#' suggesting they represent categories of the same underlying variable.
-#'
-#' @param var_names *\[character\]* Vector of variable names
-#' @param df *\[data.frame\]* Data frame to check if variables are binary
-#'
-#' @return Data frame with group information for dummy variables
-#'
-#' @keywords internal
-detect_dummy_groups <- function(var_names, df) {
-  box::use(artma / libs / core / validation[validate])
-
-  validate(is.character(var_names), is.data.frame(df))
-
-  results <- list()
-
-  # Check if variable is binary (0/1 or TRUE/FALSE)
-  is_binary <- function(var_name) {
-    if (!var_name %in% names(df)) {
-      return(FALSE)
-    }
-    vals <- unique(df[[var_name]][!is.na(df[[var_name]])])
-    length(vals) == 2 && all(vals %in% c(0, 1, TRUE, FALSE))
-  }
-
-  # Find variables with common prefixes
-  binary_vars <- var_names[vapply(var_names, is_binary, logical(1))]
-
-  if (!length(binary_vars)) {
-    return(empty_group_df())
-  }
-
-  # Extract potential base names (everything before last underscore)
-  extract_base <- function(name) {
-    parts <- strsplit(name, "_")[[1]]
-    if (length(parts) > 1) {
-      paste(parts[-length(parts)], collapse = "_")
-    } else {
-      NA_character_
-    }
-  }
-
-  bases <- vapply(binary_vars, extract_base, character(1))
-  base_table <- table(bases[!is.na(bases)])
-
-  # Only consider groups with 2+ variables
-  valid_bases <- names(base_table)[base_table >= 2]
-
-  if (!length(valid_bases)) {
-    return(empty_group_df())
-  }
-
-  for (base in valid_bases) {
-    group_vars <- binary_vars[!is.na(bases) & bases == base]
-
-    # Try to detect reference variable (often has "other", "ref", "base" suffix)
-    ref_patterns <- c("other", "ref", "reference", "base", "baseline")
-    is_ref <- rep(FALSE, length(group_vars))
-
-    for (i in seq_along(group_vars)) {
-      suffix <- tolower(sub(paste0("^", base, "_"), "", group_vars[i]))
-      if (suffix %in% ref_patterns) {
-        is_ref[i] <- TRUE
-      }
-    }
-
-    # If no explicit reference, mark the first as reference
-    if (!any(is_ref) && length(group_vars) > 0) {
-      is_ref[1] <- TRUE
-    }
-
-    for (i in seq_along(group_vars)) {
-      results[[length(results) + 1]] <- group_row(
-        var_name = group_vars[i],
-        group_id = paste0("dummy_", base),
-        group_type = "dummy",
-        group_base = base,
-        is_reference = is_ref[i]
-      )
-    }
-  }
-
-  bind_group_rows(results)
 }
 
 

--- a/inst/artma/variable/suggestion.R
+++ b/inst/artma/variable/suggestion.R
@@ -231,7 +231,10 @@ decide_variable_suggestion <- function(var_data, effect_data, data_type,
                                        is_reference, group_type,
                                        min_obs_per_split, min_variance_ratio,
                                        exclude_reference) {
-  box::use(artma / libs / core / validation[validate])
+  box::use(
+    artma / libs / core / validation[validate],
+    artma / data / profile[is_binary_column]
+  )
 
   validate(
     is.numeric(var_data),
@@ -249,8 +252,9 @@ decide_variable_suggestion <- function(var_data, effect_data, data_type,
   unique_vals <- unique(var_data)
   n_unique <- length(unique_vals)
 
-  # DUMMY VARIABLES (binary 0/1)
-  if (data_type == "dummy" || (n_unique == 2 && all(unique_vals %in% c(0, 1)))) {
+  # DUMMY VARIABLES (binary 0/1). var_data is numeric here, so is_binary_column
+  # (which allows 0/1/TRUE/FALSE) is equivalent to the previous 0/1-only test.
+  if (data_type == "dummy" || is_binary_column(var_data)) {
     # Check both splits have sufficient observations
     n_zero <- sum(var_data == 0)
     n_one <- sum(var_data == 1)

--- a/tests/testthat/test-data-profile.R
+++ b/tests/testthat/test-data-profile.R
@@ -1,0 +1,98 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
+  artma / data / profile[
+    profile_column,
+    is_binary_column,
+    detect_dummy_groups
+  ]
+)
+
+# profile_column --------------------------------------------------------------
+
+test_that("profile_column reports sequential numeric patterns", {
+  analysis <- profile_column(1:10)
+
+  expect_true(analysis$is_sequential)
+  expect_true(analysis$is_unique)
+  expect_true(analysis$is_numeric)
+  expect_equal(analysis$uniqueness_ratio, 1.0)
+  expect_equal(analysis$mean, 5.5)
+})
+
+test_that("profile_column drops NA before profiling", {
+  analysis <- profile_column(c(100, NA, 200, NA, 300))
+
+  expect_equal(analysis$mean, 200)
+  expect_equal(analysis$min, 100)
+  expect_equal(analysis$max, 300)
+})
+
+test_that("profile_column returns the empty skeleton for all-NA input", {
+  analysis <- profile_column(c(NA, NA, NA))
+
+  expect_false(analysis$is_sequential)
+  expect_false(analysis$is_unique)
+  expect_false(analysis$is_numeric)
+  expect_equal(analysis$uniqueness_ratio, 0)
+  expect_true(is.na(analysis$mean))
+})
+
+test_that("profile_column treats character columns as non-numeric", {
+  analysis <- profile_column(c("Study A", "Study B", "Study C"))
+
+  expect_false(analysis$is_numeric)
+  expect_true(analysis$is_unique)
+})
+
+# is_binary_column ------------------------------------------------------------
+
+test_that("is_binary_column accepts 0/1 numeric columns", {
+  expect_true(is_binary_column(c(0, 1, 1, 0, 1)))
+})
+
+test_that("is_binary_column accepts logical columns", {
+  expect_true(is_binary_column(c(TRUE, FALSE, TRUE)))
+})
+
+test_that("is_binary_column ignores NA when counting distinct values", {
+  expect_true(is_binary_column(c(0, 1, NA, 1, NA)))
+})
+
+test_that("is_binary_column rejects constant columns", {
+  expect_false(is_binary_column(rep(1, 10)))
+  expect_false(is_binary_column(rep(0, 10)))
+})
+
+test_that("is_binary_column rejects near-binary numerics with a third value", {
+  expect_false(is_binary_column(c(0, 1, 2)))
+})
+
+test_that("is_binary_column rejects all-NA columns", {
+  expect_false(is_binary_column(c(NA, NA)))
+})
+
+# detect_dummy_groups ---------------------------------------------------------
+
+test_that("detect_dummy_groups groups binary columns sharing a prefix", {
+  df <- data.frame(
+    country_usa = c(0, 1, 0, 1),
+    country_uk = c(1, 0, 1, 0),
+    country_other = c(0, 0, 1, 1),
+    numeric_var = c(1, 2, 3, 4)
+  )
+
+  result <- detect_dummy_groups(names(df), df)
+
+  expect_equal(nrow(result), 3)
+  expect_true(all(result$group_id == "dummy_country"))
+  expect_equal(sum(result$is_reference), 1)
+  expect_true(result$is_reference[result$var_name == "country_other"])
+})


### PR DESCRIPTION
## What moved

Introduces `inst/artma/data/profile.R` as the single home for column value profiling, consolidating three previously duplicated implementations:

- `analyze_column_values` (numeric/uniqueness/variance/sequential profiling) moved verbatim into `profile_column`. `column_recognition.R` now imports it and keeps `analyze_column_values` as a thin alias so its public API and tests are unchanged.
- The `is_binary` helper nested inside `detect_dummy_groups` (`variable/detection.R`) and the inline `n_unique == 2 && all(unique_vals %in% c(0, 1))` binary test in `decide_variable_suggestion` (`variable/suggestion.R`) are replaced by one shared `is_binary_column`.
- `detect_dummy_groups` and its row-builder helpers (`empty_group_df`, `group_row`, `bind_group_rows`) moved from `variable/detection.R` into `data/profile.R`. `detection.R` imports and re-exports them, so `variable/*` still resolves.
- `data/na_handling.R` now imports `detect_dummy_groups` from `data/profile` instead of `variable/detection`, fixing the inverted data-imports-variable dependency.

## Edge cases enumerated and preserved

The three implementations disagreed on the binary predicate; the unification preserves every caller's decision:

- `detection::is_binary` allowed `{0, 1, TRUE, FALSE}` on raw columns; `suggestion` allowed only `{0, 1}` but always ran on already-numeric, NA-filtered data. `is_binary_column` allows `{0, 1, TRUE, FALSE}`, which on numeric input is identical to the `{0, 1}` test (logicals coerce to the same numerics), so suggestion behavior is unchanged and detection behavior is unchanged.
- All-NA columns: `profile_column` returns the same all-FALSE/NA skeleton; `is_binary_column` returns FALSE (zero distinct values). Constants: not binary (one distinct value). Near-binary numerics with a third value: not binary (three distinct values). Suggestion's own no_variance / low_variance / ratio / skew branches were left untouched.

## Behavior change

None. Pure extraction, 6 call sites migrated.

## Tests

- New `tests/testthat/test-data-profile.R` pins `profile_column`, `is_binary_column` (0/1, logical, NA, constant, near-binary, all-NA), and `detect_dummy_groups`.
- Existing suites keep the outputs pinned: `test-variable-suggestion.R` (124), `test-data-column-resolution.R` (48), `test-data-column-recognition.R` (87), `test-data-na-handling.R` (11). Full suite: FAIL 0.

Refs #322 (item C6).
