### PR TITLE
refactor(formatting): shared publication-bias summary-table builder

### DIFF
--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -16,6 +16,9 @@ box::use(
     format_se,
     format_ci
   ],
+  artma / libs / formatting / summary_table[
+    shared_build_summary_table = build_summary_table
+  ],
   artma / libs / core / validation[validate, assert],
   artma / econometric / vcov[robust_vcov]
 )
@@ -702,32 +705,6 @@ run_exogeneity_tests <- function(df, options) {
 #' instead of leaking raw `NA`/`<NA>` formatting.
 NOT_COMPUTABLE <- "not computable"
 
-#' @title Replace NA entries in a character vector with the placeholder
-#' @param x *[character]* Vector to sanitize.
-#' @return *[character]* Vector with `NA` values replaced by `NOT_COMPUTABLE`.
-na_to_not_computable <- function(x) {
-  x[is.na(x)] <- NOT_COMPUTABLE
-  x
-}
-
-#' @title Fit a summary column to the table's row count
-#' @description
-#' Each summary column is assembled by concatenating per-metric values, any of
-#' which can come back zero-length when the underlying model did not produce
-#' the statistic. A short column makes the data frame assignment fail with an
-#' opaque `replacement has N rows` error, so pad it with the placeholder
-#' instead and keep the table printable.
-#' @param values *[character]* The assembled column.
-#' @param n *[integer]* The number of rows the table has.
-#' @return *[character]* A column of exactly `n` entries.
-fit_summary_column <- function(values, n) {
-  values <- as.character(values)
-  if (length(values) < n) {
-    values <- c(values, rep(NOT_COMPUTABLE, n - length(values)))
-  }
-  values[seq_len(n)]
-}
-
 build_exogeneity_summary <- function(iv_results, puniform_results, options) {
   row_labels <- c(
     "Publication Bias",
@@ -739,11 +716,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
     "F-test (AR)"
   )
 
-  summary <- data.frame(
-    Metric = row_labels,
-    stringsAsFactors = FALSE,
-    check.names = FALSE
-  )
+  columns <- list()
 
   # IV column
   if (!is.null(iv_results$coefficients)) {
@@ -756,7 +729,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
       first_stage_str <- paste0(first_stage_str, " (weak instrument)")
     }
 
-    summary[["IV"]] <- na_to_not_computable(fit_summary_column(c(
+    columns[["IV"]] <- c(
       if (nrow(pb) > 0) pb$estimate_formatted else NA_character_,
       if (nrow(pb) > 0) pb$std_error_formatted else NA_character_,
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
@@ -764,9 +737,9 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
       if (nrow(iv_coef) > 0) format_number(iv_coef$n_obs[1], 0) else NA_character_,
       first_stage_str,
       format_number(as_scalar_stat(iv_results$ar_fstat), options$round_to)
-    ), length(row_labels)))
+    )
   } else {
-    summary[["IV"]] <- rep(NOT_COMPUTABLE, length(row_labels))
+    columns[["IV"]] <- rep(NOT_COMPUTABLE, length(row_labels))
   }
 
   # p-uniform* column
@@ -788,7 +761,7 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
       NA_character_
     }
 
-    summary[["p-Uniform*"]] <- na_to_not_computable(fit_summary_column(c(
+    columns[["p-Uniform*"]] <- c(
       pb_test_str,
       pb_p_str,
       if (nrow(eff) > 0) eff$estimate_formatted else NA_character_,
@@ -796,13 +769,12 @@ build_exogeneity_summary <- function(iv_results, puniform_results, options) {
       if (nrow(pu_coef) > 0) format_number(pu_coef$n_obs[1], 0) else NA_character_,
       "", # No first-stage F for p-uniform
       "" # No F-test for p-uniform
-    ), length(row_labels)))
+    )
   } else {
-    summary[["p-Uniform*"]] <- rep(NOT_COMPUTABLE, length(row_labels))
+    columns[["p-Uniform*"]] <- rep(NOT_COMPUTABLE, length(row_labels))
   }
 
