### PR TITLE
refactor(data): column-mapping cleanup (C4)

### DIFF
--- a/inst/artma/data/index.R
+++ b/inst/artma/data/index.R
@@ -57,7 +57,7 @@ configure_data <- function(df_raw) {
 
   # Decide the missing-value and zero-SE strategies on the cleaned, standardized
   # frame so the compute phase can handle both without prompting.
-  df_std <- standardize_column_names(df_raw, auto_detect = FALSE)
+  df_std <- standardize_column_names(df_raw)
   df_clean <- clean_data(df_std)
   resolve_na_handling(df_clean)
   resolve_se_zero_handling(df_clean)
@@ -83,7 +83,7 @@ compute_data_impl <- function() {
   df_raw <- .raw_env$df_raw
 
   # Apply colnames map (now updated if drift was reconciled in configure)
-  df <- standardize_column_names(df_raw, auto_detect = FALSE)
+  df <- standardize_column_names(df_raw)
 
   prime_df_for_config_cache(df)
   df <- preprocess_data(df)

--- a/inst/artma/data/interactive_mapping.R
+++ b/inst/artma/data/interactive_mapping.R
@@ -458,109 +458,6 @@ confirm_column_mapping <- function(mapping, required_cols) {
 }
 
 
-#' @title Read the stored column records from an options file
-#' @description Returns the `data.columns` store held in a user options file,
-#'   falling back to the session option when the file cannot be read (it may
-#'   not exist yet during creation). Used to seed a merge so records already on
-#'   disk are never clobbered by a partial in-session store.
-#' @param options_file_name *\[character\]* Options file name, including suffix.
-#' @param options_dir *\[character, optional\]* Directory holding user options
-#'   files. Defaults to the standard directory.
-#' @return *\[list\]* The stored per-column records, possibly empty.
-read_stored_columns <- function(options_file_name, options_dir = NULL) {
-  box::use(
-    artma / options / files[
-      options_file_path,
-      read_options_file,
-      resolve_options_dir
-    ]
-  )
-
-  fallback <- function() {
-    store <- getOption("artma.data.columns", list())
-    if (is.list(store)) store else list()
-  }
-
-  tryCatch(
-    {
-      path <- options_file_path(
-        resolve_options_dir(options_dir, must_exist = FALSE),
-        options_file_name
-      )
-      if (!file.exists(path)) {
-        return(fallback())
-      }
-      store <- read_options_file(path)[["data"]][["columns"]]
-      if (is.list(store)) store else list()
-    },
-    error = function(e) fallback()
-  )
-}
-
-#' @title Save column mapping to options
-#' @description Save the confirmed mapping into the unified per-column store
-#'   (`data.columns`): each standard column gets a role record carrying the
-#'   mapped `source_name`.
-#' @param mapping *\[list\]* The column mapping (std_col -> data_col)
-#' @param options_file_name *\[character, optional\]* Options file name
-#' @param options_dir *\[character, optional\]* Directory holding user options
-#'   files. Defaults to the standard directory.
-#' @return *\[invisible\]* NULL
-save_column_mapping_to_options <- function(mapping, options_file_name = NULL, options_dir = NULL) {
-  box::use(artma / libs / core / utils[get_verbosity])
-
-  if (get_verbosity() >= 4) {
-    cli::cli_inform("Saving column mapping to options")
-  }
-
-  # Merge the mapping into the existing unified column store. Identity
-  # mappings clear any stale source_name instead of being stored: the sparse
-  # store only holds genuine renames.
-  #
-  # When writing to a named options file, seed from that file rather than the
-  # session option: this runs during file creation too, where the option is
-  # still unset and using it would overwrite the file's records with the role
-  # mapping alone.
-  store <- if (!is.null(options_file_name)) {
-    read_stored_columns(options_file_name, options_dir = options_dir)
-  } else {
-    getOption("artma.data.columns", list())
-  }
-  if (!is.list(store)) store <- list()
-
-  for (std_col in names(mapping)) {
-    entry <- store[[std_col]]
-    if (!is.list(entry)) entry <- list()
-    if (identical(mapping[[std_col]], std_col)) {
-      entry$source_name <- NULL
-      store[[std_col]] <- if (length(entry) == 0) NULL else entry
-    } else {
-      entry$source_name <- mapping[[std_col]]
-      store[[std_col]] <- entry
-    }
-  }
-
-  # Update options
-  if (!is.null(options_file_name)) {
-    artma::options.modify(
-      user_input = list("data.columns" = store),
-      options_file_name = options_file_name,
-      options_dir = options_dir
-    )
-    options("artma.data.columns" = store)
-  } else {
-    # Set in current session
-    options("artma.data.columns" = store)
-  }
-
-  if (get_verbosity() >= 3) {
-    cli::cli_alert_success("Column mapping saved")
-  }
-
-  invisible(NULL)
-}
-
-
 #' @title Full interactive column mapping workflow
 #' @description Complete workflow: recognize, interact, confirm, save
 #' @param df *\[data.frame\]* The data frame
@@ -582,6 +479,7 @@ column_mapping_workflow <- function(
       check_mapping_completeness,
       get_required_column_names
     ],
+    artma / data_config / column_mapping[save_column_mapping_to_options],
     artma / libs / core / utils[get_verbosity]
   )
 
@@ -649,8 +547,6 @@ column_mapping_workflow <- function(
 box::export(
   interactive_column_mapping,
   confirm_column_mapping,
-  read_stored_columns,
-  save_column_mapping_to_options,
   column_mapping_workflow,
   present_detected_mapping,
   format_mapping_display

--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -70,13 +70,16 @@ get_number_of_studies <- function(df) {
 
 #' @title Standardize column names
 #' @description Standardize the column names of a data frame to a single source of truth set of column names.
+#'   This is the pure standardizer: it never prompts and never attempts
+#'   auto-detection. Callers that need to fill in a missing mapping
+#'   interactively should run that workflow first (see
+#'   `artma / data / interactive_mapping`) and persist the result before
+#'   calling this function.
 #' @param df *\[data.frame\]* The data frame to standardize
-#' @param auto_detect *\[logical\]* If TRUE and mapping not found, attempt auto-detection
 #' @return *\[data.frame\]* The standardized data frame
-standardize_column_names <- function(df, auto_detect = TRUE) {
+standardize_column_names <- function(df) {
   box::use(
-    artma / libs / core / validation[validate, assert],
-    artma / libs / core / utils[get_verbosity]
+    artma / libs / core / validation[validate, assert]
   )
 
   validate(is.data.frame(df))
@@ -86,58 +89,6 @@ standardize_column_names <- function(df, auto_detect = TRUE) {
   # Read the column mapping from the unified per-column store
   map <- lapply(get_colnames_map(), make.names) # Handle non-standard column names
   required_colnames <- get_required_colnames()
-
-  # A required column is unresolved when it is neither mapped nor already
-  # present in the data frame under its standard name (identity mappings are
-  # not stored in the sparse column store).
-  missing_required <- base::setdiff(required_colnames, c(names(map), names(df)))
-
-  # If mapping is incomplete and auto_detect is enabled, try to recognize columns
-  if (length(missing_required) > 0 && auto_detect) {
-    if (get_verbosity() >= 3) {
-      cli::cli_alert_info("Column mapping incomplete, attempting automatic recognition...")
-    }
-
-    box::use(
-      artma / data / column_recognition[recognize_columns],
-      artma / data / interactive_mapping[column_mapping_workflow]
-    )
-
-    # Get automatic recognition
-    auto_mapping <- recognize_columns(df, min_confidence = 0.7)
-
-    # Always present detected columns to user for confirmation
-    config_setup <- getOption("artma.data.config_setup", "auto")
-
-    if (length(auto_mapping) > 0) {
-      # Columns were detected - always present them for confirmation
-      if (get_verbosity() >= 3) {
-        cli::cli_alert_info("Starting column mapping workflow...")
-      }
-      final_mapping <- column_mapping_workflow(
-        df = df,
-        auto_mapping = auto_mapping,
-        options_file_name = getOption("artma.options_file_name", NULL),
-        force_interactive = (config_setup == "manual")
-      )
-    } else {
-      # No columns detected, go straight to interactive mapping
-      if (get_verbosity() >= 3) {
-        cli::cli_alert_info("No columns automatically detected, starting interactive mapping...")
-      }
-      final_mapping <- column_mapping_workflow(
-        df = df,
-        auto_mapping = list(),
-        options_file_name = getOption("artma.options_file_name", NULL),
-        force_interactive = TRUE
-      )
-    }
-
-    # Update the map with the final mapping
-    for (std_col in names(final_mapping)) {
-      map[[std_col]] <- make.names(final_mapping[[std_col]])
-    }
-  }
 
   # Check that every required column is either mapped or already present
   missing_required <- base::setdiff(required_colnames, c(names(map), names(df)))

--- a/inst/artma/data_config/column_mapping.R
+++ b/inst/artma/data_config/column_mapping.R
@@ -1,0 +1,106 @@
+#' @title Read the stored column records from an options file
+#' @description Returns the `data.columns` store held in a user options file,
+#'   falling back to the session option when the file cannot be read (it may
+#'   not exist yet during creation). Used to seed a merge so records already on
+#'   disk are never clobbered by a partial in-session store.
+#' @param options_file_name *\[character\]* Options file name, including suffix.
+#' @param options_dir *\[character, optional\]* Directory holding user options
+#'   files. Defaults to the standard directory.
+#' @return *\[list\]* The stored per-column records, possibly empty.
+read_stored_columns <- function(options_file_name, options_dir = NULL) {
+  box::use(
+    artma / options / files[
+      options_file_path,
+      read_options_file,
+      resolve_options_dir
+    ]
+  )
+
+  fallback <- function() {
+    store <- getOption("artma.data.columns", list())
+    if (is.list(store)) store else list()
+  }
+
+  tryCatch(
+    {
+      path <- options_file_path(
+        resolve_options_dir(options_dir, must_exist = FALSE),
+        options_file_name
+      )
+      if (!file.exists(path)) {
+        return(fallback())
+      }
+      store <- read_options_file(path)[["data"]][["columns"]]
+      if (is.list(store)) store else list()
+    },
+    error = function(e) fallback()
+  )
+}
+
+#' @title Save column mapping to options
+#' @description Save the confirmed mapping into the unified per-column store
+#'   (`data.columns`): each standard column gets a role record carrying the
+#'   mapped `source_name`.
+#' @param mapping *\[list\]* The column mapping (std_col -> data_col)
+#' @param options_file_name *\[character, optional\]* Options file name
+#' @param options_dir *\[character, optional\]* Directory holding user options
+#'   files. Defaults to the standard directory.
+#' @return *\[invisible\]* NULL
+save_column_mapping_to_options <- function(mapping, options_file_name = NULL, options_dir = NULL) {
+  box::use(artma / libs / core / utils[get_verbosity])
+
+  if (get_verbosity() >= 4) {
+    cli::cli_inform("Saving column mapping to options")
+  }
+
+  # Merge the mapping into the existing unified column store. Identity
+  # mappings clear any stale source_name instead of being stored: the sparse
+  # store only holds genuine renames.
+  #
+  # When writing to a named options file, seed from that file rather than the
+  # session option: this runs during file creation too, where the option is
+  # still unset and using it would overwrite the file's records with the role
+  # mapping alone.
+  store <- if (!is.null(options_file_name)) {
+    read_stored_columns(options_file_name, options_dir = options_dir)
+  } else {
+    getOption("artma.data.columns", list())
+  }
+  if (!is.list(store)) store <- list()
+
+  for (std_col in names(mapping)) {
+    entry <- store[[std_col]]
+    if (!is.list(entry)) entry <- list()
+    if (identical(mapping[[std_col]], std_col)) {
+      entry$source_name <- NULL
+      store[[std_col]] <- if (length(entry) == 0) NULL else entry
+    } else {
+      entry$source_name <- mapping[[std_col]]
+      store[[std_col]] <- entry
+    }
+  }
+
+  # Update options
+  if (!is.null(options_file_name)) {
+    artma::options.modify(
+      user_input = list("data.columns" = store),
+      options_file_name = options_file_name,
+      options_dir = options_dir
+    )
+    options("artma.data.columns" = store)
+  } else {
+    # Set in current session
+    options("artma.data.columns" = store)
+  }
+
+  if (get_verbosity() >= 3) {
+    cli::cli_alert_success("Column mapping saved")
+  }
+
+  invisible(NULL)
+}
+
+box::export(
+  read_stored_columns,
+  save_column_mapping_to_options
+)

--- a/inst/artma/data_config/resolve.R
+++ b/inst/artma/data_config/resolve.R
@@ -57,7 +57,7 @@ standardize_df_for_config <- function(df) {
   )
 
   tryCatch(
-    standardize_column_names(df, auto_detect = FALSE),
+    standardize_column_names(df),
     error = function(e) {
       if (get_verbosity() >= 4) {
         cli::cli_inform(

--- a/tests/testthat/test-data-config-resolve.R
+++ b/tests/testthat/test-data-config-resolve.R
@@ -249,7 +249,7 @@ test_that("config keys are standardized regardless of which entry point resolves
   expect_false(any(c("coef", "stderr", "nobs") %in% names(cold_config)))
 
   # Pipeline path: prepare_data standardizes the df and primes the cache
-  df_std <- standardize_column_names(read_data(tmp_file), auto_detect = FALSE)
+  df_std <- standardize_column_names(read_data(tmp_file))
   prime_df_for_config_cache(df_std, tmp_file)
   primed_config <- get_data_config()
 

--- a/tests/testthat/test-data-interactive-mapping.R
+++ b/tests/testthat/test-data-interactive-mapping.R
@@ -12,9 +12,9 @@ box::use(
 box::use(
   artma / data / interactive_mapping[
     confirm_column_mapping,
-    save_column_mapping_to_options,
     format_mapping_display
   ],
+  artma / data_config / column_mapping[save_column_mapping_to_options],
   artma / data / column_recognition[get_required_column_names]
 )
 
@@ -227,7 +227,7 @@ test_that("format_mapping_display handles empty optional columns", {
 
 test_that("read_stored_columns seeds from the options file, not the session", {
   box::use(
-    artma / data / interactive_mapping[read_stored_columns],
+    artma / data_config / column_mapping[read_stored_columns],
     artma / options / files[write_options_file]
   )
 
@@ -253,7 +253,7 @@ test_that("read_stored_columns seeds from the options file, not the session", {
 
 test_that("save_column_mapping_to_options keeps records already in the file", {
   box::use(
-    artma / data / interactive_mapping[save_column_mapping_to_options],
+    artma / data_config / column_mapping[save_column_mapping_to_options],
     artma / options / files[options_file_path, read_options_file, write_options_file]
   )
 
@@ -302,7 +302,7 @@ test_that("save_column_mapping_to_options keeps records already in the file", {
 
 
 test_that("read_stored_columns falls back to the session store when absent", {
-  box::use(artma / data / interactive_mapping[read_stored_columns])
+  box::use(artma / data_config / column_mapping[read_stored_columns])
 
   withr::local_options(list(
     "artma.verbose" = 1,

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -7,9 +7,10 @@ box::use(
   testing / fixtures / index[FIXTURES]
 )
 
-# Note: These tests use auto_detect = FALSE to test core logic without interaction.
-# When auto_detect = TRUE, the new confirmation flow is triggered which requires
-# user interaction via climenu. Those tests are in E2E tests (tests/E2E/).
+# Note: standardize_column_names() is a pure standardizer with no interactive
+# fallback. Interactive column mapping is a separate workflow (see
+# artma / data / interactive_mapping) that callers run and persist before
+# invoking this function; those tests live in tests/E2E/.
 
 test_that("standardize_column_names handles missing required columns in options correctly", {
   box::use(
@@ -74,7 +75,7 @@ test_that("standardize_column_names handles missing required columns in options 
   for (scenario in scenarios) {
     withr::with_options(build_scenario_options(scenario$mock_colnames), {
       expect_error(
-        standardize_column_names(df = mock_df, auto_detect = FALSE),
+        standardize_column_names(df = mock_df),
         scenario$expected_error,
         info = paste("Scenario:", scenario$name)
       )
@@ -90,7 +91,7 @@ test_that("standardize_column_names accepts identity columns without a stored re
   mock_df <- MOCKS$create_mock_df()
 
   withr::with_options(list("artma.data.columns" = list()), {
-    standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+    standardized_df <- standardize_column_names(mock_df)
     expect_true(all(c("study_id", "effect", "se", "n_obs") %in% colnames(standardized_df)))
   })
 })
@@ -125,7 +126,7 @@ test_that("standardize_column_names handles missing required columns in data cor
     mock_df <- mock_df[, -which(names(mock_df) %in% scenario$missing_colnames), drop = FALSE]
 
     expect_error(
-      standardize_column_names(mock_df, auto_detect = FALSE),
+      standardize_column_names(mock_df),
       scenario$expected_error,
       info = paste("Scenario:", scenario$name)
     )
@@ -146,7 +147,7 @@ test_that("standardize_column_names standardizes non-standard column names", {
   expect_true(non_standard_name %in% colnames(mock_df))
   expect_true(!"study_id" %in% colnames(mock_df))
 
-  standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+  standardized_df <- standardize_column_names(mock_df)
   expect_true(!non_standard_name %in% colnames(standardized_df))
   expect_true("study_id" %in% colnames(standardized_df))
 })
@@ -159,7 +160,7 @@ test_that("standardize_column_names passes when all required columns are present
   mock_df <- MOCKS$create_mock_df(colnames_map = mock_colnames)
 
   expect_error(
-    standardize_column_names(mock_df, auto_detect = FALSE),
+    standardize_column_names(mock_df),
     NA,
     info = "Standardizing column names should pass when all required columns are present"
   )
@@ -198,7 +199,7 @@ test_that("standardize_column_names aborts when a rename target is already occup
     list("artma.data.columns" = list(study_id = list(source_name = "study_name"))),
     {
       expect_error(
-        standardize_column_names(mock_df, auto_detect = FALSE),
+        standardize_column_names(mock_df),
         "already has a different column named"
       )
     }
@@ -213,7 +214,7 @@ test_that("standardize_column_names allows an identity mapping through quietly",
   withr::with_options(
     list("artma.data.columns" = list(study_id = list(source_name = "study_id"))),
     {
-      standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+      standardized_df <- standardize_column_names(mock_df)
       expect_equal(anyDuplicated(colnames(standardized_df)), 0)
       expect_true("study_id" %in% colnames(standardized_df))
     }
@@ -230,7 +231,7 @@ test_that("standardize_column_names drops a byte-identical duplicate target colu
   withr::with_options(
     list("artma.data.columns" = list(study_id = list(source_name = "study_name"))),
     {
-      standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+      standardized_df <- standardize_column_names(mock_df)
       expect_equal(sum(colnames(standardized_df) == "study_id"), 1)
       expect_equal(standardized_df$study_id, 1:5)
     }
@@ -246,7 +247,7 @@ test_that("standardize_column_names still performs normal renames without collis
   FIXTURES$with_custom_colnames(mock_colnames)
   mock_df <- MOCKS$create_mock_df(colnames_map = mock_colnames)
 
-  standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+  standardized_df <- standardize_column_names(mock_df)
   expect_equal(anyDuplicated(colnames(standardized_df)), 0)
   expect_true("study_id" %in% colnames(standardized_df))
   expect_false("study_id_raw" %in% colnames(standardized_df))

--- a/tests/testthat/test-options-template-parity.R
+++ b/tests/testthat/test-options-template-parity.R
@@ -34,7 +34,10 @@ runtime_only_option_prefixes <- c("temp.")
 # Template leaves consumed outside the R options namespace:
 #   - cli.editor is read straight from the YAML options file by
 #     resolve_cli_editor() before any options are loaded
-leaves_consumed_elsewhere <- c("cli.editor")
+#   - data.config_setup is read from the in-progress `user_input` list by
+#     preprocess_column_mapping() during options creation, before the value
+#     ever reaches the options() namespace
+leaves_consumed_elsewhere <- c("cli.editor", "data.config_setup")
 
 package_root <- function() {
   normalizePath(testthat::test_path("..", ".."), winslash = "/", mustWork = FALSE)

--- a/tests/testthat/test-schema-reconcile-integration.R
+++ b/tests/testthat/test-schema-reconcile-integration.R
@@ -298,7 +298,7 @@ test_that("reconcile then standardize: produces df with standard column names", 
       reconcile_schema(df_raw, mode = "auto")
 
       # Step 2: standardize uses the now-updated record to rename the column
-      df_std <- standardize_column_names(df_raw, auto_detect = FALSE)
+      df_std <- standardize_column_names(df_raw)
 
       # Column "effect_sise" should be renamed to the standard name "effect"
       expect_true("effect" %in% colnames(df_std))


### PR DESCRIPTION
## What moved

- `read_stored_columns` and `save_column_mapping_to_options` moved from `inst/artma/data/interactive_mapping.R` to a new `inst/artma/data_config/column_mapping.R`, next to the rest of the data-config persistence layer. `interactive_mapping.R` now imports `save_column_mapping_to_options` from there for `column_mapping_workflow()`.
- All `box::use()` references and test imports updated accordingly (`tests/testthat/test-data-interactive-mapping.R`).

## What changed behavior

- Dropped the dead interactive branch of `standardize_column_names()` (`inst/artma/data/utils.R`). Both pipeline call sites (`inst/artma/data/index.R`, `inst/artma/data_config/resolve.R`) always pass `auto_detect = FALSE`, and no test exercised the `auto_detect = TRUE` path, so it was unreachable in practice. `standardize_column_names()` no longer takes an `auto_detect` argument and no longer depends on `column_recognition` or `interactive_mapping`; it is now a pure standardizer.
- Updated all call sites and tests that passed `auto_detect = FALSE` to drop the now-removed argument (`inst/artma/data/index.R`, `inst/artma/data_config/resolve.R`, `tests/testthat/test-data-utils.R`, `tests/testthat/test-data-config-resolve.R`, `tests/testthat/test-schema-reconcile-integration.R`).
- Added `data.config_setup` to the `leaves_consumed_elsewhere` exemption list in `tests/testthat/test-options-template-parity.R`: that option's only remaining consumption is `user_input[["data.config_setup"]]` inside `preprocess_column_mapping()` (reading the in-progress options during file creation, before the value reaches the `options()` namespace), which the getOption-based parity heuristic cannot see.

No behavior change to the pipeline's happy path: both call sites already ran with `auto_detect = FALSE`, so removing the branch produces identical outputs.

## Tests

- `tests/testthat/test-data-utils.R`, `tests/testthat/test-data-config-resolve.R`, `tests/testthat/test-schema-reconcile-integration.R` pin `standardize_column_names()`'s behavior with the new signature.
- `tests/testthat/test-data-interactive-mapping.R` pins the moved `read_stored_columns` / `save_column_mapping_to_options` behavior from their new home.
- `tests/testthat/test-options-template-parity.R` updated and passing.
- Full `make test` suite green (2178 passing), `make lint` clean.

Refs #322 (item C4)