### PR TITLE
ci: composite action for JAGS install steps

### DIFF
--- a/.github/actions/setup-jags/action.yml
+++ b/.github/actions/setup-jags/action.yml
@@ -1,0 +1,29 @@
+name: Setup JAGS
+description: >
+  Install the JAGS system library needed by RoBMA (Suggests). On Linux
+  setup-r-dependencies installs it from the declared sysreqs; macOS and
+  Windows need it installed explicitly.
+inputs:
+  jags-version:
+    description: JAGS version to install on Windows.
+    required: false
+    default: "4.3.1"
+runs:
+  using: composite
+  steps:
+    - name: Install JAGS (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install jags
+
+    - name: Install JAGS (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        version="${{ inputs.jags-version }}"
+        installer="$RUNNER_TEMP/jags-installer.exe"
+        curl -L -o "$installer" \
+          "https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-${version}.exe/download"
+        "$installer" //S
+        echo "JAGS_HOME=C:/Program Files/JAGS/JAGS-${version}" >> "$GITHUB_ENV"
+        echo "C:/Program Files/JAGS/JAGS-${version}/x64/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/R-CMD-check-extended.yaml
+++ b/.github/workflows/R-CMD-check-extended.yaml
@@ -57,23 +57,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      # RoBMA (Suggests) needs the JAGS system library. On Linux
-      # setup-r-dependencies installs it from the declared sysreqs; macOS and
-      # Windows need it installed explicitly.
-      - name: Install JAGS (macOS)
-        if: runner.os == 'macOS'
-        run: brew install jags
-
-      - name: Install JAGS (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          installer="$RUNNER_TEMP/jags-installer.exe"
-          curl -L -o "$installer" \
-            https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.3.1.exe/download
-          "$installer" //S
-          echo "JAGS_HOME=C:/Program Files/JAGS/JAGS-4.3.1" >> "$GITHUB_ENV"
-          echo "C:/Program Files/JAGS/JAGS-4.3.1/x64/bin" >> "$GITHUB_PATH"
+      - name: Setup JAGS
+        uses: ./.github/actions/setup-jags
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,23 +46,8 @@ jobs:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
-      # RoBMA (Suggests) needs the JAGS system library. On Linux
-      # setup-r-dependencies installs it from the declared sysreqs; macOS and
-      # Windows need it installed explicitly.
-      - name: Install JAGS (macOS)
-        if: runner.os == 'macOS'
-        run: brew install jags
-
-      - name: Install JAGS (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          installer="$RUNNER_TEMP/jags-installer.exe"
-          curl -L -o "$installer" \
-            https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.3.1.exe/download
-          "$installer" //S
-          echo "JAGS_HOME=C:/Program Files/JAGS/JAGS-4.3.1" >> "$GITHUB_ENV"
-          echo "C:/Program Files/JAGS/JAGS-4.3.1/x64/bin" >> "$GITHUB_PATH"
+      - name: Setup JAGS
+        uses: ./.github/actions/setup-jags
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Extracts the duplicated JAGS install steps into a composite action at .github/actions/setup-jags/action.yml.

What moved:
- Install JAGS (macOS): brew install jags
- Install JAGS (Windows): downloads and silently installs the JAGS Windows installer, sets JAGS_HOME and PATH

The two blocks were byte-identical across workflows, so no parameterization of OS behavior was needed. The Windows JAGS version (4.3.1) is exposed as an input (jags-version, default 4.3.1) so it is no longer hardcoded in two places.

Workflows touched:
- .github/workflows/R-CMD-check.yaml
- .github/workflows/R-CMD-check-extended.yaml

Both now call `uses: ./.github/actions/setup-jags` in place of the inline steps. No other workflow referenced JAGS.

Behavior change: none intended. Verified with yaml::read_yaml() that both workflow files and the new action.yml parse correctly and that the composite action step resolves to the same install logic previously inlined.

Refs #322 (item E2)