### PR TITLE
refactor(elliott): make C++ CDF simulation the sole production path

### DIFF
--- a/R/generated_check_manifest.R
+++ b/R/generated_check_manifest.R
@@ -119,7 +119,7 @@ utils::globalVariables(c(
     ggplot2::aes,
     lmtest::coeftest,
     memoise::cache_filesystem,
-    parallel::clusterExport,
+    parallel::detectCores,
     sandwich::vcovCL,
     yaml::read_yaml
   ))

--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -57,12 +57,7 @@ simulate_cdfs_parallel <- function(
     workers <- 1L
   }
 
-  inv_gp <- 1 / gp
   inv_sqrt_gp <- 1 / sqrt(gp)
-
-  c_grid <- seq_len(gp) * inv_gp
-  c_values <- c(0, c_grid)
-  n_values <- gp + 1L
 
   bb_sup <- numeric(it)
 
@@ -79,112 +74,28 @@ simulate_cdfs_parallel <- function(
     )
   }
 
-  use_cpp <- isTRUE(getOption("artma.methods.p_hacking_tests.simulate_cdfs.use_cpp", TRUE))
-  if (use_cpp) {
-    use_cpp <- tryCatch(
-      {
-        simulate_cdfs_block_cpp(matrix(0, nrow = 1, ncol = 1))
-        TRUE
-      },
-      error = function(e) {
-        cli::cli_warn(c(
-          "The compiled C++ implementation for CDF simulation is unavailable ({e$message}).",
-          "i" = "Falling back to the pure R implementation."
-        ))
-        FALSE
-      }
-    )
-  }
-  if (use_cpp) {
-    use_fork <- (.Platform$OS.type != "windows")
-    if (!use_fork && workers > 1L) {
-      workers <- 1L
-    }
-
-    done <- 0L
-    while (done < it) {
-      k <- min(block_size, it - done)
-      start <- done + 1L
-      end <- done + k
-
-      eps_block <- matrix(stats::rnorm(gp * k), nrow = gp) * inv_sqrt_gp
-
-      if (workers == 1L || k == 1L) {
-        bb_sup[start:end] <- simulate_cdfs_block_cpp(eps_block)
-      } else {
-        cols_split <- split(seq_len(k), rep_len(seq_len(min(workers, k)), k))
-        res_list <- parallel::mclapply(
-          cols_split,
-          function(cols) {
-            list(
-              idx = (start - 1L) + cols,
-              val = simulate_cdfs_block_cpp(eps_block[, cols, drop = FALSE])
-            )
-          },
-          mc.cores = min(workers, length(cols_split)),
-          mc.preschedule = TRUE
-        )
-        for (r in res_list) bb_sup[r$idx] <- r$val
-      }
-
-      done <- end
-      if (show_pb) cli::cli_progress_update(set = done)
-    }
-
-    if (show_pb) cli::cli_progress_done()
-    return(bb_sup)
-  }
-
-  worker_chunk <- function(eps_sub, idx_sub, c_grid, c_values, gp, inv_gp, n_values) {
-    out <- numeric(length(idx_sub))
-    b_values <- numeric(n_values)
-    y <- numeric(n_values)
-
-    for (jj in seq_along(idx_sub)) {
-      w <- cumsum(eps_sub[, jj])
-      w_end <- w[gp]
-
-      b_values[1L] <- 0
-      b_values[2L:n_values] <- w - c_grid * w_end
-
-      hull <- fdrtool::gcmlcm(c_values, b_values, type = "lcm")
-
-      y[] <- 0
-      y[1L] <- 0
-
-      hkx <- hull$x.knots
-      hky <- hull$y.knots
-      hks <- hull$slope.knots
-
-      # The x-knots are grid points j / gp, but the product hkx * gp can land
-      # just below the integer j (e.g. 86.999...); indexing with it truncates
-      # and writes the chord one grid slot too low. Round to recover j exactly.
-      ki <- as.integer(round(hkx * gp))
-
-      for (s in 2:length(ki)) {
-        a <- hky[s] - hks[s - 1L] * hkx[s]
-        b_slope <- hks[s - 1L]
-        idx <- (ki[s - 1L] + 1L):ki[s]
-        y[idx] <- a + b_slope * (idx * inv_gp)
-      }
-
-      out[jj] <- max(abs(y - b_values))
-    }
-
-    list(idx = idx_sub, val = out)
+  # The compiled C++ kernel is the single production implementation. It ships
+  # with the package (LinkingTo Rcpp), so an unavailable kernel means a broken
+  # install rather than a supported configuration; abort with a clear message.
+  # The pure R equivalent survives only as a test-only numeric reference (see
+  # tests/testthat/modules/testing/reference/elliott.R).
+  cpp_available <- tryCatch(
+    {
+      simulate_cdfs_block_cpp(matrix(0, nrow = 1, ncol = 1))
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+  if (!cpp_available) {
+    cli::cli_abort(c(
+      "The compiled C++ implementation for CDF simulation is unavailable.",
+      "i" = "artma ships this routine as compiled code. Reinstall the package so its C++ sources are built."
+    ))
   }
 
   use_fork <- (.Platform$OS.type != "windows")
-
-  cl <- NULL
   if (!use_fork && workers > 1L) {
-    cl <- parallel::makeCluster(workers)
-    on.exit(parallel::stopCluster(cl), add = TRUE)
-    parallel::clusterExport(
-      cl,
-      varlist = c("worker_chunk", "c_grid", "c_values", "gp", "inv_gp", "n_values"),
-      envir = environment()
-    )
+    workers <- 1L
   }
 
   done <- 0L
@@ -193,59 +104,23 @@ simulate_cdfs_parallel <- function(
     start <- done + 1L
     end <- done + k
 
-    # Critical: pre-generate RNG in master in serial order
-    # This preserves the same random stream as the non-parallel version.
     eps_block <- matrix(stats::rnorm(gp * k), nrow = gp) * inv_sqrt_gp
 
     if (workers == 1L || k == 1L) {
-      res <- worker_chunk(
-        eps_sub = eps_block,
-        idx_sub = start:end,
-        c_grid = c_grid, c_values = c_values,
-        gp = gp, inv_gp = inv_gp, n_values = n_values
-      )
-      bb_sup[res$idx] <- res$val
+      bb_sup[start:end] <- simulate_cdfs_block_cpp(eps_block)
     } else {
       cols_split <- split(seq_len(k), rep_len(seq_len(min(workers, k)), k))
-
-      if (use_fork) {
-        # Unix/macOS: forked workers (fast, low overhead)
-        res_list <- parallel::mclapply(
-          cols_split,
-          function(cols) {
-            worker_chunk(
-              eps_sub = eps_block[, cols, drop = FALSE],
-              idx_sub = (start - 1L) + cols,
-              c_grid = c_grid, c_values = c_values,
-              gp = gp, inv_gp = inv_gp, n_values = n_values
-            )
-          },
-          mc.cores = min(workers, length(cols_split)),
-          mc.preschedule = TRUE
-        )
-      } else {
-        # Windows: PSOCK cluster
-        tasks <- lapply(cols_split, function(cols) {
+      res_list <- parallel::mclapply(
+        cols_split,
+        function(cols) {
           list(
-            eps_sub = eps_block[, cols, drop = FALSE],
-            idx_sub = (start - 1L) + cols
+            idx = (start - 1L) + cols,
+            val = simulate_cdfs_block_cpp(eps_block[, cols, drop = FALSE])
           )
-        })
-
-        res_list <- parallel::parLapply(
-          cl,
-          tasks,
-          function(task) {
-            worker_chunk(
-              eps_sub = task$eps_sub,
-              idx_sub = task$idx_sub,
-              c_grid = c_grid, c_values = c_values,
-              gp = gp, inv_gp = inv_gp, n_values = n_values
-            )
-          }
-        )
-      }
-
+        },
+        mc.cores = min(workers, length(cols_split)),
+        mc.preschedule = TRUE
+      )
       for (r in res_list) bb_sup[r$idx] <- r$val
     }
 

--- a/inst/artma/calc/methods/elliott_cache.R
+++ b/inst/artma/calc/methods/elliott_cache.R
@@ -11,7 +11,7 @@
 NULL
 
 box::use(
-  artma / calc / methods / elliott[simulate_cdfs_block_cpp, simulate_cdfs_parallel],
+  artma / calc / methods / elliott[simulate_cdfs_parallel],
   artma / libs / infrastructure / cache[cache_cli],
   artma / libs / infrastructure / source_fingerprint[hash_source_files],
   artma / paths[PATHS]
@@ -22,27 +22,6 @@ STAGE <- "lcm_critical_values"
 # Resolved at module load time: the directory holding this module and the
 # simulation implementation it fingerprints.
 MODULE_DIR <- box::file()
-
-#' @title Decide whether the compiled simulation backend will run
-#' @description Mirror the backend selection inside
-#'   `simulate_cdfs_parallel()`, without its fallback warning: the option gate
-#'   first, then a probe of the compiled routine. The C++ path and the R
-#'   fallback can differ per draw, so the resolved backend has to be part of
-#'   the cache key.
-#' @return *\[logical\]* `TRUE` when the C++ implementation will run.
-#' @keywords internal
-uses_cpp_backend <- function() {
-  if (!isTRUE(getOption("artma.methods.p_hacking_tests.simulate_cdfs.use_cpp", TRUE))) {
-    return(FALSE)
-  }
-  tryCatch(
-    {
-      simulate_cdfs_block_cpp(matrix(0, nrow = 1, ncol = 1))
-      TRUE
-    },
-    error = function(e) FALSE
-  )
-}
 
 #' @title Fingerprint the simulation implementation
 #' @description Hash the two source files that define the simulation (the R
@@ -93,10 +72,11 @@ restore_rng_state <- function(state) {
 #' @title Build a cached variant of `simulate_cdfs_parallel()`
 #' @description
 #' Wrap `sim_fun` in a disk cache keyed narrowly on the inputs that determine
-#' the simulated table: iteration count, grid size, seed, RNG kind, the
-#' resolved backend, and the implementation fingerprint. Scheduling arguments
-#' (workers, block size, progress display) cannot change the result, so they
-#' stay out of the key and are forwarded out of band.
+#' the simulated table: iteration count, grid size, seed, RNG kind, and the
+#' implementation fingerprint. Scheduling arguments (workers, block size,
+#' progress display) cannot change the result, so they stay out of the key and
+#' are forwarded out of band. The compiled C++ kernel is the only production
+#' backend, so the implementation fingerprint alone captures it.
 #'
 #' A `NULL` seed deliberately consumes the caller's RNG state and is never
 #' cached. `options(artma.cache.use_cache = FALSE)` bypasses the cache like
@@ -167,7 +147,6 @@ make_simulate_cdfs_cached <- function(cache = NULL, sim_fun = simulate_cdfs_para
       grid_points = as.integer(grid_points),
       seed = as.integer(seed),
       rng_kind = RNGkind(),
-      use_cpp = uses_cpp_backend(),
       implementation = implementation_fingerprint()
     )
 

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -688,15 +688,6 @@ methods:
         If `TRUE`, include Elliott et al. (2022) p-hacking detection tests.
 
     simulate_cdfs:
-      use_cpp:
-        type: "logical"
-        default: true
-        help: |
-          If `TRUE`, use the compiled C++ implementation for Brownian bridge
-          simulations in the LCM test. Falls back to pure R automatically
-          if the C++ code is unavailable. Set to `FALSE` to force the R
-          implementation.
-
       chunk_size:
         type: "integer"
         default: 512

--- a/tests/testthat/modules/testing/reference/elliott.R
+++ b/tests/testthat/modules/testing/reference/elliott.R
@@ -1,0 +1,78 @@
+# Test-only numeric reference for the Elliott LCM Brownian bridge simulation.
+#
+# Production code (inst/artma/calc/methods/elliott.R) runs the compiled C++
+# kernel exclusively. This pure R implementation is kept solely as an
+# independent oracle: tests draw the same RNG stream, run both, and assert the
+# per-draw suprema agree. It uses fdrtool::gcmlcm for the greatest convex
+# minorant / least concave majorant, matching the algorithm the C++ kernel
+# reimplements.
+#
+# The simulation is serial here on purpose: the reference exists to be obviously
+# correct, not fast. A single rnorm() draw of gp * iterations values yields the
+# identical Mersenne-Twister stream that the production block loop consumes, so
+# a shared seed lines the two implementations up exactly.
+
+#' Serial pure R reference for `simulate_cdfs_parallel()`.
+#'
+#' @param iterations *\[integer\]* Number of Brownian bridge simulations.
+#' @param grid_points *\[integer\]* Number of grid points per simulation.
+#' @param seed *\[integer, optional\]* RNG seed to set before drawing. Leave
+#'   `NULL` to consume the caller's current RNG state, matching the production
+#'   contract.
+#' @return *\[numeric\]* Vector of simulated suprema, one per iteration.
+simulate_cdfs_reference <- function(iterations, grid_points, seed = NULL) {
+  if (!is.null(seed)) {
+    set.seed(as.integer(seed))
+  }
+
+  gp <- as.integer(grid_points)
+  it <- as.integer(iterations)
+
+  inv_gp <- 1 / gp
+  inv_sqrt_gp <- 1 / sqrt(gp)
+
+  c_grid <- seq_len(gp) * inv_gp
+  c_values <- c(0, c_grid)
+  n_values <- gp + 1L
+
+  eps <- matrix(stats::rnorm(gp * it), nrow = gp) * inv_sqrt_gp
+
+  bb_sup <- numeric(it)
+  b_values <- numeric(n_values)
+  y <- numeric(n_values)
+
+  for (jj in seq_len(it)) {
+    w <- cumsum(eps[, jj])
+    w_end <- w[gp]
+
+    b_values[1L] <- 0
+    b_values[2L:n_values] <- w - c_grid * w_end
+
+    hull <- fdrtool::gcmlcm(c_values, b_values, type = "lcm")
+
+    y[] <- 0
+    y[1L] <- 0
+
+    hkx <- hull$x.knots
+    hky <- hull$y.knots
+    hks <- hull$slope.knots
+
+    # The x-knots are grid points j / gp, but the product hkx * gp can land
+    # just below the integer j (e.g. 86.999...); indexing with it truncates
+    # and writes the chord one grid slot too low. Round to recover j exactly.
+    ki <- as.integer(round(hkx * gp))
+
+    for (s in 2:length(ki)) {
+      a <- hky[s] - hks[s - 1L] * hkx[s]
+      b_slope <- hks[s - 1L]
+      idx <- (ki[s - 1L] + 1L):ki[s]
+      y[idx] <- a + b_slope * (idx * inv_gp)
+    }
+
+    bb_sup[jj] <- max(abs(y - b_values))
+  }
+
+  bb_sup
+}
+
+box::export(simulate_cdfs_reference)

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -414,8 +414,7 @@ test_that("run_p_hacking_tests dedupes duplicated caliper thresholds/widths with
 test_that("run_p_hacking_tests runs the Elliott suite when requested", {
   local_options(
     artma.verbose = 1,
-    artma.cache.use_cache = FALSE,
-    artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
+    artma.cache.use_cache = FALSE
   )
   set.seed(202)
   df <- make_p_hacking_df()
@@ -674,8 +673,7 @@ test_that("run_cox_shi preserves the skip reason for the caller to record", {
 test_that("run_p_hacking_tests reports numeric Cox-Shi rows on clustered data", {
   local_options(
     artma.verbose = 1,
-    artma.cache.use_cache = FALSE,
-    artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
+    artma.cache.use_cache = FALSE
   )
   panel <- cox_shi_panel(202)
   df <- data.frame(

--- a/tests/testthat/test-elliott-cdfs-cache.R
+++ b/tests/testthat/test-elliott-cdfs-cache.R
@@ -4,22 +4,20 @@ box::use(
     expect_identical,
     expect_length,
     expect_true,
-    skip_if_not,
     test_that
   ],
   withr[local_options, local_tempdir],
-  artma / calc / methods / elliott[simulate_cdfs_block_cpp, simulate_cdfs_parallel],
+  artma / calc / methods / elliott[simulate_cdfs_parallel],
   artma / calc / methods / elliott_cache[make_simulate_cdfs_cached]
 )
 
-# Deterministic, quiet defaults for every test: the R fallback keeps results
-# identical across platforms, and caching stays on unless a test disables it.
+# Quiet defaults for every test: the compiled C++ kernel is the only
+# production backend, and caching stays on unless a test disables it.
 local_sim_options <- function(env = parent.frame()) {
   local_options(
     list(
       artma.verbose = 1,
-      artma.cache.use_cache = TRUE,
-      artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE
+      artma.cache.use_cache = TRUE
     ),
     .local_envir = env
   )
@@ -114,27 +112,4 @@ test_that("the cache key separates seeds, iteration counts, and grid sizes", {
 
   inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
   expect_equal(inst$calls(), 4L)
-})
-
-test_that("the cache key separates the compiled backend from the R fallback", {
-  cpp_available <- tryCatch(
-    {
-      simulate_cdfs_block_cpp(matrix(0, nrow = 1, ncol = 1))
-      TRUE
-    },
-    error = function(e) FALSE
-  )
-  skip_if_not(cpp_available, "compiled simulate_cdfs backend is unavailable")
-
-  local_options(list(artma.verbose = 1, artma.cache.use_cache = TRUE))
-  inst <- new_cached_instance()
-
-  local_options(list(artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = TRUE))
-  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
-  expect_equal(inst$calls(), 1L)
-
-  local_options(list(artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = FALSE))
-  inst$simulate(iterations = 3, grid_points = 20, show_progress = FALSE, seed = 123)
-  expect_equal(inst$calls(), 2L)
-  expect_length(inst$cache$keys(), 2L)
 })

--- a/tests/testthat/test-elliott-simulate-cdfs.R
+++ b/tests/testthat/test-elliott-simulate-cdfs.R
@@ -8,18 +8,18 @@ box::use(
     test_that
   ],
   withr[local_options],
-  artma / calc / methods / elliott[simulate_cdfs_parallel]
+  artma / calc / methods / elliott[simulate_cdfs_parallel],
+  testing / reference / elliott[simulate_cdfs_reference]
 )
 
+# The compiled C++ kernel is the single production implementation, so every
+# generic property test below exercises it directly.
 run_simulation <- function(seed, iterations, grid_points, show_progress = FALSE, verbose = 0,
-                           use_cpp = FALSE, workers = NULL) {
+                           workers = NULL) {
   old_kind <- RNGkind()
   on.exit(do.call(RNGkind, as.list(old_kind)), add = TRUE)
   RNGkind(kind = "Mersenne-Twister", normal.kind = "Inversion", sample.kind = "Rejection")
-  local_options(list(
-    artma.verbose = verbose,
-    artma.methods.p_hacking_tests.simulate_cdfs.use_cpp = use_cpp
-  ))
+  local_options(list(artma.verbose = verbose))
   set.seed(seed)
   simulate_cdfs_parallel(
     iterations = iterations,
@@ -27,6 +27,14 @@ run_simulation <- function(seed, iterations, grid_points, show_progress = FALSE,
     workers = workers,
     show_progress = show_progress
   )
+}
+
+run_reference <- function(seed, iterations, grid_points) {
+  old_kind <- RNGkind()
+  on.exit(do.call(RNGkind, as.list(old_kind)), add = TRUE)
+  RNGkind(kind = "Mersenne-Twister", normal.kind = "Inversion", sample.kind = "Rejection")
+  set.seed(seed)
+  simulate_cdfs_reference(iterations = iterations, grid_points = grid_points)
 }
 
 test_that("simulate_cdfs returns numeric vectors with expected shape", {
@@ -84,7 +92,7 @@ test_that("simulate_cdfs responds to different RNG seeds", {
   expect_true(any(abs(res_a - res_b) > 0))
 })
 
-test_that("pure R fallback matches the compiled implementation elementwise", {
+test_that("the production C++ kernel matches the pure R reference elementwise", {
   cpp_available <- tryCatch(
     {
       .Call("_artma_simulate_cdfs_block_cpp", PACKAGE = "artma", matrix(0, 1, 1))
@@ -95,7 +103,7 @@ test_that("pure R fallback matches the compiled implementation elementwise", {
   skip_if_not(cpp_available, "compiled simulate_cdfs_block_cpp is unavailable")
 
   # Grid sizes where some gcmlcm x-knots times grid_points land just below an
-  # integer (e.g. 86.999...). The fallback used to index with those raw
+  # integer (e.g. 86.999...). The reference used to index with those raw
   # products, so truncation wrote hull chords one grid slot too low and its
   # suprema drifted from the C++ results by up to ~0.9 on a few draws.
   configs <- list(
@@ -106,11 +114,10 @@ test_that("pure R fallback matches the compiled implementation elementwise", {
   for (cf in configs) {
     res_cpp <- run_simulation(
       seed = 42, iterations = cf$iterations, grid_points = cf$grid_points,
-      use_cpp = TRUE, workers = 1L
+      workers = 1L
     )
-    res_r <- run_simulation(
-      seed = 42, iterations = cf$iterations, grid_points = cf$grid_points,
-      use_cpp = FALSE, workers = 1L
+    res_r <- run_reference(
+      seed = 42, iterations = cf$iterations, grid_points = cf$grid_points
     )
 
     expect_length(res_r, cf$iterations)


### PR DESCRIPTION
## What moved

- The pure-R `fdrtool`-based Elliott CDF-simulation fallback moves out of production (`inst/artma/calc/methods/elliott.R`) into a test-only numeric reference at `tests/testthat/modules/testing/reference/elliott.R`, exported as `simulate_cdfs_reference()`.
- The compiled C++ kernel (`simulate_cdfs_block_cpp`) is now the single production implementation of `simulate_cdfs_parallel()`.

## What changed behavior

- `simulate_cdfs_parallel()` no longer silently falls back to pure R. If the compiled kernel is unavailable it now aborts with a clear "reinstall the package" message. This is the deliberate lightening in item D3, justified by the precondition below.
- The `artma.methods.p_hacking_tests.simulate_cdfs.use_cpp` option is removed from the template (it only chose the now-gone fallback). The options template-parity test enforces that its removal and the removal of its reads stay in lockstep.
- The Elliott critical-value disk cache (`elliott_cache.R`) drops the `use_cpp` backend probe from its key: the backend is always C++, and the implementation fingerprint (R + C++ source hashes) already captures it.

## fdrtool re-evaluation

`fdrtool` stays in Suggests. It is still used by production `lcm_test()` (`fdrtool::gcmlcm`) and guarded in `econometric/p_hacking.R`, and by the new test reference. No DESCRIPTION change; no `make document` for Imports/Suggests. `R/generated_check_manifest.R` regenerated only because the `parallel` keep-alive reference shifted from `clusterExport` (removed with the fallback) to `detectCores`.

## Precondition (item D3: "only if the C++ has proven portable across CI platforms")

Verified before implementing. `.github/workflows/R-CMD-check.yaml` builds and checks the package on `macos-latest`, `windows-latest`, and `ubuntu-latest` (release) on every PR; `R-CMD-check-extended.yaml` adds R-devel and oldrel-1 on merges to master. Both use `fail-fast: false`. The latest runs are green on every leg including `windows-latest (release)`, the package compiles `src/elliott_cdfs.cpp` on all of them, and the existing oracle test asserting C++ matches the pure-R implementation within 1e-9 runs (and passes) on Windows CI.

## Tests that pin the outputs

- `tests/testthat/test-elliott-simulate-cdfs.R`: the oracle test now compares the production C++ kernel against `simulate_cdfs_reference()` elementwise (<= 1e-9) on the same RNG stream; the shape/determinism/seed/progress tests now exercise the C++ path directly.
- `tests/testthat/test-elliott-cdfs-cache.R`: cache behavior tests run against the C++ backend; the obsolete "cache key separates the compiled backend from the R fallback" test is removed.
- `tests/testthat/test-econometric-p-hacking.R`: Elliott and Cox-Shi suite tests run against the C++ backend.

Gates: styler, `make lint` (no lints), full `make test` (0 failures), `make check` (0 errors, 0 notes; single WARNING is a local Apple-clang / R-header `-Wfixed-enum-extension` artifact unrelated to this change, not emitted on CI).

Refs #322 (item D3)
