### PR TITLE
refactor(visualization): unify plot export and tick-interval math

### DIFF
--- a/inst/artma/econometric/nonlinear.R
+++ b/inst/artma/econometric/nonlinear.R
@@ -16,7 +16,7 @@ box::use(
   artma / calc / methods / selection_model[metastudies_estimation],
   artma / calc / methods / endo_kink[run_endogenous_kink],
   artma / visualization / options[get_visualization_options],
-  artma / visualization / export[ensure_export_dir, build_export_filename, open_png_device]
+  artma / visualization / export[export_named_plots]
 )
 
 # nocov start -----------------------------------------------------------------
@@ -318,9 +318,15 @@ build_stem_plots <- function(effects, ses, estimates, mse_matrix) {
       draw_mse <- function() stem_MSE(mse_matrix)
 
       if (isTRUE(vis$export_graphics)) {
-        ensure_export_dir(vis$export_path)
-        export_stem_plot(draw_funnel, file.path(vis$export_path, build_export_filename("stem", "funnel")), vis$graph_scale)
-        export_stem_plot(draw_mse, file.path(vis$export_path, build_export_filename("stem", "mse")), vis$graph_scale)
+        export_named_plots(
+          plots = list(funnel = draw_funnel, mse = draw_mse),
+          base_name = "stem",
+          export_path = vis$export_path,
+          graph_scale = vis$graph_scale,
+          width = 800,
+          height = 600,
+          renderer = "base"
+        )
       }
 
       list(
@@ -346,23 +352,6 @@ record_stem_plot <- function(draw) {
   grDevices::dev.control("enable")
   draw()
   grDevices::recordPlot()
-}
-
-#' Export a base-graphics plotting function to a PNG file
-#'
-#' @param draw *\[function\]* Zero-argument function that draws the plot.
-#' @param path *\[character\]* Full file path (including filename).
-#' @param graph_scale *\[numeric\]* Scale factor for the exported dimensions.
-#' @return NULL (invisibly)
-#' @keywords internal
-export_stem_plot <- function(draw, path, graph_scale) {
-  if (file.exists(path)) {
-    file.remove(path)
-  }
-  open_png_device(path, width = 800 * graph_scale, height = 600 * graph_scale, units = "px", res = 90 * graph_scale)
-  on.exit(grDevices::dev.off(), add = TRUE)
-  draw()
-  invisible(NULL)
 }
 
 run_hierarchical <- function(df, total_n, options) {

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -12,7 +12,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
+    artma / visualization / export[export_named_plots]
   )
 
   validate(is.data.frame(df))
@@ -262,7 +262,14 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   )
 
   if (isTRUE(vis$export_graphics) && length(plots)) {
-    export_bpe_plots(plots = plots, export_path = vis$export_path, graph_scale = vis$graph_scale)
+    export_named_plots(
+      plots = plots,
+      base_name = "best_practice_estimate",
+      export_path = vis$export_path,
+      graph_scale = vis$graph_scale,
+      width = 800,
+      height = 600
+    )
   }
 
   if (get_verbosity() >= 3) {
@@ -1302,31 +1309,6 @@ format_bpe_group_value <- function(value, round_to) {
     return(as.character(round(value, round_to)))
   }
   as.character(value)
-}
-
-#' @title Export BPE Plots to Files
-#' @keywords internal
-export_bpe_plots <- function(plots, export_path, graph_scale) {
-  box::use(
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
-  )
-
-  ensure_export_dir(export_path)
-
-  for (plot_name in names(plots)) {
-    filename <- build_export_filename("best_practice_estimate", plot_name)
-    full_path <- file.path(export_path, filename)
-
-    save_plot(
-      plot = plots[[plot_name]],
-      path = full_path,
-      width = 800,
-      height = 600,
-      scale = graph_scale
-    )
-  }
-
-  invisible(NULL)
 }
 
 compute_context_values <- function(bma_data, row_idx, predictors, overrides) {

--- a/inst/artma/methods/box_plot.R
+++ b/inst/artma/methods/box_plot.R
@@ -12,7 +12,7 @@ box_plot <- function(df) {
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
+    artma / visualization / export[export_named_plots]
   )
 
   validate(is.data.frame(df))
@@ -81,11 +81,14 @@ box_plot <- function(df) {
   }
 
   if (export_graphics) {
-    export_box_plots(
+    export_named_plots(
       plots = result$plots,
-      factor_by = factor_by,
+      base_name = "box_plot",
       export_path = export_path,
-      graph_scale = graph_scale
+      graph_scale = graph_scale,
+      names = factor_by,
+      width = 800,
+      height = 1100
     )
   }
 
@@ -372,42 +375,6 @@ create_single_box_plot <- function(df, factor_by, theme_name, show_mean_line, ef
   p
 }
 
-
-#' Export box plots to files
-#'
-#' @param plots *\[list\]* List of ggplot objects
-#' @param factor_by *\[character\]* Factor variable name
-#' @param export_path *\[character\]* Directory path
-#' @param graph_scale *\[numeric\]* Scale factor
-#'
-#' @return NULL (invisibly)
-#' @keywords internal
-export_box_plots <- function(plots, factor_by, export_path, graph_scale) {
-  box::use(
-    artma / libs / core / utils[get_verbosity],
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
-  )
-
-  ensure_export_dir(export_path)
-  n_plots <- length(plots)
-  use_indexing <- n_plots > 1
-
-  for (i in seq_along(plots)) {
-    index <- if (use_indexing) i else NULL
-    filename <- build_export_filename("box_plot", factor_by, index = index)
-    full_path <- file.path(export_path, filename)
-
-    save_plot(
-      plot = plots[[i]],
-      path = full_path,
-      width = 800,
-      height = 1100,
-      scale = graph_scale
-    )
-  }
-
-  invisible(NULL)
-}
 
 
 box::use(

--- a/inst/artma/methods/funnel_plot.R
+++ b/inst/artma/methods/funnel_plot.R
@@ -10,7 +10,7 @@ funnel_plot <- function(df) {
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
+    artma / visualization / export[export_named_plots]
   )
 
   validate(is.data.frame(df))
@@ -121,10 +121,13 @@ funnel_plot <- function(df) {
   }
 
   if (export_graphics) {
-    export_funnel_plot(
-      plot = plot,
+    export_named_plots(
+      plots = list(effect_precision = plot),
+      base_name = "funnel_plot",
       export_path = export_path,
-      graph_scale = graph_scale
+      graph_scale = graph_scale,
+      width = 800,
+      height = 736
     )
   }
 
@@ -240,7 +243,10 @@ aggregate_study_medians <- function(df) {
 #' @return *\[list\]* With elements: ticks (numeric), tick_colors (character)
 #' @keywords internal
 generate_funnel_ticks <- function(bounds, mean_effect, add_zero, theme_name) {
-  box::use(artma / visualization / colors[get_vline_color])
+  box::use(
+    artma / visualization / colors[get_vline_color],
+    artma / visualization / ticks[resolve_tick_interval, generate_regular_ticks]
+  )
 
   lower_bound <- bounds[1]
   upper_bound <- bounds[2]
@@ -252,22 +258,22 @@ generate_funnel_ticks <- function(bounds, mean_effect, add_zero, theme_name) {
     ticks <- c(ticks, 0)
   }
 
-  interval <- determine_tick_interval(range_size)
+  interval <- resolve_tick_interval(
+    range_size,
+    breakpoints = c(1, 5, 20, 50, 100),
+    intervals = c(0.2, 1, 5, 10, 20),
+    fallback = 50
+  )
   min_distance <- interval / 5
 
-  start_tick <- ceiling(lower_bound / interval) * interval
-
-  current_tick <- start_tick
-  while (current_tick < upper_bound) {
-    far_from_lower <- abs(current_tick - lower_bound) >= min_distance
-    far_from_upper <- abs(current_tick - upper_bound) >= min_distance
-    not_duplicate <- !(current_tick %in% ticks)
-
-    if (far_from_lower && far_from_upper && not_duplicate) {
-      ticks <- c(ticks, current_tick)
-    }
-    current_tick <- current_tick + interval
-  }
+  regular_ticks <- generate_regular_ticks(
+    lower = lower_bound,
+    upper = upper_bound,
+    interval = interval,
+    edge_distance = min_distance,
+    upper_inclusive = FALSE
+  )
+  ticks <- c(ticks, regular_ticks)
 
   ticks <- sort(unique(c(ticks, mean_effect)))
 
@@ -282,31 +288,6 @@ generate_funnel_ticks <- function(bounds, mean_effect, add_zero, theme_name) {
     tick_colors = tick_colors,
     mean_effect = mean_effect
   )
-}
-
-
-#' Determine appropriate tick interval based on data range
-#'
-#' @param range_size *\[numeric\]* The range of data values
-#' @return *\[numeric\]* Appropriate tick interval
-#' @keywords internal
-determine_tick_interval <- function(range_size) {
-  if (range_size <= 1) {
-    return(0.2)
-  }
-  if (range_size <= 5) {
-    return(1)
-  }
-  if (range_size <= 20) {
-    return(5)
-  }
-  if (range_size <= 50) {
-    return(10)
-  }
-  if (range_size <= 100) {
-    return(20)
-  }
-  50
 }
 
 
@@ -383,36 +364,6 @@ create_funnel_plot <- function(df, tick_info, theme_name, precision_to_log, use_
     plot_theme
 
   p
-}
-
-
-#' Export funnel plot to file
-#'
-#' @param plot *\[ggplot\]* The plot to export
-#' @param export_path *\[character\]* Directory path
-#' @param graph_scale *\[numeric\]* Scale factor
-#'
-#' @return NULL (invisibly)
-#' @keywords internal
-export_funnel_plot <- function(plot, export_path, graph_scale) {
-  box::use(
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
-  )
-
-  ensure_export_dir(export_path)
-
-  filename <- build_export_filename("funnel_plot", "effect_precision")
-  full_path <- file.path(export_path, filename)
-
-  save_plot(
-    plot = plot,
-    path = full_path,
-    width = 800,
-    height = 736,
-    scale = graph_scale
-  )
-
-  invisible(NULL)
 }
 
 

--- a/inst/artma/methods/prima_facie_graphs.R
+++ b/inst/artma/methods/prima_facie_graphs.R
@@ -13,7 +13,7 @@ prima_facie_graphs <- function(df) {
     artma / options / index[get_option_group],
     artma / variable / detection[detect_variable_groups],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
+    artma / visualization / export[export_named_plots]
   )
 
   validate(is.data.frame(df))
@@ -111,11 +111,14 @@ prima_facie_graphs <- function(df) {
   }
 
   if (export_graphics) {
-    export_prima_facie_plots(
+    export_named_plots(
       plots = plots,
-      group_names = group_names,
+      base_name = "prima_facie",
       export_path = export_path,
-      graph_scale = graph_scale
+      graph_scale = graph_scale,
+      names = group_names,
+      width = 800,
+      height = 666
     )
   }
 
@@ -344,39 +347,6 @@ create_prima_facie_plot <- function(df, group_col, group_name, graph_type,
     )
 
   p
-}
-
-
-#' Export prima facie plots to files
-#'
-#' @param plots *\[list\]* Named list of ggplot objects
-#' @param group_names *\[character\]* Vector of group base names
-#' @param export_path *\[character\]* Directory path
-#' @param graph_scale *\[numeric\]* Scale factor
-#'
-#' @return NULL (invisibly)
-#' @keywords internal
-export_prima_facie_plots <- function(plots, group_names, export_path, graph_scale) {
-  box::use(
-    artma / visualization / export[save_plot, build_export_filename, ensure_export_dir]
-  )
-
-  ensure_export_dir(export_path)
-
-  for (i in seq_along(plots)) {
-    filename <- build_export_filename("prima_facie", group_names[i])
-    full_path <- file.path(export_path, filename)
-
-    save_plot(
-      plot = plots[[i]],
-      path = full_path,
-      width = 800,
-      height = 666,
-      scale = graph_scale
-    )
-  }
-
-  invisible(NULL)
 }
 
 

--- a/inst/artma/methods/t_stat_histogram.R
+++ b/inst/artma/methods/t_stat_histogram.R
@@ -13,11 +13,7 @@ t_stat_histogram <- function(df) {
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[
-      save_plot,
-      build_export_filename,
-      ensure_export_dir
-    ]
+    artma / visualization / export[export_named_plots]
   )
 
   validate(is.data.frame(df))
@@ -137,13 +133,16 @@ t_stat_histogram <- function(df) {
 
   # Export if enabled
   if (export_graphics) {
-    export_t_stat_histograms(
-      main_plot = main_result$plot,
-      close_up_plot = if (!is.null(close_up_result)) {
-        close_up_result$plot
-      },
+    export_named_plots(
+      plots = list(
+        full_range = main_result$plot,
+        close_up = if (!is.null(close_up_result)) close_up_result$plot
+      ),
+      base_name = "t_stat_histogram",
       export_path = export_path,
-      graph_scale = graph_scale
+      graph_scale = graph_scale,
+      width = 800,
+      height = 600
     )
   }
 
@@ -216,31 +215,6 @@ compute_data_bounds <- function(filtered_values,
 }
 
 
-#' Determine tick interval for histogram based on data range
-#'
-#' @param range_size *\[numeric\]* Range of data
-#' @return *\[numeric\]* Tick interval
-#' @keywords internal
-determine_histogram_tick_interval <- function(range_size) {
-  if (range_size <= 5) {
-    return(1)
-  }
-  if (range_size <= 20) {
-    return(2)
-  }
-  if (range_size <= 50) {
-    return(5)
-  }
-  if (range_size <= 100) {
-    return(10)
-  }
-  if (range_size <= 200) {
-    return(20)
-  }
-  50
-}
-
-
 #' Generate intelligent x-axis ticks for t-statistic histogram
 #'
 #' @description
@@ -263,7 +237,8 @@ generate_histogram_ticks <- function(bounds,
                                      min_tick_distance,
                                      theme_name) {
   box::use(
-    artma / visualization / colors[get_colors, get_vline_color]
+    artma / visualization / colors[get_colors, get_vline_color],
+    artma / visualization / ticks[resolve_tick_interval, generate_regular_ticks]
   )
 
   lower <- bounds[1]
@@ -278,24 +253,23 @@ generate_histogram_ticks <- function(bounds,
   special_ticks <- unique(c(crit_ticks, mean_value))
 
   # Determine interval for regular ticks
-  interval <- determine_histogram_tick_interval(range_size)
+  interval <- resolve_tick_interval(
+    range_size,
+    breakpoints = c(5, 20, 50, 100, 200),
+    intervals = c(1, 2, 5, 10, 20),
+    fallback = 50
+  )
 
   # Generate regular ticks
-  start_tick <- ceiling(lower / interval) * interval
-  regular_ticks <- numeric(0)
-  current <- start_tick
-  while (current <= upper) {
-    far_from_special <- all(
-      abs(current - special_ticks) >= min_tick_distance
-    )
-    far_from_lower <- abs(current - lower) >= min_tick_distance / 2
-    far_from_upper <- abs(current - upper) >= min_tick_distance / 2
-
-    if (far_from_special && far_from_lower && far_from_upper) {
-      regular_ticks <- c(regular_ticks, current)
-    }
-    current <- current + interval
-  }
+  regular_ticks <- generate_regular_ticks(
+    lower = lower,
+    upper = upper,
+    interval = interval,
+    edge_distance = min_tick_distance / 2,
+    special_values = special_ticks,
+    special_distance = min_tick_distance,
+    upper_inclusive = TRUE
+  )
 
   # Combine all ticks
   all_ticks <- sort(unique(c(
@@ -460,59 +434,6 @@ build_histogram <- function(t_values,
     n_outliers = filter_result$n_outliers,
     mean_t = mean_t
   )
-}
-
-
-#' Export t-statistic histograms to files
-#'
-#' @param main_plot *\[ggplot\]* Main histogram
-#' @param close_up_plot *\[ggplot, NULL\]* Close-up histogram
-#' @param export_path *\[character\]* Directory
-#' @param graph_scale *\[numeric\]* Scale factor
-#'
-#' @return NULL (invisibly)
-#' @keywords internal
-export_t_stat_histograms <- function(main_plot,
-                                     close_up_plot,
-                                     export_path,
-                                     graph_scale) {
-  box::use(
-    artma / visualization / export[
-      save_plot,
-      build_export_filename,
-      ensure_export_dir
-    ]
-  )
-
-  ensure_export_dir(export_path)
-
-  if (!is.null(main_plot)) {
-    filename <- build_export_filename(
-      "t_stat_histogram", "full_range"
-    )
-    save_plot(
-      plot = main_plot,
-      path = file.path(export_path, filename),
-      width = 800,
-      height = 600,
-      scale = graph_scale
-    )
-  }
-
-  if (!is.null(close_up_plot)) {
-    filename <- build_export_filename(
-      "t_stat_histogram", "close_up"
-    )
-    save_plot(
-      plot = close_up_plot,
-      path = file.path(export_path, filename),
-      width = 800,
-      height = 600,
-      scale = graph_scale
-    )
-  }
-
-  invisible(NULL)
 }
 
 

--- a/inst/artma/visualization/export.R
+++ b/inst/artma/visualization/export.R
@@ -239,10 +239,149 @@ save_plot_html <- function(plot, path) {
 }
 
 
+#' Export a single base-graphics plot to a PNG file
+#'
+#' @description
+#' Opens a PNG device sized `width`/`height` (scaled by `graph_scale`),
+#' invokes `draw()` to render into it, and guarantees the device is closed
+#' even if `draw()` errors.
+#'
+#' @param draw *\[function\]* Zero-argument function that draws the plot
+#' @param path *\[character\]* Full file path (including filename)
+#' @param width *\[numeric\]* Unscaled device width, in pixels
+#' @param height *\[numeric\]* Unscaled device height, in pixels
+#' @param graph_scale *\[numeric\]* Scale multiplier for dimensions and resolution
+#'
+#' @return NULL (invisibly)
+#' @keywords internal
+export_base_plot <- function(draw, path, width, height, graph_scale) {
+  box::use(artma / libs / core / validation[validate])
+
+  validate(
+    is.function(draw),
+    is.character(path),
+    is.numeric(width), width > 0,
+    is.numeric(height), height > 0,
+    is.numeric(graph_scale), graph_scale > 0
+  )
+
+  if (file.exists(path)) {
+    file.remove(path)
+  }
+
+  open_png_device(
+    path,
+    width = width * graph_scale,
+    height = height * graph_scale,
+    units = "px",
+    res = 90 * graph_scale
+  )
+  on.exit(grDevices::dev.off(), add = TRUE)
+  draw()
+
+  invisible(NULL)
+}
+
+
+#' Export a named collection of plots to files
+#'
+#' @description
+#' Generic replacement for the near-identical `export_*_plots` wrappers that
+#' used to live one per method: builds a standardized filename for each plot
+#' via `build_export_filename()` and writes it with either `save_plot()`
+#' (ggplot2 objects) or `export_base_plot()` (zero-argument base-graphics draw
+#' functions).
+#'
+#' `NULL` entries in `plots` are skipped (e.g. an optional close-up plot that
+#' was not built). Entries are named for filename purposes either by
+#' `names(plots)`, or by `names` when supplied; a scalar `names` is recycled
+#' across every plot. When every plot shares the same name and there is more
+#' than one plot, a `1`-based index is appended to disambiguate filenames
+#' (matching the historical box-plot naming scheme); set `use_indexing`
+#' explicitly to override this inference.
+#'
+#' @param plots *\[list\]* List of plots (ggplot objects, or zero-argument draw
+#'   functions when `renderer = "base"`). May contain `NULL` entries, which
+#'   are skipped.
+#' @param base_name *\[character\]* Base filename prefix (e.g. "box_plot")
+#' @param export_path *\[character\]* Directory to export to
+#' @param graph_scale *\[numeric\]* Scale factor for dimensions
+#' @param names *\[character, optional\]* Name to use per plot for the
+#'   filename. Defaults to `names(plots)`. A scalar is recycled.
+#' @param width *\[numeric\]* Unscaled plot width. Defaults to 800.
+#' @param height *\[numeric\]* Unscaled plot height. Defaults to 600.
+#' @param use_indexing *\[logical, optional\]* Force (or suppress) the
+#'   numeric-suffix disambiguation. Defaults to auto-detection (see above).
+#' @param renderer *\[character\]* Either `"ggplot"` (default, uses
+#'   `save_plot()`) or `"base"` (uses `export_base_plot()` for base-graphics
+#'   draw functions).
+#'
+#' @return NULL (invisibly)
+export_named_plots <- function(plots,
+                               base_name,
+                               export_path,
+                               graph_scale,
+                               names = NULL,
+                               width = 800,
+                               height = 600,
+                               use_indexing = NULL,
+                               renderer = c("ggplot", "base")) {
+  box::use(artma / libs / core / validation[validate])
+
+  renderer <- match.arg(renderer)
+
+  validate(
+    is.list(plots),
+    is.character(base_name),
+    is.character(export_path),
+    is.numeric(graph_scale)
+  )
+
+  ensure_export_dir(export_path)
+
+  plot_names <- names %||% base::names(plots)
+  validate(!is.null(plot_names), length(plot_names) %in% c(1, length(plots)))
+  if (length(plot_names) == 1 && length(plots) > 1) {
+    plot_names <- rep(plot_names, length(plots))
+  }
+
+  if (is.null(use_indexing)) {
+    use_indexing <- length(plots) > 1 && length(unique(plot_names)) == 1
+  }
+
+  for (i in seq_along(plots)) {
+    plot <- plots[[i]]
+    if (is.null(plot)) {
+      next
+    }
+
+    index <- if (use_indexing) i else NULL
+    filename <- build_export_filename(base_name, plot_names[i], index = index)
+    full_path <- file.path(export_path, filename)
+
+    if (renderer == "base") {
+      export_base_plot(plot, full_path, width = width, height = height, graph_scale = graph_scale)
+    } else {
+      save_plot(
+        plot = plot,
+        path = full_path,
+        width = width,
+        height = height,
+        scale = graph_scale
+      )
+    }
+  }
+
+  invisible(NULL)
+}
+
+
 box::export(
   ensure_export_dir,
   build_export_filename,
   open_png_device,
   save_plot,
-  save_plot_html
+  save_plot_html,
+  export_base_plot,
+  export_named_plots
 )

--- a/inst/artma/visualization/ticks.R
+++ b/inst/artma/visualization/ticks.R
@@ -44,7 +44,110 @@ format_colored_tick_labels <- function(ticks, colors) {
   colored
 }
 
+#' Resolve a tick interval from a breakpoint table
+#'
+#' @description
+#' Shared stepwise lookup used by plot-specific tick generators: the first
+#' breakpoint that the data range does not exceed determines the interval,
+#' falling back to `fallback` when the range exceeds every breakpoint.
+#'
+#' @param range_size *\[numeric\]* The range of the data being ticked
+#' @param breakpoints *\[numeric\]* Ascending upper bounds for each interval
+#' @param intervals *\[numeric\]* Interval to use for each breakpoint
+#'   (same length as `breakpoints`)
+#' @param fallback *\[numeric\]* Interval used when `range_size` exceeds every
+#'   breakpoint
+#'
+#' @return *\[numeric\]* The resolved tick interval
+#' @keywords internal
+resolve_tick_interval <- function(range_size, breakpoints, intervals, fallback) {
+  box::use(artma / libs / core / validation[validate])
+
+  validate(
+    is.numeric(range_size), length(range_size) == 1,
+    is.numeric(breakpoints),
+    is.numeric(intervals), length(breakpoints) == length(intervals),
+    is.numeric(fallback), length(fallback) == 1
+  )
+
+  for (i in seq_along(breakpoints)) {
+    if (range_size <= breakpoints[i]) {
+      return(intervals[i])
+    }
+  }
+
+  fallback
+}
+
+#' Generate evenly spaced regular ticks within bounds
+#'
+#' @description
+#' Shared stepping loop used by plot-specific tick generators: starting from
+#' the first multiple of `interval` at or above `lower`, walks up to `upper`
+#' by `interval`, keeping a candidate only when it stays `edge_distance` away
+#' from both bounds and (if any `special_values` are given) `special_distance`
+#' away from all of them. Exact duplicates are left for the caller to remove
+#' via `sort(unique(...))`, matching prior per-plot behavior.
+#'
+#' @param lower *\[numeric\]* Lower bound
+#' @param upper *\[numeric\]* Upper bound
+#' @param interval *\[numeric\]* Step size between candidate ticks
+#' @param edge_distance *\[numeric\]* Minimum distance a candidate must keep
+#'   from `lower` and `upper`
+#' @param special_values *\[numeric\]* Values (e.g. mean, critical values) that
+#'   candidates must also keep clear of. Defaults to none.
+#' @param special_distance *\[numeric\]* Minimum distance from `special_values`.
+#'   Defaults to `edge_distance`.
+#' @param upper_inclusive *\[logical\]* Whether `upper` itself is a valid
+#'   candidate position. Defaults to `FALSE`.
+#'
+#' @return *\[numeric\]* The generated regular tick positions (may be empty)
+#' @keywords internal
+generate_regular_ticks <- function(lower,
+                                   upper,
+                                   interval,
+                                   edge_distance,
+                                   special_values = numeric(0),
+                                   special_distance = edge_distance,
+                                   upper_inclusive = FALSE) {
+  box::use(artma / libs / core / validation[validate])
+
+  validate(
+    is.numeric(lower), length(lower) == 1,
+    is.numeric(upper), length(upper) == 1,
+    is.numeric(interval), length(interval) == 1, interval > 0,
+    is.numeric(edge_distance), length(edge_distance) == 1,
+    is.numeric(special_values),
+    is.numeric(special_distance), length(special_distance) == 1,
+    is.logical(upper_inclusive)
+  )
+
+  ticks <- numeric(0)
+  current <- ceiling(lower / interval) * interval
+
+  in_range <- function(x) if (upper_inclusive) x <= upper else x < upper
+
+  while (in_range(current)) {
+    far_from_edges <- abs(current - lower) >= edge_distance &&
+      abs(current - upper) >= edge_distance
+    far_from_special <- if (length(special_values)) {
+      all(abs(current - special_values) >= special_distance)
+    } else {
+      TRUE
+    }
+
+    if (far_from_edges && far_from_special) {
+      ticks <- c(ticks, current)
+    }
+    current <- current + interval
+  }
+
+  ticks
+}
+
 box::export(
   format_tick_labels,
-  format_colored_tick_labels
+  format_colored_tick_labels,
+  resolve_tick_interval,
+  generate_regular_ticks
 )

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -4,11 +4,12 @@ box::use(
     expect_error,
     expect_named,
     expect_false,
+    expect_setequal,
     expect_true,
     skip_if_not_installed,
     test_that
   ],
-  withr[local_options]
+  withr[local_options, local_tempdir]
 )
 
 box::use(ggplot2[is_ggplot])
@@ -374,4 +375,40 @@ test_that("best_practice_estimate reports has_recommendation explicitly in the o
   # Every demo predictor matches a keyword rule, so all have a genuine recommendation.
   expect_true(all(overrides$has_recommendation))
   expect_false(any(overrides$recommended == "no recommendation"))
+})
+
+test_that("best_practice_estimate writes one PNG per plot when export is enabled", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+  dir <- local_tempdir()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = make_bpe_demo_config(),
+    artma.output.save_results = FALSE,
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd",
+    artma.methods.best_practice_estimate.include_study_rows = TRUE
+  ))
+
+  bma_result <- bma(df)
+
+  local_options(list(
+    artma.visualization.export_graphics = TRUE,
+    artma.visualization.export_path = dir
+  ))
+
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  expect_setequal(
+    list.files(dir),
+    paste0("best_practice_estimate_", names(result$plots), ".png")
+  )
 })

--- a/tests/testthat/test-box-plot-study-label.R
+++ b/tests/testthat/test-box-plot-study-label.R
@@ -1,5 +1,5 @@
 box::use(
-  testthat[expect_equal, expect_true, test_that]
+  testthat[expect_equal, expect_setequal, expect_true, test_that]
 )
 
 box::use(
@@ -56,4 +56,28 @@ test_that("box_plot builds a plot even when the data has duplicate column names"
   expect_equal(result$meta$factor_by, "study_label")
   expect_true(inherits(result$plots[[1]], "ggplot"))
   expect_true(is.data.frame(ggplot2::ggplot_build(result$plots[[1]])$data[[1]]))
+})
+
+test_that("box_plot writes exactly one PNG file when export is enabled", {
+  df <- data.frame(
+    study_id = c(1L, 2L, 1L, 3L),
+    study_label = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)", "Clark (2010)"),
+    effect = c(0.2, 0.3, 0.1, 0.4),
+    se = c(0.1, 0.1, 0.2, 0.1),
+    n_obs = c(100, 120, 100, 140),
+    stringsAsFactors = FALSE
+  )
+  dir <- withr::local_tempdir()
+
+  withr::local_options(list(
+    "artma.visualization.export_graphics" = TRUE,
+    "artma.visualization.export_path" = dir,
+    "artma.output.save_results" = FALSE,
+    "artma.verbose" = 1,
+    "artma.data.columns" = list()
+  ))
+
+  box_plot(df)
+
+  expect_setequal(list.files(dir), "box_plot_study_label.png")
 })

--- a/tests/testthat/test-funnel-plot.R
+++ b/tests/testthat/test-funnel-plot.R
@@ -167,6 +167,21 @@ test_that("funnel_plot handles precision_to_log option", {
 })
 
 
+test_that("funnel_plot writes exactly one PNG file when export is enabled", {
+  dir <- withr::local_tempdir()
+  local_funnel_options(
+    "artma.visualization.export_graphics" = TRUE,
+    "artma.visualization.export_path" = dir,
+    "artma.output.save_results" = FALSE
+  )
+
+  df <- create_test_data()
+  funnel_plot(df)
+
+  expect_setequal(list.files(dir), "funnel_plot_effect_precision.png")
+})
+
+
 test_that("funnel_plot returns empty result when all data filtered", {
   local_funnel_options(
     "artma.methods.funnel_plot.effect_proximity" = 0,

--- a/tests/testthat/test-funnel-plot.R
+++ b/tests/testthat/test-funnel-plot.R
@@ -5,6 +5,7 @@ box::use(
     expect_named,
     expect_null,
     expect_s3_class,
+    expect_setequal,
     expect_true,
     test_that
   ],

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -106,8 +106,7 @@ test_that("nonlinear tests writes STEM diagnostic plot files when export is enab
 
   res <- suppressWarnings(nonlinear_tests(df))
 
-  expect_true(file.exists(file.path(dir, "stem_funnel.png")))
-  expect_true(file.exists(file.path(dir, "stem_mse.png")))
+  expect_setequal(list.files(dir), c("stem_funnel.png", "stem_mse.png"))
   expect_s3_class(res$plots$stem_funnel, "recordedplot")
   expect_s3_class(res$plots$stem_mse, "recordedplot")
 })

--- a/tests/testthat/test-prima-facie-graphs.R
+++ b/tests/testthat/test-prima-facie-graphs.R
@@ -1,0 +1,35 @@
+box::use(
+  testthat[expect_setequal, test_that],
+  withr[local_options, local_tempdir]
+)
+
+box::use(
+  artma / methods / prima_facie_graphs[prima_facie_graphs]
+)
+
+create_test_data <- function(n = 60, seed = 1) {
+  set.seed(seed)
+  data.frame(
+    effect = rnorm(n, mean = 0.3, sd = 0.2),
+    region_north = rep(c(1, 0), each = n / 2),
+    region_south = rep(c(0, 1), each = n / 2),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("prima_facie_graphs writes one PNG file per detected group when export is enabled", {
+  dir <- local_tempdir()
+
+  local_options(list(
+    "artma.visualization.export_graphics" = TRUE,
+    "artma.visualization.export_path" = dir,
+    "artma.output.save_results" = FALSE,
+    "artma.verbose" = 1,
+    "artma.data.columns" = list()
+  ))
+
+  df <- create_test_data()
+  prima_facie_graphs(df)
+
+  expect_setequal(list.files(dir), "prima_facie_region.png")
+})

--- a/tests/testthat/test-t-stat-histogram.R
+++ b/tests/testthat/test-t-stat-histogram.R
@@ -5,6 +5,7 @@ box::use(
     expect_named,
     expect_null,
     expect_s3_class,
+    expect_setequal,
     expect_true,
     test_that
   ],
@@ -166,4 +167,42 @@ test_that("t_stat_histogram reports correct mean", {
   result <- t_stat_histogram(df)
 
   expect_equal(result$meta$mean_t_stat, 1)
+})
+
+
+test_that("t_stat_histogram writes both PNG files when export and close-up are enabled", {
+  dir <- withr::local_tempdir()
+  local_hist_options(
+    "artma.methods.t_stat_histogram.close_up_enabled" = TRUE,
+    "artma.methods.t_stat_histogram.close_up_lower" = -10,
+    "artma.methods.t_stat_histogram.close_up_upper" = 10,
+    "artma.methods.t_stat_histogram.close_up_min_tick_distance" = 0.3,
+    "artma.visualization.export_graphics" = TRUE,
+    "artma.visualization.export_path" = dir,
+    "artma.output.save_results" = FALSE
+  )
+
+  df <- create_test_data()
+  t_stat_histogram(df)
+
+  expect_setequal(
+    list.files(dir),
+    c("t_stat_histogram_full_range.png", "t_stat_histogram_close_up.png")
+  )
+})
+
+
+test_that("t_stat_histogram writes only the full-range PNG when close-up is disabled", {
+  dir <- withr::local_tempdir()
+  local_hist_options(
+    "artma.methods.t_stat_histogram.close_up_enabled" = FALSE,
+    "artma.visualization.export_graphics" = TRUE,
+    "artma.visualization.export_path" = dir,
+    "artma.output.save_results" = FALSE
+  )
+
+  df <- create_test_data()
+  t_stat_histogram(df)
+
+  expect_setequal(list.files(dir), "t_stat_histogram_full_range.png")
 })


### PR DESCRIPTION
## What moved

- Added a generic `export_named_plots(plots, base_name, export_path, graph_scale, ...)` in `inst/artma/visualization/export.R`, replacing the six near-identical `export_*_plots`/`export_stem_plot` wrappers previously duplicated in `best_practice_estimate.R`, `funnel_plot.R`, `box_plot.R`, `prima_facie_graphs.R`, `t_stat_histogram.R`, and `econometric/nonlinear.R`. It supports both ggplot objects (via the existing `save_plot()`) and base-graphics draw functions (via a new `export_base_plot()` helper, used for the STEM plots), with a shared filename convention and optional numeric-suffix disambiguation.
- Moved the duplicated tick-interval math out of `funnel_plot.R` and `t_stat_histogram.R` into two new shared helpers in `inst/artma/visualization/ticks.R`: `resolve_tick_interval()` (breakpoint-table lookup) and `generate_regular_ticks()` (the bounds/edge/special-value stepping loop). Each method still supplies its own breakpoint table and distance parameters, since the two callers use different thresholds.

## What changed behavior

None intended. Every migrated writer still calls `record_output_file()` (verified: `save_plot()` and `open_png_device()`, which `export_base_plot()` uses, both already call it, so every export path stays cache-revalidation safe with no new call sites needed). Output file names, graphics devices, and dimensions are preserved exactly for every one of the six call sites.

## Tests pinning the output

Added file-set snapshot tests (checking the set of files written, not pixels) covering every migrated writer:
- `tests/testthat/test-funnel-plot.R`: writes exactly `funnel_plot_effect_precision.png`.
- `tests/testthat/test-box-plot-study-label.R`: writes exactly `box_plot_study_label.png`.
- `tests/testthat/test-t-stat-histogram.R`: writes both `t_stat_histogram_full_range.png` and `t_stat_histogram_close_up.png` when close-up is enabled, and only the full-range file when it is disabled.
- `tests/testthat/test-prima-facie-graphs.R` (new file, no prior coverage existed): writes `prima_facie_<group>.png` per detected group.
- `tests/testthat/test-best-practice-estimate.R`: writes one `best_practice_estimate_<plot_name>.png` per entry in the returned `plots` list.
- `tests/testthat/test-nonlinear-tests.R`: tightened the existing STEM plot check to assert the exact file set (`stem_funnel.png`, `stem_mse.png`).

All of the above pass locally, along with the full `test-visualization.R` and `test-visualization-fork-safety.R` suites. `styler::style_file()` and `LC_ALL=en_US.UTF-8 make lint` are clean on every changed file.

Refs #322 (item B3)