### PR TITLE
fix(data): import get_verbosity in standardize_column_names, update stale test calls

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -29,6 +29,7 @@
 ^releaes_notes\.md$
 ^release-notes\.md$
 ^AGENTS\.md$
+^box-to-r-migration-plan\.md$
 ^CLAUDE\.md$
 ^Makefile$
 ^\.claude$

--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -79,6 +79,7 @@ get_number_of_studies <- function(df) {
 #' @return *\[data.frame\]* The standardized data frame
 standardize_column_names <- function(df) {
   box::use(
+    artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[validate, assert]
   )
 

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -215,7 +215,7 @@ test_that("the collision abort message names the exact remediation commands", {
     list("artma.data.columns" = list(study_id = list(source_name = "study_name"))),
     {
       err <- tryCatch(
-        standardize_column_names(mock_df, auto_detect = FALSE),
+        standardize_column_names(mock_df),
         error = function(e) conditionMessage(e)
       )
       expect_true(grepl('config.set("study_id", drop_conflicting_raw = TRUE)', err, fixed = TRUE))
@@ -237,7 +237,7 @@ test_that("standardize_column_names drops the raw column when drop_conflicting_r
       "artma.verbose" = 1L
     ),
     {
-      standardized_df <- standardize_column_names(mock_df, auto_detect = FALSE)
+      standardized_df <- standardize_column_names(mock_df)
       expect_equal(sum(colnames(standardized_df) == "study_id"), 1)
       expect_equal(standardized_df$study_id, paste("Study", 1:5))
       expect_false("study_name" %in% colnames(standardized_df))


### PR DESCRIPTION
Fixes the red master CI after the #322 merge batch.

Two green PRs conflicted semantically:
- #335 (b55d9dd) removed the `auto_detect` parameter from `standardize_column_names()` and updated most of `test-data-utils.R`, but the collision tests added by #332 were cut before that and still passed `auto_detect = FALSE`. Those calls now error with "unused argument" (3 failures on master).
- Removing the stale argument unmasked a second bug: the `drop_conflicting_raw` path from #332 calls `get_verbosity()`, which #335's version of `inst/artma/data/utils.R` never imports (this was also the standing box_usage lint warning).

Changes:
- drop `auto_detect = FALSE` from the two stale test calls
- import `get_verbosity` in `standardize_column_names()`

`test-data-utils.R`: 35/35 pass. `make lint`: clean, the box_usage warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)