### PR TITLE
refactor(econometric): single robust_vcov helper for the four vcov ladders

### DIFF
--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -16,55 +16,30 @@ box::use(
     format_se,
     format_ci
   ],
-  artma / libs / core / validation[validate, assert]
+  artma / libs / core / validation[validate, assert],
+  artma / econometric / vcov[robust_vcov]
 )
 
 # Robust variance-covariance matrix helper ---------------------------------
 
 #' @title Get robust variance-covariance matrix with fallbacks
 #' @description
-#' Computes robust variance-covariance matrix using multiple fallback strategies
-#' to avoid numerical instability warnings. Tries clustered standard errors first,
-#' then falls back to non-clustered robust standard errors, and finally to standard
-#' variance-covariance matrix.
+#' Thin wrapper over the shared [robust_vcov()] helper pinning this call site's
+#' ladder: clustered HC1, then non-clustered HC1, then HC0, then `stats::vcov`,
+#' with the robust steps run under `suppressWarnings()` and a required cluster.
 #' @param model *[model object]* Regression model (e.g., from AER::ivreg).
 #' @param cluster *[vector]* Clustering variable (e.g., study_id).
 #' @return *[matrix]* Variance-covariance matrix.
 get_robust_vcov <- function(model, cluster) {
-  validate(!is.null(model), !is.null(cluster))
-
-  # Try vcovCL with HC1 (clustered, most stable)
-  vcov_result <- tryCatch(
-    suppressWarnings(sandwich::vcovCL(model, cluster = cluster, type = "HC1")),
-    error = function(e) NULL
+  robust_vcov(
+    model = model,
+    cluster = cluster,
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = c("HC1", "HC0"),
+    require_cluster = TRUE,
+    suppress_warnings = TRUE
   )
-
-  if (!is.null(vcov_result)) {
-    return(vcov_result)
-  }
-
-  # Fall back to vcovHC with HC1 (non-clustered, stable)
-  vcov_result <- tryCatch(
-    suppressWarnings(sandwich::vcovHC(model, type = "HC1")),
-    error = function(e) NULL
-  )
-
-  if (!is.null(vcov_result)) {
-    return(vcov_result)
-  }
-
-  # Fall back to vcovHC with HC0 (less stable but more robust)
-  vcov_result <- tryCatch(
-    suppressWarnings(sandwich::vcovHC(model, type = "HC0")),
-    error = function(e) NULL
-  )
-
-  if (!is.null(vcov_result)) {
-    return(vcov_result)
-  }
-
-  # Last resort: standard vcov
-  stats::vcov(model)
 }
 
 # IV regression utilities --------------------------------------------------

--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -14,7 +14,8 @@ box::use(
     format_number,
     format_se,
     format_ci
-  ]
+  ],
+  artma / econometric / vcov[robust_vcov]
 )
 
 # nocov start: glue/cli heavy formatting helpers ---------------------------
