### PR TITLE
refactor(formatting): kill nonlinear.R formatting-helper shadowing

### DIFF
--- a/inst/artma/calc/index.R
+++ b/inst/artma/calc/index.R
@@ -1,6 +1,6 @@
 box::use(
-  artma / calc / meta[t_stat, precision, reg_dof]
+  artma / calc / meta[t_stat, precision, reg_dof, normal_p_value]
 )
 
 
-box::export(t_stat, precision, reg_dof)
+box::export(t_stat, precision, reg_dof, normal_p_value)

--- a/inst/artma/calc/meta.R
+++ b/inst/artma/calc/meta.R
@@ -62,8 +62,24 @@ precision <- function(se = NULL, reg_dof = NULL) {
 }
 
 
+#' @title Two-sided normal p-value for an estimate/standard-error pair
+#' @description Calculate the p-value from a Wald z-statistic under a normal
+#'   approximation, used by the non-linear publication-bias estimators.
+#' @param estimate *\[numeric\]* The point estimate.
+#' @param std_error *\[numeric\]* The standard error of the estimate.
+#' @return *\[numeric\]* The two-sided p-value, or `NA_real_` if the inputs
+#'   are not finite or `std_error` is non-positive.
+normal_p_value <- function(estimate, std_error) {
+  if (!is.finite(estimate) || !is.finite(std_error) || std_error <= 0) {
+    return(NA_real_)
+  }
+  2 * stats::pnorm(abs(estimate / std_error), lower.tail = FALSE)
+}
+
+
 box::export(
   t_stat,
   precision,
-  reg_dof
+  reg_dof,
+  normal_p_value
 )

