### PR TITLE
refactor(data): move configure-phase resolvers into data/configure.R

### DIFF
--- a/R/artma.R
+++ b/R/artma.R
@@ -160,7 +160,8 @@ artma <- function(
       # Mirror prepare_data's phases: decide the NA strategy (configure), run
       # the pure preprocess + compute, then persist the computed columns.
       box::use(
-        artma / data / preprocess[clean_data, preprocess_data, resolve_na_handling],
+        artma / data / preprocess[clean_data, preprocess_data],
+        artma / data / configure[resolve_na_handling],
         artma / data / compute[compute_optional_columns, update_config_with_computed_columns]
       )
 

--- a/R/generated_check_manifest.R
+++ b/R/generated_check_manifest.R
@@ -24,6 +24,7 @@ utils::globalVariables(c(
   "collect_leaf_paths",
   "compute",
   "compute_optional_columns",
+  "configure",
   "const",
   "core",
   "data",

--- a/inst/artma/data/configure.R
+++ b/inst/artma/data/configure.R
@@ -1,0 +1,136 @@
+#' @title Resolve the missing-value handling strategy
+#' @description Configure-phase decision that fixes `artma.data.na_handling`
+#'   before the cached compute phase runs. When the option is already set it is
+#'   a no-op. Otherwise, if the (already cleaned) data frame has missing values
+#'   in optional columns, it prompts the user interactively (and offers to save
+#'   the choice) or falls back to the deterministic `"stop"` strategy in a
+#'   non-interactive session. This is intentionally separate from
+#'   `handle_missing_values()` (the pure compute-phase step) so that no prompt
+#'   or option write ever happens inside the cached pipeline.
+#' @param df *\[data.frame\]* The cleaned data frame used to detect optional
+#'   missing values (as produced by `clean_data()`).
+#' @return `NULL`, invisibly.
+#' @keywords internal
+resolve_na_handling <- function(df) {
+  box::use(
+    artma / libs / core / utils[get_verbosity],
+    artma / data / na_handling[detect_missing_values],
+    artma / options / prompts[prompt_na_handling],
+    artma / interactive / save_preference[prompt_save_preference]
+  )
+
+  na_handling_option <- getOption("artma.data.na_handling", default = NA)
+
+  # Strategy already configured: nothing to decide.
+  if (!is.na(na_handling_option)) {
+    return(invisible(NULL))
+  }
+
+  na_summary <- detect_missing_values(df)
+
+  # Without optional missing values there is no decision to make; the compute
+  # phase falls back to the deterministic "stop" default when it runs.
+  if (!na_summary$has_optional_na) {
+    return(invisible(NULL))
+  }
+
+  if (interactive()) {
+    if (get_verbosity() >= 3) {
+      cli::cli_alert_info("Missing values detected and no handling strategy configured")
+    }
+
+    # Prompt the user for their preference and record it for this session.
+    selected_strategy <- prompt_na_handling()
+    options(artma.data.na_handling = selected_strategy)
+
+    # Offer to persist the preference to the options file.
+    prompt_save_preference(
+      option_path = "data.na_handling",
+      value = selected_strategy,
+      description = "missing value handling strategy",
+      respect_autonomy = FALSE
+    )
+  } else {
+    # Non-interactive mode: default to "stop"
+    if (get_verbosity() >= 2) {
+      cli::cli_warn("Running in non-interactive mode with missing values. Defaulting to 'stop' strategy.")
+    }
+    options(artma.data.na_handling = "stop")
+  }
+
+  invisible(NULL)
+}
+
+#' @title Resolve the zero-standard-error handling strategy
+#' @description Configure-phase decision that fixes `artma.calc.se_zero_handling`
+#'   before the cached compute phase runs. When the option is already set it is
+#'   a no-op. Otherwise, if the (already cleaned) data frame has rows with a
+#'   zero standard error, it prompts the user interactively when the autonomy
+#'   level warrants it (offering the strict `"stop"` choice among others), or
+#'   falls back to the friendlier `"remove"` strategy. This is intentionally
+#'   separate from `enforce_correct_values()` (the pure compute-phase step) so
+#'   that no prompt or option write ever happens inside the cached pipeline.
+#' @param df *\[data.frame\]* The cleaned data frame used to detect zero
+#'   standard errors (as produced by `clean_data()`).
+#' @return `NULL`, invisibly.
+#' @keywords internal
+resolve_se_zero_handling <- function(df) {
+  box::use(
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / core / autonomy[should_prompt_user],
+    artma / options / prompts[prompt_se_zero_handling],
+    artma / interactive / save_preference[prompt_save_preference]
+  )
+
+  se_zero_handling_option <- getOption("artma.calc.se_zero_handling", default = NA)
+
+  # Strategy already configured: nothing to decide.
+  if (!is.na(se_zero_handling_option)) {
+    return(invisible(NULL))
+  }
+
+  if (is.null(df[["se"]])) {
+    return(invisible(NULL))
+  }
+
+  zero_se_rows <- which(suppressWarnings(as.numeric(df$se)) == 0)
+
+  # Without zero standard errors there is no decision to make; the compute
+  # phase falls back to the deterministic "remove" default when it runs.
+  if (length(zero_se_rows) == 0) {
+    return(invisible(NULL))
+  }
+
+  if (should_prompt_user(required_level = "autonomous")) {
+    if (get_verbosity() >= 3) {
+      cli::cli_alert_info("Zero standard errors detected and no handling strategy configured")
+    }
+
+    # Prompt the user for their preference and record it for this session.
+    selected_strategy <- prompt_se_zero_handling()
+    options(artma.calc.se_zero_handling = selected_strategy)
+
+    # Offer to persist the preference to the options file.
+    prompt_save_preference(
+      option_path = "calc.se_zero_handling",
+      value = selected_strategy,
+      description = "zero standard error handling strategy",
+      respect_autonomy = FALSE
+    )
+  } else {
+    if (get_verbosity() >= 2) {
+      cli::cli_warn(c(
+        "!" = "{length(zero_se_rows)} row{?s} with zero standard errors detected.",
+        "i" = "Defaulting to the {.val remove} strategy. Set {.field artma.calc.se_zero_handling} to {.val stop} for stricter validation."
+      ))
+    }
+    options(artma.calc.se_zero_handling = "remove")
+  }
+
+  invisible(NULL)
+}
+
+box::export(
+  resolve_na_handling,
+  resolve_se_zero_handling
+)

--- a/inst/artma/data/index.R
+++ b/inst/artma/data/index.R
@@ -47,7 +47,8 @@ configure_data <- function(df_raw) {
   box::use(
     artma / data / utils[standardize_column_names],
     artma / data / schema_reconcile[reconcile_schema],
-    artma / data / preprocess[clean_data, resolve_na_handling, resolve_se_zero_handling]
+    artma / data / preprocess[clean_data],
+    artma / data / configure[resolve_na_handling, resolve_se_zero_handling]
   )
 
   # Detect and resolve any schema drift before column standardization. This may

--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -52,70 +52,6 @@ remove_empty_rows <- function(df) {
   df
 }
 
-#' @title Resolve the missing-value handling strategy
-#' @description Configure-phase decision that fixes `artma.data.na_handling`
-#'   before the cached compute phase runs. When the option is already set it is
-#'   a no-op. Otherwise, if the (already cleaned) data frame has missing values
-#'   in optional columns, it prompts the user interactively (and offers to save
-#'   the choice) or falls back to the deterministic `"stop"` strategy in a
-#'   non-interactive session. This is intentionally separate from
-#'   `handle_missing_values()` (the pure compute-phase step) so that no prompt
-#'   or option write ever happens inside the cached pipeline.
-#' @param df *\[data.frame\]* The cleaned data frame used to detect optional
-#'   missing values (as produced by `clean_data()`).
-#' @return `NULL`, invisibly.
-#' @keywords internal
-resolve_na_handling <- function(df) {
-  box::use(
-    artma / libs / core / utils[get_verbosity],
-    artma / data / na_handling[detect_missing_values],
-    artma / options / prompts[prompt_na_handling],
-    artma / interactive / save_preference[prompt_save_preference]
-  )
-
-  na_handling_option <- getOption("artma.data.na_handling", default = NA)
-
-  # Strategy already configured: nothing to decide.
-  if (!is.na(na_handling_option)) {
-    return(invisible(NULL))
-  }
-
-  na_summary <- detect_missing_values(df)
-
-  # Without optional missing values there is no decision to make; the compute
-  # phase falls back to the deterministic "stop" default when it runs.
-  if (!na_summary$has_optional_na) {
-    return(invisible(NULL))
-  }
-
-  if (interactive()) {
-    if (get_verbosity() >= 3) {
-      cli::cli_alert_info("Missing values detected and no handling strategy configured")
-    }
-
-    # Prompt the user for their preference and record it for this session.
-    selected_strategy <- prompt_na_handling()
-    options(artma.data.na_handling = selected_strategy)
-
-    # Offer to persist the preference to the options file.
-    prompt_save_preference(
-      option_path = "data.na_handling",
-      value = selected_strategy,
-      description = "missing value handling strategy",
-      respect_autonomy = FALSE
-    )
-  } else {
-    # Non-interactive mode: default to "stop"
-    if (get_verbosity() >= 2) {
-      cli::cli_warn("Running in non-interactive mode with missing values. Defaulting to 'stop' strategy.")
-    }
-    options(artma.data.na_handling = "stop")
-  }
-
-  invisible(NULL)
-}
-
-
 #' @title Enforce correct data types
 #' @description Enforce correct data types. Every column of the data frame
 #'   must have a corresponding data config entry; a missing entry means the
@@ -160,75 +96,6 @@ enforce_data_types <- function(df) {
     }
   }
   df
-}
-
-#' @title Resolve the zero-standard-error handling strategy
-#' @description Configure-phase decision that fixes `artma.calc.se_zero_handling`
-#'   before the cached compute phase runs. When the option is already set it is
-#'   a no-op. Otherwise, if the (already cleaned) data frame has rows with a
-#'   zero standard error, it prompts the user interactively when the autonomy
-#'   level warrants it (offering the strict `"stop"` choice among others), or
-#'   falls back to the friendlier `"remove"` strategy. This is intentionally
-#'   separate from `enforce_correct_values()` (the pure compute-phase step) so
-#'   that no prompt or option write ever happens inside the cached pipeline.
-#' @param df *\[data.frame\]* The cleaned data frame used to detect zero
-#'   standard errors (as produced by `clean_data()`).
-#' @return `NULL`, invisibly.
-#' @keywords internal
-resolve_se_zero_handling <- function(df) {
-  box::use(
-    artma / libs / core / utils[get_verbosity],
-    artma / libs / core / autonomy[should_prompt_user],
-    artma / options / prompts[prompt_se_zero_handling],
-    artma / interactive / save_preference[prompt_save_preference]
-  )
-
-  se_zero_handling_option <- getOption("artma.calc.se_zero_handling", default = NA)
-
-  # Strategy already configured: nothing to decide.
-  if (!is.na(se_zero_handling_option)) {
-    return(invisible(NULL))
-  }
-
-  if (is.null(df[["se"]])) {
-    return(invisible(NULL))
-  }
-
-  zero_se_rows <- which(suppressWarnings(as.numeric(df$se)) == 0)
-
-  # Without zero standard errors there is no decision to make; the compute
-  # phase falls back to the deterministic "remove" default when it runs.
-  if (length(zero_se_rows) == 0) {
-    return(invisible(NULL))
-  }
-
-  if (should_prompt_user(required_level = "autonomous")) {
-    if (get_verbosity() >= 3) {
-      cli::cli_alert_info("Zero standard errors detected and no handling strategy configured")
-    }
-
-    # Prompt the user for their preference and record it for this session.
-    selected_strategy <- prompt_se_zero_handling()
-    options(artma.calc.se_zero_handling = selected_strategy)
-
-    # Offer to persist the preference to the options file.
-    prompt_save_preference(
-      option_path = "calc.se_zero_handling",
-      value = selected_strategy,
-      description = "zero standard error handling strategy",
-      respect_autonomy = FALSE
-    )
-  } else {
-    if (get_verbosity() >= 2) {
-      cli::cli_warn(c(
-        "!" = "{length(zero_se_rows)} row{?s} with zero standard errors detected.",
-        "i" = "Defaulting to the {.val remove} strategy. Set {.field artma.calc.se_zero_handling} to {.val stop} for stricter validation."
-      ))
-    }
-    options(artma.calc.se_zero_handling = "remove")
-  }
-
-  invisible(NULL)
 }
 
 #' @title Check for invalid values
@@ -415,8 +282,9 @@ clean_data <- function(df) {
 #'   Column presence validation is handled upstream by the schema reconciliation
 #'   step; this function assumes the dataframe columns already match the config.
 #'   It is pure: the missing-value strategy is resolved beforehand by
-#'   `resolve_na_handling()` in the configure phase, so this function never
-#'   prompts or writes options and can run inside the cached compute phase.
+#'   `resolve_na_handling()` (`artma/data/configure.R`) in the configure phase,
+#'   so this function never prompts or writes options and can run inside the
+#'   cached compute phase.
 #' @param df *[data.frame]* Standardized data frame to clean.
 #' @return *[data.frame]* The type-safe, cleaned data frame.
 preprocess_data <- function(df) {
@@ -436,7 +304,5 @@ box::export(
   enforce_data_types,
   enforce_correct_values,
   apply_subset_conditions,
-  preprocess_data,
-  resolve_na_handling,
-  resolve_se_zero_handling
+  preprocess_data
 )

--- a/tests/testthat/test-data-configure.R
+++ b/tests/testthat/test-data-configure.R
@@ -1,0 +1,59 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_null,
+    expect_warning,
+    test_that
+  ],
+  withr[local_options]
+)
+
+test_that <- getFromNamespace("test_that", "testthat")
+expect_equal <- getFromNamespace("expect_equal", "testthat")
+expect_null <- getFromNamespace("expect_null", "testthat")
+expect_warning <- getFromNamespace("expect_warning", "testthat")
+
+# -- resolve_se_zero_handling ------------------------------------------------------
+
+test_that("resolve_se_zero_handling is a no-op when the option is already configured", {
+  box::use(artma / data / configure[resolve_se_zero_handling])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = "stop",
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(se = c(0.1, 0))
+  resolve_se_zero_handling(df)
+
+  expect_equal(getOption("artma.calc.se_zero_handling"), "stop")
+})
+
+test_that("resolve_se_zero_handling is a no-op when no zero SE rows are found", {
+  box::use(artma / data / configure[resolve_se_zero_handling])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = NULL,
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(se = c(0.1, 0.2))
+  resolve_se_zero_handling(df)
+
+  expect_null(getOption("artma.calc.se_zero_handling"))
+})
+
+test_that("resolve_se_zero_handling defaults to 'remove' in a non-interactive session", {
+  box::use(artma / data / configure[resolve_se_zero_handling])
+
+  withr::local_options(list(
+    "artma.calc.se_zero_handling" = NULL,
+    "artma.autonomy.level" = NULL,
+    "artma.verbose" = 2
+  ))
+
+  df <- data.frame(se = c(0.1, 0, 0.2))
+  expect_warning(resolve_se_zero_handling(df), "stricter validation")
+
+  expect_equal(getOption("artma.calc.se_zero_handling"), "remove")
+})

--- a/tests/testthat/test-data-preprocess.R
+++ b/tests/testthat/test-data-preprocess.R
@@ -4,7 +4,6 @@ box::use(
     expect_error,
     expect_true,
     expect_false,
-    expect_null,
     expect_warning,
     expect_no_warning,
     test_that
@@ -17,7 +16,6 @@ expect_equal <- getFromNamespace("expect_equal", "testthat")
 expect_error <- getFromNamespace("expect_error", "testthat")
 expect_true <- getFromNamespace("expect_true", "testthat")
 expect_false <- getFromNamespace("expect_false", "testthat")
-expect_null <- getFromNamespace("expect_null", "testthat")
 expect_warning <- getFromNamespace("expect_warning", "testthat")
 expect_no_warning <- getFromNamespace("expect_no_warning", "testthat")
 
@@ -272,47 +270,5 @@ test_that("enforce_correct_values 'ignore' strategy silently keeps rows", {
   expect_equal(result, df)
 })
 
-# -- resolve_se_zero_handling ------------------------------------------------------
-
-test_that("resolve_se_zero_handling is a no-op when the option is already configured", {
-  box::use(artma / data / preprocess[resolve_se_zero_handling])
-
-  withr::local_options(list(
-    "artma.calc.se_zero_handling" = "stop",
-    "artma.verbose" = 1
-  ))
-
-  df <- data.frame(se = c(0.1, 0))
-  resolve_se_zero_handling(df)
-
-  expect_equal(getOption("artma.calc.se_zero_handling"), "stop")
-})
-
-test_that("resolve_se_zero_handling is a no-op when no zero SE rows are found", {
-  box::use(artma / data / preprocess[resolve_se_zero_handling])
-
-  withr::local_options(list(
-    "artma.calc.se_zero_handling" = NULL,
-    "artma.verbose" = 1
-  ))
-
-  df <- data.frame(se = c(0.1, 0.2))
-  resolve_se_zero_handling(df)
-
-  expect_null(getOption("artma.calc.se_zero_handling"))
-})
-
-test_that("resolve_se_zero_handling defaults to 'remove' in a non-interactive session", {
-  box::use(artma / data / preprocess[resolve_se_zero_handling])
-
-  withr::local_options(list(
-    "artma.calc.se_zero_handling" = NULL,
-    "artma.autonomy.level" = NULL,
-    "artma.verbose" = 2
-  ))
-
-  df <- data.frame(se = c(0.1, 0, 0.2))
-  expect_warning(resolve_se_zero_handling(df), "stricter validation")
-
-  expect_equal(getOption("artma.calc.se_zero_handling"), "remove")
-})
+# resolve_se_zero_handling now lives in inst/artma/data/configure.R; see
+# tests/testthat/test-data-configure.R for its tests.


### PR DESCRIPTION
## What moved
resolve_na_handling and resolve_se_zero_handling moved verbatim (no edits in transit) from
inst/artma/data/preprocess.R into a new inst/artma/data/configure.R, so the file name signals
"may prompt" (configure.R) versus "pure compute" (preprocess.R). box::export list in preprocess.R
updated accordingly.

## Call sites updated
- inst/artma/data/index.R: configure_data() now imports the resolvers from artma/data/configure
  instead of artma/data/preprocess.
- R/artma.R: the artma() entry point imports resolve_na_handling from artma/data/configure.
- R/generated_check_manifest.R regenerated via make document (adds the configure box path).
- tests/testthat/test-data-preprocess.R: resolve_se_zero_handling tests moved to a new
  tests/testthat/test-data-configure.R, importing from the new module.

## What did not change
No edits to the resolver bodies: same interactive()/should_prompt_user branching, same option
reads/writes, same prompts and messages. Zero behavior change.

## Tests pinning behavior
- tests/testthat/test-data-configure.R (moved, unchanged assertions) covers resolve_se_zero_handling.
- tests/testthat/test-data-index.R exercises configure_data(), which calls both resolvers.
- Full make test suite passes (2178 passed, 0 failed).

Refs #322 (item C5)