@@ -325,9 +326,13 @@ tidy_from_coeftest <- function(coef_matrix) {
 }
 
 tidy_lm_model <- function(model, data, cluster_column) {
-  vcov <- tryCatch(
-    sandwich::vcovCL(model, cluster = data[[cluster_column]], type = "HC1"),
-    error = function(e) sandwich::vcovHC(model, type = "HC1")
+  vcov <- robust_vcov(
+    model = model,
+    cluster = data[[cluster_column]],
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = "HC1",
+    final_vcov_fallback = FALSE
   )
 
   coef_matrix <- lmtest::coeftest(model, vcov. = vcov)
@@ -343,14 +348,12 @@ tidy_lm_model <- function(model, data, cluster_column) {
 }
 
 tidy_plm_generic <- function(model, data) {
-  vcov <- tryCatch(
-    plm::vcovHC(model, type = "HC1", cluster = "group"),
-    error = function(e) {
-      tryCatch(
-        plm::vcovHC(model, type = "HC0"),
-        error = function(e2) stats::vcov(model)
-      )
-    }
+  vcov <- robust_vcov(
+    model = model,
+    cluster = "group",
+    engine = "plm",
+    clustered_type = "HC1",
+    fallback_types = "HC0"
   )
   coef_matrix <- lmtest::coeftest(model, vcov = vcov)
 
@@ -366,9 +369,13 @@ tidy_plm_generic <- function(model, data) {
 }
 
 tidy_plm_within <- function(model, data) {
-  vcov <- tryCatch(
-    plm::vcovHC(model, type = "HC1", cluster = "group"),
-    error = function(e) plm::vcovHC(model, type = "HC0")
+  vcov <- robust_vcov(
+    model = model,
+    cluster = "group",
+    engine = "plm",
+    clustered_type = "HC1",
+    fallback_types = "HC0",
+    final_vcov_fallback = FALSE
   )
 
   coef_matrix <- lmtest::coeftest(model, vcov = vcov)

--- a/inst/artma/econometric/vcov.R
+++ b/inst/artma/econometric/vcov.R
@@ -1,0 +1,140 @@
+#' @title Robust variance-covariance helper
+#' @description
+#' Single implementation of the "clustered robust vcov, fall back to
+#' non-clustered robust vcov, fall back to the plain model vcov" ladder that
+#' several econometric call sites need. Both the `sandwich` (lm/ivreg) and the
+#' `plm` (panel) engines are supported through the `engine` argument.
+NULL
+
+box::use(
+  artma / libs / core / validation[validate]
+)
+
+#' @title Compute a robust variance-covariance matrix with fallbacks
+#' @description
+#' Runs an ordered ladder of vcov estimators and returns the first that
+#' succeeds. The primary estimator is a clustered robust vcov when a usable
+#' `cluster` is supplied, otherwise a non-clustered robust vcov of the same HC
+#' `clustered_type`. It is followed by the non-clustered HC types listed in
+#' `fallback_types`, and finally by `stats::vcov()` when `final_vcov_fallback`
+#' is `TRUE`. Every step except the last runs under `tryCatch()` and is skipped
+#' on error (or a `NULL` result); the last step runs uncaught so its error
+#' propagates, matching the original call sites.
+#'
+#' The four historical call sites disagreed on the exact ladder, so each
+#' difference is preserved through a parameter:
+#'
+#' * `get_robust_vcov` (exogeneity, ivreg): `engine = "sandwich"`,
+#'   `clustered_type = "HC1"`, `fallback_types = c("HC1", "HC0")`,
+#'   `require_cluster = TRUE`, `suppress_warnings = TRUE`. The intermediate
+#'   non-clustered HC1 step and the warning suppression are unique to this site.
+#' * `resolve_bpe_vcov` (best-practice estimate): `engine = "sandwich"`,
+#'   `clustered_type = "HC0"`, `match_cluster_length = TRUE`, no HC
+#'   `fallback_types`. The cluster is used only when its length equals the
+#'   model's `nobs`; otherwise the primary step is the non-clustered HC0 vcov,
+#'   and the only fallback is `stats::vcov()`.
+#' * `tidy_lm_model` (linear lm specs): `engine = "sandwich"`,
+#'   `clustered_type = "HC1"`, `fallback_types = "HC1"`,
+#'   `final_vcov_fallback = FALSE`. No plain-vcov last resort: if the
+#'   non-clustered HC1 step errors, that error propagates.
+#' * `tidy_plm_generic` / `tidy_plm_within` (linear panel specs):
+#'   `engine = "plm"`, `clustered_type = "HC1"`, `fallback_types = "HC0"`.
+#'   `tidy_plm_generic` keeps the `stats::vcov()` last resort
+#'   (`final_vcov_fallback = TRUE`); `tidy_plm_within` does not
+#'   (`final_vcov_fallback = FALSE`). For `plm`, `cluster` is the panel
+#'   dimension string (e.g. `"group"`) passed straight to `plm::vcovHC()`.
+#'
+#' @param model *[model object]* Fitted model (`lm`, `AER::ivreg`, or `plm`).
+#' @param cluster *[vector or character, optional]* Clustering variable. For
+#'   `engine = "sandwich"` a vector (e.g. `study_id`); for `engine = "plm"` the
+#'   panel dimension string passed to `plm::vcovHC()` (e.g. `"group"`). `NULL`
+#'   means no clustered step is attempted.
+#' @param engine *[character]* `"sandwich"` (default) or `"plm"`.
+#' @param clustered_type *[character]* HC type used for the primary step.
+#'   Defaults to `"HC1"`.
+#' @param fallback_types *[character]* Zero or more non-clustered HC types tried,
+#'   in order, after the primary step. Defaults to none.
+#' @param require_cluster *[logical]* When `TRUE`, `validate()` that both `model`
+#'   and `cluster` are non-`NULL`. Defaults to `FALSE`.
+#' @param match_cluster_length *[logical]* `sandwich` only. When `TRUE`, use the
+#'   cluster only if `length(cluster) == stats::nobs(model)`, otherwise fall
+#'   back to the non-clustered primary step. Defaults to `FALSE`.
+#' @param final_vcov_fallback *[logical]* When `TRUE` (default), append
+#'   `stats::vcov(model)` as the last resort.
+#' @param suppress_warnings *[logical]* When `TRUE`, wrap the robust
+#'   (`sandwich`/`plm`) steps in `suppressWarnings()`. The `stats::vcov()` last
+#'   resort is never suppressed. Defaults to `FALSE`.
+#' @return *[matrix]* A variance-covariance matrix.
+robust_vcov <- function(model,
+                        cluster = NULL,
+                        engine = c("sandwich", "plm"),
+                        clustered_type = "HC1",
+                        fallback_types = character(),
+                        require_cluster = FALSE,
+                        match_cluster_length = FALSE,
+                        final_vcov_fallback = TRUE,
+                        suppress_warnings = FALSE) {
+  engine <- match.arg(engine)
+
+  if (require_cluster) {
+    validate(!is.null(model), !is.null(cluster))
+  }
+
+  use_cluster <- if (is.null(cluster)) {
+    FALSE
+  } else if (match_cluster_length) {
+    length(cluster) == stats::nobs(model)
+  } else {
+    TRUE
+  }
+
+  # A robust (sandwich/plm) vcov step, optionally clustered, wrapped in
+  # suppressWarnings() when requested.
+  robust_step <- function(type, clustered) {
+    force(type)
+    force(clustered)
+    function() {
+      value <- if (engine == "sandwich") {
+        if (clustered) {
+          sandwich::vcovCL(model, cluster = cluster, type = type)
+        } else {
+          sandwich::vcovHC(model, type = type)
+        }
+      } else {
+        if (clustered) {
+          plm::vcovHC(model, type = type, cluster = cluster)
+        } else {
+          plm::vcovHC(model, type = type)
+        }
+      }
+      value
+    }
+  }
+
+  steps <- list(robust_step(clustered_type, use_cluster))
+  for (type in fallback_types) {
+    steps[[length(steps) + 1L]] <- robust_step(type, FALSE)
+  }
+
+  run_robust <- function(step) {
+    if (suppress_warnings) suppressWarnings(step()) else step()
+  }
+
+  # The final stats::vcov() step is never suppressed and runs uncaught.
+  final_step <- if (final_vcov_fallback) function() stats::vcov(model) else NULL
+
+  for (i in seq_along(steps)) {
+    is_last <- is.null(final_step) && i == length(steps)
+    if (is_last) {
+      return(run_robust(steps[[i]]))
+    }
+    result <- tryCatch(run_robust(steps[[i]]), error = function(e) NULL)
+    if (!is.null(result)) {
+      return(result)
+    }
+  }
+
+  final_step()
+}
+
+box::export(robust_vcov)

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -749,16 +749,13 @@ resolve_bpe_context <- function(df, bma_data) {
 }
 
 resolve_bpe_vcov <- function(ols_model, cluster_ids = NULL) {
-  tryCatch(
-    {
-      if (!is.null(cluster_ids) && length(cluster_ids) == stats::nobs(ols_model)) {
-        return(sandwich::vcovCL(ols_model, cluster = cluster_ids, type = "HC0"))
-      }
-      sandwich::vcovHC(ols_model, type = "HC0")
-    },
-    error = function(e) {
-      stats::vcov(ols_model)
-    }
+  box::use(artma / econometric / vcov[robust_vcov])
+  robust_vcov(
+    model = ols_model,
+    cluster = cluster_ids,
+    engine = "sandwich",
+    clustered_type = "HC0",
+    match_cluster_length = TRUE
   )
 }
 

--- a/tests/testthat/test-econometric-vcov.R
+++ b/tests/testthat/test-econometric-vcov.R
@@ -1,0 +1,206 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_true,
+    skip_if_not_installed,
+    test_that
+  ],
+  artma / econometric / vcov[robust_vcov]
+)
+
+# Deterministic fixture matching the shape used across the linear tests: an
+# intercept + `se` slope model with a repeating `study_id` cluster.
+make_vcov_fixture <- function() {
+  set.seed(42)
+  n_studies <- 6L
+  per_study <- 5L
+  study_ids <- rep(seq_len(n_studies), each = per_study)
+  se_vals <- runif(n_studies * per_study, 0.05, 0.15)
+  data.frame(
+    study_id = study_ids,
+    effect = rnorm(n_studies * per_study, 0.2, 0.05),
+    se = se_vals,
+    study_size = sample(20:80, n_studies * per_study, replace = TRUE),
+    precision = 1 / se_vals
+  )
+}
+
+# --- sandwich engine: exogeneity get_robust_vcov ladder --------------------
+
+test_that("robust_vcov reproduces the get_robust_vcov clustered HC1 ladder", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  result <- robust_vcov(
+    model = model,
+    cluster = df$study_id,
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = c("HC1", "HC0"),
+    require_cluster = TRUE,
+    suppress_warnings = TRUE
+  )
+
+  oracle <- suppressWarnings(
+    sandwich::vcovCL(model, cluster = df$study_id, type = "HC1")
+  )
+  expect_equal(result, oracle)
+
+  # Pinned golden values captured from the original ladder.
+  expect_equal(unname(result["se", "se"]), 0.092270063, tolerance = 1e-7)
+  expect_equal(unname(result["(Intercept)", "(Intercept)"]), 0.0009163101, tolerance = 1e-7)
+})
+
+test_that("get_robust_vcov ladder falls back to non-clustered HC1 on cluster error", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  # A wrong-length cluster makes vcovCL error; the ladder should fall through
+  # to the non-clustered HC1 step.
+  result <- robust_vcov(
+    model = model,
+    cluster = c(1, 2, 3),
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = c("HC1", "HC0"),
+    require_cluster = TRUE,
+    suppress_warnings = TRUE
+  )
+
+  oracle <- suppressWarnings(sandwich::vcovHC(model, type = "HC1"))
+  expect_equal(result, oracle)
+})
+
+test_that("robust_vcov errors when a required cluster is NULL", {
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+  expect_error(
+    robust_vcov(model = model, cluster = NULL, require_cluster = TRUE)
+  )
+})
+
+# --- sandwich engine: resolve_bpe_vcov ladder ------------------------------
+
+test_that("robust_vcov reproduces resolve_bpe_vcov clustered HC0 (matching length)", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  result <- robust_vcov(
+    model = model,
+    cluster = df$study_id,
+    engine = "sandwich",
+    clustered_type = "HC0",
+    match_cluster_length = TRUE
+  )
+
+  oracle <- sandwich::vcovCL(model, cluster = df$study_id, type = "HC0")
+  expect_equal(result, oracle)
+  expect_equal(unname(result["se", "se"]), 0.089088337, tolerance = 1e-7)
+})
+
+test_that("resolve_bpe_vcov ladder uses non-clustered HC0 when cluster length mismatches", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  # Wrong-length cluster: the length guard rejects it and the primary step is
+  # the non-clustered HC0 vcov.
+  result <- robust_vcov(
+    model = model,
+    cluster = c(1, 2, 3),
+    engine = "sandwich",
+    clustered_type = "HC0",
+    match_cluster_length = TRUE
+  )
+
+  oracle <- sandwich::vcovHC(model, type = "HC0")
+  expect_equal(result, oracle)
+  expect_equal(unname(result["se", "se"]), 0.1105633, tolerance = 1e-6)
+
+  # NULL cluster follows the same non-clustered branch.
+  result_null <- robust_vcov(
+    model = model,
+    cluster = NULL,
+    engine = "sandwich",
+    clustered_type = "HC0",
+    match_cluster_length = TRUE
+  )
+  expect_equal(result_null, oracle)
+})
+
+# --- sandwich engine: tidy_lm_model ladder ---------------------------------
+
+test_that("robust_vcov reproduces tidy_lm_model HC1 ladder without a vcov last resort", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  result <- robust_vcov(
+    model = model,
+    cluster = df$study_id,
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = "HC1",
+    final_vcov_fallback = FALSE
+  )
+
+  oracle <- tryCatch(
+    sandwich::vcovCL(model, cluster = df$study_id, type = "HC1"),
+    error = function(e) sandwich::vcovHC(model, type = "HC1")
+  )
+  expect_equal(result, oracle)
+})
+
+# --- plm engine: tidy_plm_generic / tidy_plm_within ladders ----------------
+
+test_that("robust_vcov reproduces the tidy_plm_generic HC1/HC0 ladder", {
+  skip_if_not_installed("plm")
+  df <- make_vcov_fixture()
+  model <- plm::plm(effect ~ se, data = df, model = "random", index = "study_id")
+
+  result <- robust_vcov(
+    model = model,
+    cluster = "group",
+    engine = "plm",
+    clustered_type = "HC1",
+    fallback_types = "HC0"
+  )
+
+  oracle <- tryCatch(
+    plm::vcovHC(model, type = "HC1", cluster = "group"),
+    error = function(e) {
+      tryCatch(
+        plm::vcovHC(model, type = "HC0"),
+        error = function(e2) stats::vcov(model)
+      )
+    }
+  )
+  expect_equal(result, oracle)
+  expect_equal(unname(result["se", "se"]), 0.086204523, tolerance = 1e-7)
+})
+
+test_that("robust_vcov reproduces the tidy_plm_within HC1/HC0 ladder", {
+  skip_if_not_installed("plm")
+  df <- make_vcov_fixture()
+  model <- plm::plm(effect ~ se, data = df, model = "within", index = "study_id")
+
+  result <- robust_vcov(
+    model = model,
+    cluster = "group",
+    engine = "plm",
+    clustered_type = "HC1",
+    fallback_types = "HC0",
+    final_vcov_fallback = FALSE
+  )
+
+  oracle <- tryCatch(
+    plm::vcovHC(model, type = "HC1", cluster = "group"),
+    error = function(e) plm::vcovHC(model, type = "HC0")
+  )
+  expect_equal(result, oracle)
+  expect_equal(unname(result["se", "se"]), 0.1058499, tolerance = 1e-6)
+})


