### PR TITLE
perf(methods): scope disk caching to expensive stages only (D1)

### DIFF
--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -793,7 +793,8 @@ run <- register_runtime_method(
   bma,
   stage = "bma",
   required_columns = c("effect", "se"),
-  suggests = "BMS"
+  suggests = "BMS",
+  cached = TRUE
 )
 
 # prepare_bma_inputs is exported because the fma method reuses it directly.

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -223,7 +223,8 @@ run <- register_runtime_method(
   stage = "robma",
   required_columns = c("effect", "se"),
   suggests = "RoBMA",
-  opt_in = TRUE
+  opt_in = TRUE,
+  cached = TRUE
 )
 
 box::export(robma, run)

--- a/inst/artma/modules/runtime_methods.R
+++ b/inst/artma/modules/runtime_methods.R
@@ -67,6 +67,14 @@ METHOD_META_ATTR <- "artma_method_meta"
 #' * `opt_in`: when `TRUE`, the method is left out of `methods = "all"` and must
 #'   be requested by name. Use it for methods too expensive to run by default.
 #'
+#' Disk caching is opt-in. Only the expensive stages (BMA, RoBMA) set
+#' `cached = TRUE`; the Elliott simulation keeps its own narrow cache in
+#' `calc/methods/elliott_cache.R`. Every other method runs uncached: for a
+#' method that recomputes in well under a second, building the cache signature
+#' (a fingerprint of the whole `inst/artma` source tree plus the full option
+#' group) and revalidating recorded output files costs more than the
+#' recomputation it would save.
+#'
 #' @param impl *\[function\]* The method implementation (its `run` worker).
 #' @param stage *\[character\]* Stage label used for cache keys and the cache
 #'   hit notice. Conventionally matches the implementation's name.
@@ -79,45 +87,57 @@ METHOD_META_ATTR <- "artma_method_meta"
 #' @param opt_in *\[logical, optional\]* If `TRUE`, exclude the method from
 #'   `methods = "all"`; it then runs only when named explicitly. Defaults to
 #'   `FALSE`.
+#' @param cached *\[logical, optional\]* If `TRUE`, wrap the method in the full
+#'   disk-caching stack (memoise, cache signature, package source fingerprint,
+#'   output-file revalidation). Defaults to `FALSE`, which returns the
+#'   implementation unwrapped so cheap methods carry no caching overhead.
 #' @param label *\[character, optional\]* Human-readable display label. Defaults
 #'   to `stage`.
