### PR TITLE
feat(data): reconcile column-mapping conflicts and give actionable collision errors

### DIFF
--- a/R/data_config.R
+++ b/R/data_config.R
@@ -34,7 +34,10 @@ config.get <- function(var_name = NULL, options_file_name = NULL, options_dir = 
 #'   values are persisted to the options file.
 #' @param var_name *\[character\]* The variable name to configure.
 #' @param ... Named arguments for config fields to set
-#'   (e.g., `bma = TRUE, bma_to_log = TRUE`).
+#'   (e.g., `bma = TRUE, bma_to_log = TRUE`). Column mappings are set the same
+#'   way: `source_name = "study_name"` maps the variable to that column in the
+#'   data file, and `drop_conflicting_raw = TRUE` keeps such a mapping while
+#'   dropping a different raw column that occupies the standard name.
 #' @param options_file_name *\[character, optional\]* The name of the options
 #'   file. If `NULL` (default), the user will be prompted interactively.
 #' @param options_dir *\[character, optional\]* The directory containing options
@@ -49,7 +52,11 @@ config.set <- function(var_name, ..., options_file_name = NULL, options_dir = NU
       box::use(artma / data_config / write[update_data_config])
       fields <- list(...)
       if (length(fields) == 0) {
-        cli::cli_abort("No config fields provided. Use named arguments, e.g., {.code bma = TRUE}.")
+        cli::cli_abort(c(
+          "x" = "No config fields provided.",
+          "i" = "Usage: {.code artma::config.set(\"<variable>\", <field> = <value>)}, e.g. {.code artma::config.set(\"study_id\", source_name = \"study_name\")}.",
+          "i" = "To inspect current values, use {.code artma::config.get()}."
+        ))
       }
       changes <- list()
       changes[[make.names(var_name)]] <- fields

--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -42,6 +42,7 @@ CONST <- list(
   DATA_CONFIG = list(
     KEYS = list(
       SOURCE_NAME = "source_name",
+      DROP_CONFLICTING_RAW = "drop_conflicting_raw",
       IS_COMPUTED = "is_computed",
       VAR_NAME = "var_name",
       VAR_NAME_VERBOSE = "var_name_verbose",

--- a/inst/artma/data/schema_reconcile.R
+++ b/inst/artma/data/schema_reconcile.R
@@ -111,7 +111,10 @@ emit_reconcile_complete <- function() {
 #'   name for role columns and by the column's own name for moderators.
 #' @return *\[list\]* Drift report with fields: `missing_roles` (named character
 #'   vector, names = standard names, values = the stored source columns that
-#'   vanished), `missing_moderators`, `added`, and `has_drift`.
+#'   vanished), `missing_moderators`, `added`, `conflicts` (named character
+#'   vector, names = standard names whose non-identity mapping collides with a
+#'   different raw column of the same name, values = the mapped source
+#'   columns), and `has_drift`.
 #' @keywords internal
 detect_schema_drift <- function(raw_df, columns_store) {
   box::use(
@@ -147,6 +150,31 @@ detect_schema_drift <- function(raw_df, columns_store) {
   missing_role_std <- names(role_values)[!role_values %in% df_cols]
   missing_roles <- vapply(role_sources[missing_role_std], identity, character(1))
 
+  # --- Mapping conflicts ---
+  # A role mapped (non-identity) to a source column collides when the raw data
+  # also contains a *different* column named exactly like the standard name.
+  # Renaming the source would then produce two columns sharing that name, so
+  # `standardize_column_names()` aborts. Flag it here so reconciliation can
+  # resolve it up front. Byte-identical occupants are excluded (the pipeline
+  # drops those quietly), as are conflicts the user already resolved via
+  # `drop_conflicting_raw`.
+  conflicts <- character(0)
+  raw_df_cols <- make.names(colnames(raw_df))
+  for (std in names(role_values)) {
+    src_norm <- role_values[[std]]
+    if (identical(src_norm, std)) next
+    if (!std %in% df_cols || !src_norm %in% df_cols) next
+
+    entry <- columns_store[[std]]
+    if (is.list(entry) && isTRUE(entry[["drop_conflicting_raw"]])) next
+
+    src_values <- raw_df[[which(raw_df_cols == src_norm)[[1]]]]
+    std_values <- raw_df[[which(raw_df_cols == std)[[1]]]]
+    if (identical(src_values, std_values)) next
+
+    conflicts[[std]] <- role_sources[[std]]
+  }
+
   # --- Moderator columns (non-role record keys) ---
   # Computed columns are added by the pipeline, not by the user's data, so they
   # will never be present in the raw df and must not be flagged as missing.
@@ -172,10 +200,12 @@ detect_schema_drift <- function(raw_df, columns_store) {
     missing_roles = missing_roles, # named: std name -> stored source column
     missing_moderators = missing_moderators,
     added = added,
+    conflicts = conflicts, # named: std name -> mapped source column
     has_drift = (
       length(missing_roles) > 0 ||
         length(missing_moderators) > 0 ||
-        length(added) > 0
+        length(added) > 0 ||
+        length(conflicts) > 0
     )
   )
 }
@@ -250,7 +280,11 @@ show_drift_summary <- function(drift, proposals_roles, proposals_moderators, rol
   cli::cli_h3("Standard columns")
   for (std in names(role_sources)) {
     stored <- role_sources[[std]]
-    if (std %in% names(drift$missing_roles)) {
+    if (std %in% names(drift$conflicts)) {
+      cli::cli_alert_warning(
+        "{.val {stored}} {cli::symbol$arrow_right} {.val {std}} CONFLICTS with an existing {.val {std}} column in the data"
+      )
+    } else if (std %in% names(drift$missing_roles)) {
       prop <- proposals_roles[[std]]
       if (!is.null(prop) && !is.na(prop$candidate)) {
         cli::cli_alert_warning(
@@ -299,6 +333,19 @@ auto_decisions <- function(drift, proposals_roles, proposals_moderators) {
   renames <- list()
   drops <- character(0)
   remaps <- list()
+  conflicts <- list()
+
+  # Mapping conflicts: the explicit mapping is a deliberate user choice, so it
+  # wins over a colliding raw column; the raw column is dropped with a warning.
+  for (std in names(drift$conflicts)) {
+    src <- drift$conflicts[[std]]
+    conflicts[[std]] <- "keep_mapping"
+    if (get_verbosity() >= 2) {
+      cli::cli_alert_warning(
+        "Column {.val {std}} is mapped from {.val {src}}, but the data also contains a different {.val {std}} column. Keeping the mapping and dropping the raw {.val {std}} column. Run {.code artma::config.reset(\"{std}\")} to use the raw column instead."
+      )
+    }
+  }
 
   # Role columns: accept high-confidence proposals, abort if unresolvable
   for (std in names(drift$missing_roles)) {
@@ -347,7 +394,7 @@ auto_decisions <- function(drift, proposals_roles, proposals_moderators) {
     }
   }
 
-  list(renames = renames, drops = drops, remaps = remaps)
+  list(renames = renames, drops = drops, remaps = remaps, conflicts = conflicts)
 }
 
 #' @title Ask for reconciliation decisions interactively
@@ -357,8 +404,31 @@ ask_decisions <- function(drift, proposals_roles, proposals_moderators, raw_df) 
   renames <- list()
   drops <- character(0)
   remaps <- list()
+  conflicts <- list()
 
   all_df_cols <- make.names(colnames(raw_df))
+
+  # --- Mapping conflicts ---
+  for (std in names(drift$conflicts)) {
+    src <- drift$conflicts[[std]]
+
+    prompt_text <- cli::format_inline(
+      "Column {.val {std}} is mapped from {.val {src}}, but the data also contains a different column named {.val {std}}. Which one should supply {.val {std}}?"
+    )
+    choices <- c(
+      cli::format_inline("Keep the mapping: use {.val {src}} and drop the raw {.val {std}} column"),
+      cli::format_inline("Use the raw {.val {std}} column (removes the mapping from {.val {src}})"),
+      "Abort"
+    )
+
+    choice <- climenu::select(choices = choices, prompt = prompt_text)
+
+    if (is.null(choice) || grepl("^Abort", choice)) {
+      cli::cli_abort("Reconciliation aborted by user.")
+    }
+
+    conflicts[[std]] <- if (grepl("^Keep", choice)) "keep_mapping" else "use_existing"
+  }
 
   # --- Role columns ---
   for (std in names(drift$missing_roles)) {
@@ -456,7 +526,7 @@ ask_decisions <- function(drift, proposals_roles, proposals_moderators, raw_df) 
     }
   }
 
-  list(renames = renames, drops = drops, remaps = remaps)
+  list(renames = renames, drops = drops, remaps = remaps, conflicts = conflicts)
 }
 
 # -- Confirmation and summary --
@@ -471,6 +541,20 @@ confirm_decisions <- function(decisions, drift, role_sources) {
     old_raw <- role_sources[[std]]
     new_raw <- decisions$renames[[std]]
     cli::cli_alert_success("Mapped: {.val {old_raw}} {cli::symbol$arrow_right} {.val {new_raw}}")
+  }
+
+  # Mapping conflict resolutions
+  for (std in names(decisions$conflicts)) {
+    src <- role_sources[[std]]
+    if (identical(decisions$conflicts[[std]], "keep_mapping")) {
+      cli::cli_alert_success(
+        "Kept mapping: {.val {src}} {cli::symbol$arrow_right} {.val {std}} (the raw {.val {std}} column will be dropped from the analysis)"
+      )
+    } else {
+      cli::cli_alert_success(
+        "Using the raw {.val {std}} column (removed the mapping from {.val {src}})"
+      )
+    }
   }
 
   # Moderator drops
@@ -492,7 +576,10 @@ confirm_decisions <- function(decisions, drift, role_sources) {
   }
 
   # Unchanged role columns
-  unchanged <- setdiff(names(role_sources), names(drift$missing_roles))
+  unchanged <- setdiff(
+    names(role_sources),
+    c(names(drift$missing_roles), names(drift$conflicts))
+  )
   if (length(unchanged) > 0) {
     unchanged_raw <- unlist(role_sources[unchanged], use.names = FALSE)
     cli::cli_alert_success("Unchanged: {.val {unchanged_raw}}")
@@ -551,6 +638,22 @@ apply_reconciliation <- function(decisions) {
     }
   }
 
+  # 4. Mapping conflict resolutions: either the mapping wins and the raw
+  #    column is flagged for dropping at standardization time, or the mapping
+  #    is removed so the raw column backs the role directly.
+  for (std in names(decisions$conflicts)) {
+    entry <- store[[std]]
+    if (!is.list(entry)) entry <- list()
+    if (identical(decisions$conflicts[[std]], "keep_mapping")) {
+      entry$drop_conflicting_raw <- TRUE
+      store[[std]] <- entry
+    } else {
+      entry$source_name <- NULL
+      entry$drop_conflicting_raw <- NULL
+      store[[std]] <- if (length(entry) == 0) NULL else entry
+    }
+  }
+
   write_unified_columns(store)
 
   invisible(NULL)
@@ -579,30 +682,37 @@ reconcile_schema <- function(raw_df, mode = NULL) {
     getOption("artma.data.expected_schema_columns", NA_character_)
   )
 
-  # Initialize baseline schema on first run. Until this baseline exists, drift
-  # details are suppressed regardless of reconcile mode.
-  if (length(expected_schema_cols) == 0L) {
-    persist_expected_schema_cols(current_schema_cols)
-    emit_reconcile_complete()
-    return(invisible(NULL))
-  }
+  first_run <- length(expected_schema_cols) == 0L
 
   columns_store <- get_columns_store()
 
   # Detect drift
   drift <- detect_schema_drift(raw_df, columns_store)
 
-  # "Added" columns should only include columns that are new relative to the
-  # stored baseline schema. Baseline columns that are simply not mapped should
-  # not be treated as drift on every run.
-  drift$added <- setdiff(drift$added, expected_schema_cols)
+  if (first_run) {
+    # No baseline schema yet: missing/added comparisons are meaningless, so
+    # suppress them. Mapping conflicts are baseline-independent (an explicit
+    # mapping colliding with a raw column) and stay actionable even now;
+    # left unresolved they would abort the pipeline later anyway.
+    drift$missing_roles <- stats::setNames(character(0), character(0))
+    drift$missing_moderators <- character(0)
+    drift$added <- character(0)
+  } else {
+    # "Added" columns should only include columns that are new relative to the
+    # stored baseline schema. Baseline columns that are simply not mapped
+    # should not be treated as drift on every run.
+    drift$added <- setdiff(drift$added, expected_schema_cols)
+  }
+
   drift$has_drift <- (
     length(drift$missing_roles) > 0 ||
       length(drift$missing_moderators) > 0 ||
-      length(drift$added) > 0
+      length(drift$added) > 0 ||
+      length(drift$conflicts) > 0
   )
 
   if (!drift$has_drift) {
+    if (first_run) persist_expected_schema_cols(current_schema_cols)
     emit_reconcile_complete()
     return(invisible(NULL))
   }
@@ -623,6 +733,12 @@ reconcile_schema <- function(raw_df, mode = NULL) {
     if (length(drift$added) > 0) {
       msgs <- c(msgs, "i" = cli::format_inline(
         "New column{?s} not in config: {.val {drift$added}}"
+      ))
+    }
+    if (length(drift$conflicts) > 0) {
+      conflict_pairs <- paste0(unname(drift$conflicts), " -> ", names(drift$conflicts))
+      msgs <- c(msgs, "i" = cli::format_inline(
+        "Mapping conflict{?s}: {.val {conflict_pairs}} while the data also contains a different raw column of the same standard name"
       ))
     }
     msgs <- c(msgs,

--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -166,9 +166,13 @@ standardize_column_names <- function(df, auto_detect = TRUE) {
   # A rename target already occupied by a different column would otherwise
   # silently produce two columns sharing a name; `df$<name>` would then return
   # whichever comes first, ignoring the user's explicit mapping. Detect this
-  # before renaming and abort, except for the two cases where no collision
-  # actually results: an identity mapping (source == target, a no-op), or the
-  # occupying column being renamed away itself in this same pass.
+  # before renaming and abort, except for the cases where no collision
+  # actually results: an identity mapping (source == target, a no-op), the
+  # occupying column being renamed away itself in this same pass, or the user
+  # having resolved the conflict in favor of the mapping (drop_conflicting_raw).
+  column_store <- getOption("artma.data.columns", list())
+  if (!is.list(column_store)) column_store <- list()
+
   for (i in seq_along(rename_from)) {
     source_col <- rename_from[[i]]
     target_col <- rename_to[[i]]
@@ -183,9 +187,22 @@ standardize_column_names <- function(df, auto_detect = TRUE) {
       next
     }
 
+    store_entry <- column_store[[target_col]]
+    if (is.list(store_entry) && isTRUE(store_entry[["drop_conflicting_raw"]])) {
+      if (get_verbosity() >= 3) {
+        cli::cli_alert_info(
+          "Dropping the raw {.val {target_col}} column: {.val {source_col}} is configured to supply it."
+        )
+      }
+      df[[target_col]] <- NULL
+      next
+    }
+
     cli::cli_abort(c(
       "x" = "Cannot map {.val {source_col}} to standard column {.val {target_col}}: the data frame already has a different column named {.val {target_col}}.",
-      "i" = "Resolve this by remapping {.val {target_col}} to a different source column, removing that mapping (e.g. via {.code artma::config.set()} or your options file), or renaming the raw {.val {target_col}} column in your data."
+      "i" = "Keep the mapping and drop the raw column: {.code artma::config.set(\"{target_col}\", drop_conflicting_raw = TRUE)}",
+      "i" = "Use the raw {.val {target_col}} column instead: {.code artma::config.reset(\"{target_col}\")}",
+      "i" = "Or map {.val {target_col}} to another source column: {.code artma::config.set(\"{target_col}\", source_name = \"<column>\")}"
     ))
   }
 

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -922,6 +922,10 @@ data:
       a {.strong source_name} field naming the column in your data file that maps to
       that standard column. Records for moderator variables are keyed by the column's
       own (syntactic) name.
+      A role record may also set {.strong drop_conflicting_raw} to true: when its
+      source_name mapping collides with a different raw column that already carries
+      the standard name, the raw column is dropped from the analysis instead of
+      aborting the run.
       Besides {.strong source_name}, each record can override analysis fields such as
       var_name_verbose, var_name_description, data_type, group_category,
       variable_summary, effect_sum_stats, equal, gltl, bma, bma_reference_var,

--- a/man/config.set.Rd
+++ b/man/config.set.Rd
@@ -10,7 +10,10 @@ config.set(var_name, ..., options_file_name = NULL, options_dir = NULL)
 \item{var_name}{\emph{[character]} The variable name to configure.}
 
 \item{...}{Named arguments for config fields to set
-(e.g., \verb{bma = TRUE, bma_to_log = TRUE}).}
+(e.g., \verb{bma = TRUE, bma_to_log = TRUE}). Column mappings are set the same
+way: \code{source_name = "study_name"} maps the variable to that column in the
+data file, and \code{drop_conflicting_raw = TRUE} keeps such a mapping while
+dropping a different raw column that occupies the standard name.}
 
 \item{options_file_name}{\emph{[character, optional]} The name of the options
 file. If \code{NULL} (default), the user will be prompted interactively.}

--- a/tests/testthat/test-data-config-defaults.R
+++ b/tests/testthat/test-data-config-defaults.R
@@ -80,7 +80,7 @@ test_that("build_default_config_entry: entry has all expected fields", {
 
   entry <- build_default_config_entry("x", c(1, 2, 3))
   expected_fields <- c(
-    "source_name", "is_computed",
+    "source_name", "drop_conflicting_raw", "is_computed",
     "var_name", "var_name_verbose", "var_name_description",
     "data_type", "group_category", "variable_summary",
     "effect_sum_stats", "equal", "gltl", "bma", "bma_reference_var",

--- a/tests/testthat/test-data-schema-reconcile.R
+++ b/tests/testthat/test-data-schema-reconcile.R
@@ -170,6 +170,116 @@ test_that("score_rename_candidate uses the pattern engine when the role is known
   expect_true(with_role >= MATCH_THRESHOLDS$rename_auto)
 })
 
+# Mapping conflicts: a role mapped to a source column while a different raw
+# column already occupies the standard name.
+
+test_that("detect_schema_drift flags a mapping conflict with an occupying raw column", {
+  box::use(artma / data / schema_reconcile[detect_schema_drift])
+
+  # study_id is mapped from "study", but the df also has its own study_id
+  # column with different content.
+  raw_df <- base_df(study_id = c("X", "Y", "Z"))
+
+  result <- detect_schema_drift(raw_df, base_store())
+
+  expect_true(result$has_drift)
+  expect_equal(result$conflicts[["study_id"]], "study")
+  expect_equal(length(result$missing_roles), 0L)
+  # The occupying column carries a standard name, so it is not "added" either.
+  expect_false("study_id" %in% result$added)
+})
+
+test_that("detect_schema_drift ignores a byte-identical occupying column", {
+  box::use(artma / data / schema_reconcile[detect_schema_drift])
+
+  # Identical content: standardize_column_names() resolves this quietly.
+  raw_df <- base_df()
+  raw_df$study_id <- raw_df$study
+
+  result <- detect_schema_drift(raw_df, base_store())
+
+  expect_equal(length(result$conflicts), 0L)
+})
+
+test_that("detect_schema_drift skips conflicts already resolved via drop_conflicting_raw", {
+  box::use(artma / data / schema_reconcile[detect_schema_drift])
+
+  raw_df <- base_df(study_id = c("X", "Y", "Z"))
+  store <- base_store(
+    list(study_id = list(source_name = "study", drop_conflicting_raw = TRUE))
+  )
+
+  result <- detect_schema_drift(raw_df, store)
+
+  expect_equal(length(result$conflicts), 0L)
+})
+
+test_that("detect_schema_drift reports a missing source, not a conflict, when the source vanished", {
+  box::use(artma / data / schema_reconcile[detect_schema_drift])
+
+  # "study" is gone; the occupying study_id column is a rename candidate, not
+  # a conflict.
+  raw_df <- data.frame(
+    effect_size = 1:3, se_col = 0.1, study_id = "A", n_obs = 10L
+  )
+
+  result <- detect_schema_drift(raw_df, base_store())
+
+  expect_true("study_id" %in% names(result$missing_roles))
+  expect_equal(length(result$conflicts), 0L)
+})
+
+test_that("reconcile_schema auto resolves a conflict by keeping the mapping", {
+  box::use(artma / data / schema_reconcile[reconcile_schema])
+
+  raw_df <- base_df(study_id = c("X", "Y", "Z"))
+
+  withr::with_options(
+    base_reconcile_opts(),
+    {
+      reconcile_schema(raw_df, mode = "auto")
+
+      store <- getOption("artma.data.columns")
+      expect_equal(store$study_id$source_name, "study")
+      expect_true(isTRUE(store$study_id$drop_conflicting_raw))
+      expect_true("study_id" %in% getOption("artma.data.expected_schema_columns"))
+    }
+  )
+})
+
+test_that("reconcile_schema resolves conflicts even on the first run without a baseline", {
+  box::use(artma / data / schema_reconcile[reconcile_schema])
+
+  raw_df <- base_df(study_id = c("X", "Y", "Z"))
+
+  withr::with_options(
+    base_reconcile_opts(
+      list("artma.data.expected_schema_columns" = NA_character_)
+    ),
+    {
+      reconcile_schema(raw_df, mode = "auto")
+
+      store <- getOption("artma.data.columns")
+      expect_true(isTRUE(store$study_id$drop_conflicting_raw))
+      expect_true("study_id" %in% getOption("artma.data.expected_schema_columns"))
+    }
+  )
+})
+
+test_that("reconcile_schema strict aborts on a mapping conflict", {
+  box::use(artma / data / schema_reconcile[reconcile_schema])
+
+  raw_df <- base_df(study_id = c("X", "Y", "Z"))
+
+  withr::with_options(
+    base_reconcile_opts(),
+    expect_error(
+      reconcile_schema(raw_df, mode = "strict"),
+      "Mapping conflict"
+    )
+  )
+})
+
 # reconcile_schema (strict mode)
 #
 # The strict-mode abort paths (missing required column, missing moderator, added

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -205,6 +205,45 @@ test_that("standardize_column_names aborts when a rename target is already occup
   )
 })
 
+test_that("the collision abort message names the exact remediation commands", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  mock_df <- build_collision_df("study_name", paste("Study", 1:5))
+
+  withr::with_options(
+    list("artma.data.columns" = list(study_id = list(source_name = "study_name"))),
+    {
+      err <- tryCatch(
+        standardize_column_names(mock_df, auto_detect = FALSE),
+        error = function(e) conditionMessage(e)
+      )
+      expect_true(grepl('config.set("study_id", drop_conflicting_raw = TRUE)', err, fixed = TRUE))
+      expect_true(grepl('config.reset("study_id")', err, fixed = TRUE))
+    }
+  )
+})
+
+test_that("standardize_column_names drops the raw column when drop_conflicting_raw is set", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  mock_df <- build_collision_df("study_name", paste("Study", 1:5))
+
+  withr::with_options(
+    list(
+      "artma.data.columns" = list(
+        study_id = list(source_name = "study_name", drop_conflicting_raw = TRUE)
+      ),
+      "artma.verbose" = 1L
+    ),
+    {
+      standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+      expect_equal(sum(colnames(standardized_df) == "study_id"), 1)
+      expect_equal(standardized_df$study_id, paste("Study", 1:5))
+      expect_false("study_name" %in% colnames(standardized_df))
+    }
+  )
+})
+
 test_that("standardize_column_names allows an identity mapping through quietly", {
   box::use(artma / data / utils[standardize_column_names])
 


### PR DESCRIPTION
## Problem

A role mapping (e.g. `study_id` mapped from `study_name`) whose target standard name is already occupied by a different raw column produced a confusing flow:

1. `reconcile_schema()` printed "Schema reconciliation complete" because `detect_schema_drift()` treated every standard name as referenced, so the collision was never flagged as drift.
2. Two lines later, `standardize_column_names()` hard-aborted on the collision, with remediation advice that pointed at `artma::config.set()` without saying how to use it.
3. A bare `artma::config.set()` call then failed with "No config fields provided. Use named arguments, e.g., `bma = TRUE`.", which gives no hint that mappings are set via `source_name`.

## Changes

- `detect_schema_drift()` reports a new `conflicts` field: roles whose non-identity mapping collides with a different raw column of the same standard name. Byte-identical occupants and already-resolved conflicts are excluded.
- `reconcile_schema()` resolves conflicts as part of the normal drift flow:
  - ask mode: a menu asking which column should supply the role (keep the mapping and drop the raw column, or use the raw column and remove the mapping)
  - auto mode: the explicit mapping wins; the raw column is dropped with a warning that names the undo command
  - strict mode: aborts with the conflict listed
  - conflicts are also detected on the first run, which previously skipped drift detection entirely before the baseline schema existed
- New per-column config field `drop_conflicting_raw`: when set on a role record, `standardize_column_names()` drops the colliding raw column instead of aborting. Added to `CONST$DATA_CONFIG$KEYS` and documented in the options template.
- The collision abort now lists three copy-pasteable fixes: `config.set("<col>", drop_conflicting_raw = TRUE)`, `config.reset("<col>")`, or remapping via `source_name`.
- `config.set()` with no fields now shows usage with a mapping example and points at `config.get()`; its docs mention `source_name` and `drop_conflicting_raw`.

## Testing

- New unit tests for the conflict detection (flagged, byte-identical skip, resolved skip, missing-source precedence), the auto/first-run/strict reconcile paths, the `drop_conflicting_raw` standardization path, and the remediation commands in the abort message.
- Full suite: 2245 passing, 0 failures. Lint clean, docs regenerated.