--- a/inst/artma/econometric/nonlinear.R
+++ b/inst/artma/econometric/nonlinear.R
@@ -8,10 +8,11 @@ box::use(
   utils[capture.output],
   artma / libs / core / validation[validate, validate_columns, assert],
   artma / libs / formatting / results[
-    significance_mark,
     format_number,
-    format_se
+    format_estimate_with_pvalue,
+    format_standard_error
   ],
+  artma / calc / meta[normal_p_value],
   artma / calc / methods / stem[stem, stem_funnel, stem_MSE, STEM_MIN_STUDIES],
   artma / calc / methods / selection_model[metastudies_estimation],
   artma / calc / methods / endo_kink[run_endogenous_kink],
@@ -20,30 +21,6 @@ box::use(
 )
 
 # nocov start -----------------------------------------------------------------
-
-normal_p_value <- function(estimate, std_error) {
-  if (!is.finite(estimate) || !is.finite(std_error) || std_error <= 0) {
-    return(NA_real_)
-  }
-  2 * stats::pnorm(abs(estimate / std_error), lower.tail = FALSE)
-}
-
-format_estimate <- function(estimate, p_value, digits, add_marks) {
-  formatted <- format_number(estimate, digits)
-  if (!length(formatted)) {
-    return(character(0))
-  }
-  marks <- if (isTRUE(add_marks)) significance_mark(p_value) else ""
-  formatted <- paste0(formatted, marks)
-  formatted[is.na(formatted)] <- ""
-  formatted
-}
-
-format_standard_error <- function(std_error, digits) {
-  formatted <- format_se(std_error, digits)
-  formatted[is.na(formatted)] <- ""
-  formatted
-}
 
 #' Kish's effective sample size for a set of precision weights
 #'
@@ -603,7 +580,7 @@ run_nonlinear_methods <- function(df, options) {
   coefficients <- do.call(rbind, results)
   digits <- options$round_to %||% 3L
   add_marks <- isTRUE(options$add_significance_marks)
-  coefficients$estimate_formatted <- format_estimate(coefficients$estimate, coefficients$p_value, digits, add_marks)
+  coefficients$estimate_formatted <- format_estimate_with_pvalue(coefficients$estimate, coefficients$p_value, digits, add_marks)
   coefficients$std_error_formatted <- format_standard_error(coefficients$std_error, digits)
   summary <- build_summary_table(coefficients, digits)
   list(

--- a/inst/artma/libs/formatting/results.R
+++ b/inst/artma/libs/formatting/results.R
@@ -67,6 +67,42 @@ format_estimate <- function(x, digits, marks = "") {
   formatted
 }
 
+#' @title Format an estimate whose marks are derived from a raw p-value
+#' @description
+#' Companion to [format_estimate()] for callers that hold a raw p-value and an
+#' "append marks or not" flag rather than a precomputed marks vector.
+#' Note: unlike [format_estimate()], a non-finite `x` here ends up as the
+#' literal string `"NA"` rather than `NA_character_`, because the marks are
+#' pasted on before the finiteness check. This mirrors the historical
+#' behaviour of the callers this consolidates and is preserved intentionally.
+#' @param x *[numeric]* Estimates to format.
+#' @param p_value *[numeric]* Two-sided p-values used to derive marks.
+#' @param digits *[integer]* Number of decimals.
+#' @param add_marks *[logical]* Whether to append significance marks.
+#' @return *[character]* Formatted estimates.
+format_estimate_with_pvalue <- function(x, p_value, digits, add_marks) {
+  formatted <- format_number(x, digits)
+  if (!length(formatted)) {
+    return(character(0))
+  }
+  marks <- if (isTRUE(add_marks)) significance_mark(p_value) else ""
+  formatted <- paste0(formatted, marks)
+  formatted[is.na(formatted)] <- ""
+  formatted
+}
+
+#' @title Format a standard error, blanking non-finite values
+#' @description Like [format_se()], but renders non-finite standard errors as
+#'   an empty string instead of `NA_character_`.
+#' @param se *[numeric]* Standard errors to format.
+#' @param digits *[integer]* Number of decimals.
+#' @return *[character]* Formatted, parenthesised standard errors.
+format_standard_error <- function(se, digits) {
+  formatted <- format_se(se, digits)
+  formatted[is.na(formatted)] <- ""
+  formatted
+}
+
 format_se <- function(se, digits) {
   if (!length(se)) {
     return(character(0))
@@ -252,7 +288,9 @@ box::export(
   significance_mark,
   format_number,
   format_estimate,
+  format_estimate_with_pvalue,
   format_se,
+  format_standard_error,
   format_ci,
   print_summary_table,
   print_sectioned_table,

--- a/tests/testthat/test-calc-meta.R
+++ b/tests/testthat/test-calc-meta.R
@@ -1,0 +1,17 @@
+box::use(
+  testthat[expect_identical, expect_true, test_that]
+)
+
+box::use(artma / calc / meta[normal_p_value])
+
+test_that("normal_p_value computes the two-sided normal p-value", {
+  expect_identical(normal_p_value(1.96, 1), 2 * stats::pnorm(1.96, lower.tail = FALSE))
+})
+
+test_that("normal_p_value returns NA for non-finite or non-positive inputs", {
+  expect_true(is.na(normal_p_value(NA_real_, 1)))
+  expect_true(is.na(normal_p_value(1, NA_real_)))
+  expect_true(is.na(normal_p_value(Inf, 1)))
+  expect_true(is.na(normal_p_value(1, 0)))
+  expect_true(is.na(normal_p_value(1, -1)))
+})

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -3,6 +3,7 @@ box::use(
     expect_equal,
     expect_false,
     expect_gt,
+    expect_identical,
     expect_match,
     expect_named,
     expect_s3_class,
@@ -123,6 +124,46 @@ make_degenerate_options <- function() {
     hierarchical_iterations = 10L
   )
 }
+
+# Characterization test for B7 (formatting-helper consolidation): pins the
+# exact formatted cells produced by the deterministic estimators (WAAP, STEM),
+# including the current literal "NA" string rendered for a model that has no
+# publication-bias term. This must stay byte-for-byte identical across the
+# format_estimate()/format_standard_error()/normal_p_value() consolidation.
+test_that("WAAP and STEM formatted cells are pinned across the formatting refactor", {
+  df <- make_demo_data()
+  options <- list(
+    add_significance_marks = TRUE,
+    round_to = 2L,
+    stem_representative_sample = "medians",
+    selection_cutoffs = c(1.96, 2.58),
+    selection_symmetric = FALSE,
+    selection_model = "normal",
+    hierarchical_iterations = 50L
+  )
+
+  res <- suppressWarnings(run_nonlinear_methods(df, options))
+
+  waap_rows <- res$coefficients[res$coefficients$model == "waap", ]
+  waap_pb <- waap_rows[waap_rows$term == "publication_bias", ]
+  waap_eff <- waap_rows[waap_rows$term == "effect", ]
+  expect_identical(waap_pb$estimate_formatted, "NA")
+  expect_identical(waap_pb$std_error_formatted, "")
+  expect_identical(waap_eff$estimate_formatted, "0.13***")
+  expect_identical(waap_eff$std_error_formatted, "(0.01)")
+
+  stem_rows <- res$coefficients[res$coefficients$model == "stem", ]
+  stem_pb <- stem_rows[stem_rows$term == "publication_bias", ]
+  stem_eff <- stem_rows[stem_rows$term == "effect", ]
+  expect_identical(stem_pb$estimate_formatted, "NA")
+  expect_identical(stem_pb$std_error_formatted, "")
+  expect_identical(stem_eff$estimate_formatted, "0.15***")
+  expect_identical(stem_eff$std_error_formatted, "(0.02)")
+
+  summary <- res$summary
+  expect_identical(summary$WAAP[summary$Metric == "Publication Bias"], "NA")
+  expect_identical(summary$Stem[summary$Metric == "Publication Bias"], "NA")
+})
 
 test_that("WAAP and Top10 are skipped when a single observation dominates the weights", {
   n_moderate <- 20

--- a/tests/testthat/test-result-formatters.R
+++ b/tests/testthat/test-result-formatters.R
@@ -124,3 +124,29 @@ test_that("format_estimate returns an empty vector for empty input", {
 
   expect_identical(format_estimate(numeric(0), 2L), character(0))
 })
+
+test_that("format_estimate_with_pvalue renders a non-finite estimate as literal \"NA\"", {
+  box::use(artma / libs / formatting / results[format_estimate_with_pvalue])
+
+  # Unlike format_estimate(), marks are pasted on before the finiteness check,
+  # so a non-finite estimate becomes the literal string "NA" rather than
+  # NA_character_. This mirrors the moved nonlinear.R behaviour and is pinned
+  # deliberately, not fixed, by the B7 consolidation.
+  expect_identical(
+    format_estimate_with_pvalue(NA_real_, NA_real_, 2L, TRUE),
+    "NA"
+  )
+})
+
+test_that("format_estimate_with_pvalue appends marks only when add_marks is TRUE", {
+  box::use(artma / libs / formatting / results[format_estimate_with_pvalue])
+
+  expect_identical(format_estimate_with_pvalue(0.5, 0.001, 2L, TRUE), "0.50***")
+  expect_identical(format_estimate_with_pvalue(0.5, 0.001, 2L, FALSE), "0.50")
+})
+
+test_that("format_standard_error blanks non-finite standard errors", {
+  box::use(artma / libs / formatting / results[format_standard_error])
+
+  expect_identical(format_standard_error(c(0.05, NA_real_, Inf), 2L), c("(0.05)", "", ""))
+})


### PR DESCRIPTION
## What moved
- Local `format_estimate(estimate, p_value, digits, add_marks)` in `inst/artma/econometric/nonlinear.R` moved to `inst/artma/libs/formatting/results.R` as `format_estimate_with_pvalue()`, alongside the existing (differently-signatured) exported `format_estimate()`. No new name collision: they are distinct functions, so the local override that shadowed the exported helper is gone.
- Local `format_standard_error()` in `nonlinear.R` moved verbatim to `results.R`, next to `format_se()`.
- Local `normal_p_value()` in `nonlinear.R` moved to `inst/artma/calc/meta.R` and exported through `calc/index.R`.
- `nonlinear.R` now imports all three from their new homes instead of redefining them.

## What did not change (behavior)
Outputs are byte-for-byte identical, including the pre-existing quirk where a
non-finite estimate paired with marks renders as the literal string `"NA"`
(because marks are pasted on before the finiteness check) rather than a true
`NA`. That quirk is documented in `format_estimate_with_pvalue()`'s roxygen
and preserved deliberately, not fixed, since this item is a pure consolidation.

## Tests pinning the outputs
- `tests/testthat/test-nonlinear-tests.R`: new characterization test
  "WAAP and STEM formatted cells are pinned across the formatting refactor",
  written and run against the pre-refactor code first, asserting exact
  `estimate_formatted`/`std_error_formatted` values and the literal `"NA"`
  cell in the exported summary table.
- `tests/testthat/test-result-formatters.R`: new unit tests for
  `format_estimate_with_pvalue()` and `format_standard_error()`.
- `tests/testthat/test-calc-meta.R` (new file): unit tests for the moved
  `normal_p_value()`.

All of the above pass unchanged before and after the move.

Refs #322 (item B7)