### PR DESCRIPTION
## What moved

Extracted the four duplicated "clustered robust vcov, fall back to non-clustered robust vcov, fall back to plain vcov" ladders into one shared helper `robust_vcov()` in `inst/artma/econometric/vcov.R`, supporting both the `sandwich` (lm/ivreg) and `plm` (panel) engines through an `engine` argument. Migrated all four historical call sites to delegate to it:

- `get_robust_vcov` in `inst/artma/econometric/exogeneity.R`
- `resolve_bpe_vcov` in `inst/artma/methods/best_practice_estimate.R`
- `tidy_lm_model`, `tidy_plm_generic`, and `tidy_plm_within` in `inst/artma/econometric/linear.R`

## What changed behavior

Nothing. Each call site disagreed on the exact ladder (HC1 vs HC0 primary type, intermediate non-clustered HC steps, warning suppression, a cluster-length guard, whether `stats::vcov` is a last resort). Every divergence is preserved through a parameter and documented in the helper's roxygen. Pure extraction, five call sites (four functions, one used from six model specs) migrated.

## Divergences preserved via parameters

- `get_robust_vcov`: sandwich, clustered HC1, fallbacks HC1 then HC0, `require_cluster`, `suppress_warnings`.
- `resolve_bpe_vcov`: sandwich, clustered HC0, `match_cluster_length` (cluster used only when its length equals `nobs`), no HC fallbacks, `stats::vcov` last resort.
- `tidy_lm_model`: sandwich, clustered HC1, fallback HC1, no `stats::vcov` last resort.
- `tidy_plm_generic` / `tidy_plm_within`: plm, clustered HC1 (cluster = "group"), fallback HC0; generic keeps the `stats::vcov` last resort, within does not.

## Tests that pin the outputs

New `tests/testthat/test-econometric-vcov.R` (15 assertions) pins each ladder's matrix against the original inline expression as an oracle, plus hardcoded golden scalar values captured from the pre-refactor code, and covers the clustered-error fallback and length-guard branches. Existing suites confirm the call sites are unchanged: `test-econometric-exogeneity.R`, `test-linear-tests.R`, `test-methods-p-hacking-exogeneity.R`, `test-best-practice-estimate.R`.

Gates: styler, `make lint` (no lints), full `make test` (FAIL 0), `make check` (0 errors/notes; the single install WARNING is a pre-existing environmental Apple-clang warning from R's own `Boolean.h` header, unrelated to this pure-R change).

Refs #322 (item B1).