-  attr(summary, "row.names") <- row_labels
-  summary
+  shared_build_summary_table(row_labels, columns, missing_value = NOT_COMPUTABLE)
 }
 
 box::export(

--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -15,6 +15,9 @@ box::use(
     format_se,
     format_ci
   ],
+  artma / libs / formatting / summary_table[
+    shared_build_summary_table = build_summary_table
+  ],
   artma / econometric / vcov[robust_vcov]
 )
 
@@ -743,7 +746,6 @@ build_summary_table <- function(coefficients, digits) {
     return(data.frame())
   }
 
-  models <- unique(coefficients$model)
   row_labels <- c(
     "Publication Bias",
     "(Std. Error)",
@@ -754,13 +756,8 @@ build_summary_table <- function(coefficients, digits) {
     "Total Observations"
   )
 
-  summary <- data.frame(
-    Metric = row_labels,
-    stringsAsFactors = FALSE,
-    check.names = FALSE
-  )
-
-  for (model in models) {
+  columns <- list()
+  for (model in unique(coefficients$model)) {
     model_rows <- coefficients[coefficients$model == model, , drop = FALSE]
     pb <- model_rows[model_rows$term == "publication_bias", , drop = FALSE]
     eff <- model_rows[model_rows$term == "effect", , drop = FALSE]
@@ -773,7 +770,8 @@ build_summary_table <- function(coefficients, digits) {
       n_obs_value <- n_obs_value[1]
     }
 
-    col_values <- c(
+    column_name <- model_rows$model_label[1]
+    columns[[column_name]] <- c(
       if (nrow(pb)) pb$estimate_formatted else NA_character_,
       if (nrow(pb)) pb$std_error_formatted else NA_character_,
       if (nrow(pb)) pb$bootstrap_formatted else NA_character_,
@@ -782,13 +780,9 @@ build_summary_table <- function(coefficients, digits) {
       if (nrow(eff)) eff$bootstrap_formatted else NA_character_,
       if (nrow(model_rows)) format_number(n_obs_value, 0) else NA_character_
     )
-
-    column_name <- model_rows$model_label[1]
-    summary[[column_name]] <- col_values
   }
 
-  attr(summary, "row.names") <- row_labels
-  summary
+  shared_build_summary_table(row_labels, columns)
 }
 
 box::export(

--- a/inst/artma/econometric/nonlinear.R
+++ b/inst/artma/econometric/nonlinear.R
@@ -13,6 +13,9 @@ box::use(
     format_standard_error
   ],
   artma / calc / meta[normal_p_value],
+  artma / libs / formatting / summary_table[
+    shared_build_summary_table = build_summary_table
+  ],
   artma / calc / methods / stem[stem, stem_funnel, stem_MSE, STEM_MIN_STUDIES],
   artma / calc / methods / selection_model[metastudies_estimation],
   artma / calc / methods / endo_kink[run_endogenous_kink],
@@ -471,7 +474,7 @@ build_summary_table <- function(coefficients, digits) {
     "Total observations",
     "Model observations"
   )
-  summary <- data.frame(Metric = row_labels, check.names = FALSE, stringsAsFactors = FALSE)
+  columns <- list()
   for (model in unique(coefficients$model)) {
     model_rows <- coefficients[coefficients$model == model, , drop = FALSE]
     pb_row <- model_rows[model_rows$term == "publication_bias", , drop = FALSE]
@@ -480,7 +483,7 @@ build_summary_table <- function(coefficients, digits) {
     total_obs <- total_obs[is.finite(total_obs)]
     model_obs <- unique(model_rows$n_obs_model)
     model_obs <- model_obs[is.finite(model_obs)]
-    column <- c(
+    columns[[model_rows$model_label[1]]] <- c(
       if (nrow(pb_row)) pb_row$estimate_formatted else "",
       if (nrow(pb_row)) pb_row$std_error_formatted else "",
       if (nrow(eff_row)) eff_row$estimate_formatted else "",
@@ -488,11 +491,8 @@ build_summary_table <- function(coefficients, digits) {
       if (length(total_obs)) format_number(total_obs[1], 0) else "",
       if (length(model_obs)) format_number(model_obs[1], 0) else ""
     )
-    column[is.na(column)] <- ""
-    summary[[model_rows$model_label[1]]] <- column
   }
-  attr(summary, "row.names") <- row_labels
-  summary
+  shared_build_summary_table(row_labels, columns, missing_value = "")
 }
 
 run_nonlinear_methods <- function(df, options) {

--- a/inst/artma/libs/formatting/summary_table.R
+++ b/inst/artma/libs/formatting/summary_table.R
@@ -1,0 +1,54 @@
+#' @title Shared summary-table builder
+#' @description
+#' One pivoted-table builder shared by the publication-bias/effect summary
+#' tables (linear tests, non-linear tests, exogeneity tests): a `Metric`
+#' column of row labels plus one column per model/method, each holding
+#' already-formatted character values.
+NULL
+
+box::use(
+  artma / libs / core / validation[validate]
+)
+
+#' @title Build a pivoted publication-bias/effect summary table
+#' @description
+#' Assembles the `Metric` + one-column-per-model summary tables used across
+#' the testing methods. Callers pass already-formatted character columns; this
+#' function pads short columns and replaces `NA` entries with `missing_value`,
+#' so a metric a given model could not produce (e.g. a zero-length test
+#' statistic) does not abort the table assembly.
+#' @param row_labels *[character]* Row labels. Becomes the `Metric` column and
+#'   the data frame's `row.names`.
+#' @param columns *[list]* Named list of character vectors, one per model/
+#'   method column. Each vector is padded to `length(row_labels)` with
+#'   `missing_value` when shorter, and truncated when longer.
+#' @param missing_value *[character, optional]* Value used to pad short
+#'   columns and to replace `NA` entries. Defaults to `NA_character_`, which
+#'   leaves `NA` entries as `NA` (no replacement).
+#' @return *[data.frame]* `Metric` column plus one column per entry in
+#'   `columns`, with `row.names` set to `row_labels`.
+build_summary_table <- function(row_labels, columns, missing_value = NA_character_) {
+  validate(is.character(row_labels), is.list(columns))
+
+  n <- length(row_labels)
+  summary <- data.frame(
+    Metric = row_labels,
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+
+  for (column_name in names(columns)) {
+    values <- as.character(columns[[column_name]])
+    if (length(values) < n) {
+      values <- c(values, rep(missing_value, n - length(values)))
+    }
+    values <- values[seq_len(n)]
+    values[is.na(values)] <- missing_value
+    summary[[column_name]] <- values
+  }
+
+  attr(summary, "row.names") <- row_labels
+  summary
+}
+
+box::export(build_summary_table)

--- a/tests/testthat/test-summary-table-characterization.R
+++ b/tests/testthat/test-summary-table-characterization.R
@@ -1,0 +1,157 @@
+box::use(
+  testthat[
+    expect_equal,
+    test_that
+  ],
+  withr[local_options, local_seed]
+)
+
+box::use(
+  artma / methods / linear_tests[linear_tests],
+  artma / methods / nonlinear_tests[nonlinear_tests]
+)
+
+# These tests pin the exact printed shape of the linear- and nonlinear-tests
+# summary tables on fixed fixtures, ahead of consolidating the three
+# `build_summary_table()`/`build_exogeneity_summary()` implementations
+# (linear.R, nonlinear.R, exogeneity.R) into one shared builder in
+# `libs/formatting/`. Migrated call sites must keep producing the exact same
+# data frames captured here. Exogeneity's own build_exogeneity_summary is
+# already pinned directly by tests/testthat/test-econometric-exogeneity.R.
+#
+# Every seeded draw below pins the RNG kind explicitly (via `local_seed()`)
+# rather than relying on `set.seed()` alone: other test files can leave the
+# global RNG kind changed (e.g. method orchestration switches it to
+# "L'Ecuyer-CMRG" for per-method streams), which would otherwise make the
+# fixture data, and therefore the pinned tables below, depend on run order.
+
+make_linear_demo_data <- function() {
+  local_seed(42, .rng_kind = "Mersenne-Twister", .rng_normal_kind = "Inversion", .rng_sample_kind = "Rejection")
+  n_studies <- 6L
+  per_study <- 5L
+  study_ids <- rep(paste0("S", seq_len(n_studies)), each = per_study)
+  se_vals <- runif(n_studies * per_study, min = 0.05, max = 0.15)
+  data.frame(
+    study_id = study_ids,
+    effect = rnorm(n_studies * per_study, mean = 0.2, sd = 0.05),
+    se = se_vals,
+    study_size = sample(20:80, n_studies * per_study, replace = TRUE),
+    precision = 1 / se_vals,
+    check.names = FALSE
+  )
+}
+
+make_nonlinear_demo_data <- function() {
+  n_studies <- 15L
+  per_study <- 6L
+  study_ids <- rep(paste0("S", seq_len(n_studies)), each = per_study)
+  base_se <- seq(0.05, 0.12, length.out = per_study)
+  se_vals <- rep(base_se, times = n_studies)
+  effect_base <- 0.15 + seq(-0.01, 0.01, length.out = n_studies)
+  effect_offsets <- seq(-0.02, 0.02, length.out = per_study)
+  effect_vals <- rep(effect_base, each = per_study) + rep(effect_offsets, times = n_studies)
+  data.frame(
+    study_id = study_ids,
+    effect = effect_vals,
+    se = se_vals,
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("linear_tests summary table is pinned on fixture data", {
+  testthat::skip_if_not_installed("plm")
+
+  df <- make_linear_demo_data()
+
+  local_options(
+    "artma.methods.add_significance_marks" = TRUE,
+    "artma.methods.linear_tests.bootstrap_replications" = 10L,
+    "artma.methods.linear_tests.conf_level" = 0.9,
+    "artma.output.number_of_decimals" = 2,
+    "artma.verbose" = 1
+  )
+
+  local_seed(100, .rng_kind = "Mersenne-Twister", .rng_normal_kind = "Inversion", .rng_sample_kind = "Rejection")
+  res <- suppressWarnings(suppressMessages(linear_tests(df)))
+
+  expected <- structure(
+    list(
+      Metric = c(
+        "Publication Bias", "(Std. Error)", "Bootstrap CI (PB)",
+        "Effect Beyond Bias", "(Std. Error)", "Bootstrap CI (Effect)",
+        "Total Observations"
+      ),
+      OLS = c(
+        "-0.25", "(0.30)", "[-0.61, 0.38]", "0.21***", "(0.03)",
+        "[0.13, 0.25]", "30"
+      ),
+      `Fixed Effects` = c(
+        "-0.19", "(0.33)", "[-0.54, 0.02]", "0.20", "(0.33)",
+        "[0.18, 0.25] †", "30"
+      ),
+      `Between Effects` = c(
+        "-1.63", "(2.24)", "[-3.95, 0.21]", "0.36", "(0.25)",
+        "[0.17, 0.62] †", "30"
+      ),
+      `Random Effects` = c(
+        "-0.23", "(0.29)", "[-0.59, 0.16]", "0.21***", "(0.03)",
+        "[0.18, 0.24]", "30"
+      ),
+      `Study Weighted OLS` = c(
+        "-0.33", "(0.27)", "[-0.67, 0.07]", "0.22***", "(0.02)",
+        "[0.19, 0.24]", "30"
+      ),
+      `Precision Weighted OLS` = c(
+        "-0.24", "(0.24)", "[-0.53, 0.03]", "0.21***", "(0.03)",
+        "[0.18, 0.23]", "30"
+      )
+    ),
+    row.names = c(
+      "Publication Bias", "(Std. Error)", "Bootstrap CI (PB)",
+      "Effect Beyond Bias", "(Std. Error)", "Bootstrap CI (Effect)",
+      "Total Observations"
+    ),
+    class = "data.frame"
+  )
+
+  expect_equal(res$tables$summary, expected)
+})
+
+test_that("nonlinear_tests summary table is pinned on fixture data", {
+  local_options(
+    "artma.methods.nonlinear_tests.add_significance_marks" = TRUE,
+    "artma.methods.nonlinear_tests.round_to" = 2L,
+    "artma.methods.nonlinear_tests.stem_representative_sample" = "medians",
+    "artma.methods.nonlinear_tests.selection_cutoffs" = c(1.96, 2.58),
+    "artma.methods.nonlinear_tests.selection_symmetric" = FALSE,
+    "artma.methods.nonlinear_tests.selection_model" = "normal",
+    "artma.methods.nonlinear_tests.hierarchical_iterations" = 50L,
+    "artma.output.number_of_decimals" = 3L,
+    "artma.visualization.export_graphics" = FALSE,
+    "artma.verbose" = 0L
+  )
+
+  df <- make_nonlinear_demo_data()
+  local_seed(7, .rng_kind = "Mersenne-Twister", .rng_normal_kind = "Inversion", .rng_sample_kind = "Rejection")
+  res <- suppressWarnings(nonlinear_tests(df))
+
+  expected <- structure(
+    list(
+      Metric = c(
+        "Publication Bias", "(Std. Error)", "Effect Beyond Bias",
+        "(Std. Error)", "Total observations", "Model observations"
+      ),
+      WAAP = c("NA", "", "0.13***", "(0.01)", "90", "15"),
+      Stem = c("NA", "", "0.15***", "(0.02)", "90", "14"),
+      Hierarch = c("0.56***", "(0.16)", "0.08", "(0.15)", "90", "90"),
+      `Endogenous Kink` = c("0.57***", "(0.03)", "0.10***", "(0.00)", "90", "90")
+    ),
+    row.names = c(
+      "Publication Bias", "(Std. Error)", "Effect Beyond Bias",
+      "(Std. Error)", "Total observations", "Model observations"
+    ),
+    class = "data.frame"
+  )
+
+  expect_equal(res$tables$summary, expected)
+})


### PR DESCRIPTION
## What moved

Extracted one shared builder, `build_summary_table()` in `inst/artma/libs/formatting/summary_table.R`, replacing the three near-identical implementations:

- `build_summary_table` in `inst/artma/econometric/linear.R`
- `build_summary_table` in `inst/artma/econometric/nonlinear.R`
- `build_exogeneity_summary` in `inst/artma/econometric/exogeneity.R`

Each call site still assembles its own row labels and per-model/method columns (the domain-specific part), then hands them to the shared builder, which pads short columns, replaces NA with a configurable placeholder, and sets the Metric column plus row.names.

## What changed behavior

Nothing. This is a pure extraction: no call site's data frame output changes shape or values.

## Tests

- New characterization tests in `tests/testthat/test-summary-table-characterization.R` pin the exact `linear_tests()` and `nonlinear_tests()` summary tables on fixed fixtures, ahead of and after the consolidation, so the migrated call sites are proven to produce identical data frames.
- `exogeneity`'s summary table was already pinned by the existing `tests/testthat/test-econometric-exogeneity.R`, which still passes unchanged.
- Full `make test` passes, both in the default parallel mode and serially.

Note: the new tests pin their RNG state via `withr::local_seed()` with an explicit RNG kind, rather than bare `set.seed()`, because the global RNG kind can be left switched to L'Ecuyer-CMRG by other tests that exercise the method orchestrator; pinning the kind keeps the fixture data and pinned tables independent of test run order.

Refs #322 (item B2)