### PR TITLE
refactor(visualization): drop ggtext from Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,4 +77,4 @@ Config/testthat/start-first: github-actions, release
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     cli (>= 3.6.5),
     climenu (>= 0.1.7),
     ggplot2 (>= 3.4.0),
-    ggtext (>= 0.1.2),
     lmtest (>= 0.9-40),
     memoise (>= 2.0.1),
     parallel,
@@ -78,4 +77,4 @@ Config/testthat/start-first: github-actions, release
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/generated_check_manifest.R
+++ b/R/generated_check_manifest.R
@@ -117,7 +117,6 @@ utils::globalVariables(c(
 .artma_check_manifest_keep_alive <- function() {
   invisible(list(
     ggplot2::aes,
-    ggtext::element_markdown,
     lmtest::coeftest,
     memoise::cache_filesystem,
     parallel::clusterExport,

--- a/inst/artma/visualization/theme.R
+++ b/inst/artma/visualization/theme.R
@@ -8,8 +8,9 @@
 #' Constructs a consistent ggplot2 theme based on the selected color theme.
 #' Used across all artma visualization methods for visual consistency.
 #'
-#' Uses ggtext::element_markdown() for x-axis text to support per-tick coloring
-#' via HTML spans in tick labels.
+#' Uses ggplot2::element_text() for x-axis text. Note: per-tick HTML color
+#' spans produced by format_colored_tick_labels() are not rendered as colors
+#' here; they show as plain text including the raw markup.
 #'
 #' @param theme_name *\[character\]* One of: blue, yellow, green, red, purple
 #'
@@ -30,7 +31,7 @@ get_theme <- function(theme_name) {
 
   ggplot2::theme(
     axis.line = ggplot2::element_line(color = "black", linewidth = 0.5, linetype = "solid"),
-    axis.text.x = ggtext::element_markdown(size = 12),
+    axis.text.x = ggplot2::element_text(color = "black", size = 12),
     axis.text.y = ggplot2::element_text(color = "black", size = 12),
     axis.title.x = ggplot2::element_text(size = 14),
     axis.title.y = ggplot2::element_text(size = 14),

--- a/inst/artma/visualization/ticks.R
+++ b/inst/artma/visualization/ticks.R
@@ -27,9 +27,11 @@ format_tick_labels <- function(x) {
 #' Format tick labels with HTML color spans
 #'
 #' @description
-#' Wraps tick labels in HTML span elements with color styling for use with
-#' ggtext::element_markdown(). This enables per-tick coloring (e.g., highlighting
-#' the mean tick in a different color).
+#' Wraps tick labels in HTML span elements with color styling. Historically
+#' rendered via ggtext::element_markdown() for per-tick coloring (e.g.,
+#' highlighting the mean tick in a different color); the theme now uses plain
+#' ggplot2::element_text(), so the HTML markup is displayed as literal text
+#' rather than rendered as color.
 #'
 #' @param ticks *\[numeric\]* Tick values
 #' @param colors *\[character\]* Color for each tick (same length as ticks)

--- a/man/artma-package.Rd
+++ b/man/artma-package.Rd
@@ -18,10 +18,5 @@ Useful links:
 \author{
 \strong{Maintainer}: Petr Čala \email{61505008@fsv.cuni.cz}
 
-Authors:
-\itemize{
-  \item Petr Čala \email{61505008@fsv.cuni.cz}
-}
-
 }
 \keyword{internal}

--- a/man/artma-package.Rd
+++ b/man/artma-package.Rd
@@ -18,5 +18,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Petr Čala \email{61505008@fsv.cuni.cz}
 
+Authors:
+\itemize{
+  \item Petr Čala \email{61505008@fsv.cuni.cz}
+}
+
 }
 \keyword{internal}


### PR DESCRIPTION
## What moved
- inst/artma/visualization/theme.R: axis.text.x now uses ggplot2::element_text() instead of ggtext::element_markdown().
- DESCRIPTION: removed ggtext from Imports.
- R/generated_check_manifest.R, man/artma-package.Rd: regenerated via make document (drops the ggtext keep-alive reference).
- inst/artma/visualization/ticks.R: doc comment updated to reflect the new rendering behavior.

## What changed behavior (visual degradation, maintainer sign-off given per issue #322 item D2)
format_colored_tick_labels() (used by funnel_plot and t_stat_histogram) still wraps tick labels in HTML span tags with inline color styling, intended for Markdown rendering. With ggtext removed, the theme's axis.text.x element no longer interprets that markup: the raw HTML tags will display as literal text on the x axis of these two plots instead of rendering as colored tick labels. No test or snapshot in the repository asserted on the markdown rendering or on the colored appearance of these ticks (grepped for ggtext, element_markdown, and format_colored_tick_labels across tests/), so no test updates were needed.

## Tests
- make test: full suite green (2178 passed, 0 failed) both before and after the change.
- make lint: no lints found.

Refs #322 (item D2).