-#' @param key_builder *\[function, optional\]* Cache signature builder. Defaults
-#'   to the standard data cache signature. Whatever it returns, the method's own
-#'   source hash is appended, so editing a method file invalidates that method's
-#'   cache without disturbing the others.
-#' @param ... *\[any\]* Extra arguments forwarded to `cache_cli_runner`.
-#' @return *\[function\]* The cached `run` wrapper, carrying the method metadata
-#'   in its `artma_method_meta` attribute.
+#' @param key_builder *\[function, optional\]* Cache signature builder, used only
+#'   when `cached = TRUE`. Defaults to the standard data cache signature.
+#'   Whatever it returns, the method's own source hash is appended, so editing a
+#'   method file invalidates that method's cache without disturbing the others.
+#' @param ... *\[any\]* Extra arguments forwarded to `cache_cli_runner` when
+#'   `cached = TRUE`; ignored otherwise.
+#' @return *\[function\]* The `run` wrapper (cached when `cached = TRUE`, the bare
+#'   implementation otherwise), carrying the method metadata in its
+#'   `artma_method_meta` attribute.
 register_runtime_method <- function(impl, stage,
                                     depends_on = character(),
                                     required_columns = character(),
                                     suggests = character(),
                                     opt_in = FALSE,
+                                    cached = FALSE,
                                     label = NULL,
                                     key_builder = NULL, ...) {
-  box::use(
-    artma / libs / infrastructure / cache[cache_cli_runner],
-    artma / libs / infrastructure / source_fingerprint[method_source_hash],
-    artma / data / cache_signatures[build_data_cache_signature]
-  )
+  if (isTRUE(cached)) {
+    box::use(
+      artma / libs / infrastructure / cache[cache_cli_runner],
+      artma / libs / infrastructure / source_fingerprint[method_source_hash],
+      artma / data / cache_signatures[build_data_cache_signature]
+    )
 
-  base_key_builder <- key_builder
-  if (is.null(base_key_builder)) {
-    base_key_builder <- function(...) build_data_cache_signature()
-  }
-
-  # The data frame and any upstream `<dependency>_result` reach the cache key
-  # as ordinary call arguments, which `memoise` hashes; the signature adds the
-  # inputs that are not arguments (options, data source, package source).
-  signature_builder <- function(...) {
-    signature <- base_key_builder(...)
-    if (!is.list(signature)) {
-      signature <- list(value = signature)
+    base_key_builder <- key_builder
+    if (is.null(base_key_builder)) {
+      base_key_builder <- function(...) build_data_cache_signature()
     }
-    c(signature, list(method_source = method_source_hash(stage)))
-  }
 
-  run <- cache_cli_runner(impl, stage = stage, key_builder = signature_builder, ...)
+    # The data frame and any upstream `<dependency>_result` reach the cache key
+    # as ordinary call arguments, which `memoise` hashes; the signature adds the
+    # inputs that are not arguments (options, data source, package source).
+    signature_builder <- function(...) {
+      signature <- base_key_builder(...)
+      if (!is.list(signature)) {
+        signature <- list(value = signature)
+      }
+      c(signature, list(method_source = method_source_hash(stage)))
+    }
+
+    run <- cache_cli_runner(impl, stage = stage, key_builder = signature_builder, ...)
+  } else {
+    # Cheap methods run uncached: the bare implementation is the `run` wrapper.
+    run <- impl
+  }
 
   attr(run, METHOD_META_ATTR) <- list(
     stage = stage,

--- a/tests/testthat/test-cache-signature-components.R
+++ b/tests/testthat/test-cache-signature-components.R
@@ -3,9 +3,11 @@ box::use(
   testing / fixtures / index[FIXTURES]
 )
 
-# Caching is on by default, so every component of the cache signature needs a
+# Caching is opt-in per method (`cached = TRUE`), reserved for the expensive
+# stages. For a cached method, every component of the cache signature needs a
 # test that proves a change to it produces a miss. A stale hit is a correctness
-# bug, not a performance one.
+# bug, not a performance one. The demo method below opts in so it exercises the
+# full signature stack the expensive methods rely on.
 
 cache_test_options <- function() {
   list(
@@ -33,6 +35,7 @@ make_counted_method <- function(stage = "cache_signature_demo") {
   state$run <- register_runtime_method(
     impl,
     stage = stage,
+    cached = TRUE,
     cache = memoise::cache_memory()
   )
 

--- a/tests/testthat/test-runtime-methods.R
+++ b/tests/testthat/test-runtime-methods.R
@@ -96,6 +96,57 @@ test_that("register_runtime_method attaches declarative metadata", {
   expect_equal(meta$opt_in, FALSE)
 })
 
+test_that("register_runtime_method leaves cheap methods uncached by default", {
+  box::use(
+    artma / modules / runtime_methods[register_runtime_method]
+  )
+
+  local_options(list(artma.cache.use_cache = TRUE))
+
+  calls <- 0L
+  impl <- function(df, ...) {
+    calls <<- calls + 1L
+    calls
+  }
+  run <- register_runtime_method(impl, stage = "cheap")
+
+  df <- data.frame(x = 1)
+  run(df = df)
+  run(df = df)
+
+  # No caching layer wraps the method, so the implementation runs every call.
+  expect_equal(calls, 2L)
+})
+
+test_that("register_runtime_method caches a method opted into caching", {
+  box::use(
+    artma / modules / runtime_methods[register_runtime_method]
+  )
+
+  local_options(list(artma.cache.use_cache = TRUE))
+
+  calls <- 0L
+  impl <- function(df, ...) {
+    calls <<- calls + 1L
+    calls
+  }
+  run <- register_runtime_method(
+    impl,
+    stage = "pricey",
+    cached = TRUE,
+    key_builder = function(...) list(fixed = TRUE),
+    cache = memoise::cache_memory()
+  )
+
+  df <- data.frame(x = 1)
+  first <- run(df = df)
+  second <- run(df = df)
+
+  # The second identical call is served from cache: the implementation ran once.
+  expect_equal(calls, 1L)
+  expect_equal(first, second)
+})
+
 test_that("register_runtime_method records the opt-in flag", {
   box::use(
     artma / modules / runtime_methods[get_method_metadata, register_runtime_method]


### PR DESCRIPTION
## What moved

`register_runtime_method()` gains a `cached` flag (default `FALSE`). Only the
expensive stages opt in: `bma` and `robma` now pass `cached = TRUE`. The Elliott
LCM simulation keeps its own narrow cache in
`inst/artma/calc/methods/elliott_cache.R` (unchanged), so all three expensive
stages named in the item (Elliott simulation, RoBMA, BMA) remain cached.

When `cached = FALSE` the registrar returns the implementation unwrapped: no
memoise layer, no cache signature, no whole-tree source fingerprint, no
output-file capture or revalidation. The full stack still wires up unchanged for
the two opted-in methods.

The boolean is named `cached` rather than `cache` so a `cache` object can still
be forwarded through `...` to `cache_cli_runner` (the signature-component tests
inject an in-memory cache that way).

## What changed behavior

These 13 methods lose their per-method disk cache and now always recompute:
`best_practice_estimate`, `box_plot`, `effect_summary_stats`, `exogeneity_tests`,
`fma`, `funnel_plot`, `linear_tests`, `maive`, `nonlinear_tests`,
`p_hacking_tests`, `prima_facie_graphs`, `t_stat_histogram`,
`variable_summary_stats`. (`p_hacking_tests` keeps the Elliott simulation cache;
only its cheap method-level wrapper is dropped.)

## Why (measurement on fixture-style data, n=300)

For a cheap method the caching machinery costs more than the recomputation it
would save. Timings on generated meta-analysis data (300 rows), warm session:

| operation | cost |
|---|---|
| `funnel_plot` recompute | ~16 to 20 ms |
| `effect_summary_stats` recompute | ~12 to 18 ms |
| `funnel_plot` cached wrapper, warm HIT | ~42 to 51 ms |
| `funnel_plot` cached wrapper, cold MISS | ~61 to 72 ms |
| `package_source_fingerprint()` cold (once/session) | ~20 to 25 ms |

A cache HIT for `funnel_plot` (~42 to 51 ms) is consistently 2 to 3x slower than
just recomputing it (~16 to 20 ms), because memoise has to hash the whole data
frame argument plus the full signature (the entire `artma.*` option group and a
fingerprint of every R file under `inst/artma`) and read the artifact from disk.
The common case is a MISS (any option or source edit busts every method's key),
which is slower still. Dropping the cache for these methods removes pure
overhead.

## memoise / output_files checks

The item asked whether `memoise` can leave Imports and whether `output_files.R`
shrinks. Neither applies:

- `memoise` stays in Imports: still used by `inst/artma/options/template.R`
  (`.parse_template_memoised`) and by `cache.R`, which remains active for `bma`,
  `robma`, and the Elliott simulation cache.
- `output_files.R` is unchanged: the output-file capture/revalidation it
  provides is still needed by the two cached methods, so every export stays live.

## Tests

- `test-runtime-methods.R`: new cases pin the contract, a method left at the
  default recomputes on every call, and a method registered with `cached = TRUE`
  serves the second identical call from cache.
- `test-cache-signature-components.R`: the demo method now opts in
  (`cached = TRUE`) so it still exercises the full signature stack; the six
  cache-hit/miss assertions that pin each signature component pass unchanged.

## Gates

`styler`, `make lint`, `make test` (FAIL 0, PASS 2181), and `make check` all
green. No `box::use()` import in `R/` or DESCRIPTION Imports changed, so the
check manifest is untouched.

Refs #322 (item D1).
