### PR TITLE
test(p-hacking): coarsen reference_bounds grid to speed up bounds test

### DIFF
--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -704,8 +704,13 @@ test_that("run_p_hacking_tests reports numeric Cox-Shi rows on clustered data", 
 # Direct transcription of the pre-refactor compute_bounds, which evaluated
 # lambda2 per order (and per pair within an order) instead of sharing the
 # adjacent-pair vectors. Guards the refactor against any numeric drift.
+#
+# The h grid is 10x coarser than production's seq(0, 100, by = 0.001): each
+# bound is a max over the grid, so density only affects the max's resolution.
+# On the configs below the coarser max stays within 1.3e-5 relative of the
+# fine-grid value, well inside the 1e-4 tolerance used in the comparison.
 reference_bounds <- function(p_min, p_max, n_bins, order) {
-  h <- seq(0, 100, by = 0.001)
+  h <- seq(0, 100, by = 0.01)
   grid <- linspace(p_min, p_max, n_bins + 1)
   width <- c(n_bins, n_bins - 1, n_bins - 2)[order + 1]
   bounds <- numeric(width)
@@ -739,7 +744,8 @@ test_that("compute_bounds matches the per-order lambda2 formulas", {
     for (order in 0:2) {
       expect_equal(
         shared[[order + 1]],
-        reference_bounds(config$p_min, config$p_max, config$n_bins, order)
+        reference_bounds(config$p_min, config$p_max, config$n_bins, order),
+        tolerance = 1e-4
       )
     }
     expect_equal(bound0(config$p_min, config$p_max, config$n_bins), shared[[1]])


### PR DESCRIPTION
## Summary

The p-hacking test file was the suite's second-slowest at ~4.06s serial, with "compute_bounds matches the per-order lambda2 formulas" alone taking 1.42s. The reference_bounds helper evaluated lambda2 over a 100,001-point h grid (seq(0, 100, by = 0.001)) for every bin of two configs across orders 0:2.

This coarsens the reference grid to by = 0.01 and sets an explicit tolerance = 1e-4 on the comparison. Each bound is a max over the h grid, so grid density only affects the max's resolution: measured worst-case relative deviation from the fine grid on these configs is 1.3e-5, well inside the tolerance, while any real refactor drift the test guards against would blow far past it. A comment on the helper records this reasoning.

The test drops from 1.42s to ~0.78s; the remainder is compute_bounds itself exercising the production by = 0.001 grid, which the test must do. The rest of the file (123 tests, ~2.6s) is dominated by Cox-Shi golden-value tests at 0.35s or less each with no dense grids to trim, so it is left as is.

## Testing

- make test-file FILE=test-econometric-p-hacking.R: 124 pass, 0 fail
- Per-test timing via testthat ListReporter confirms the target test at 0.776s