### PR TITLE
test(maive): cut the wild-bootstrap reproducibility test from 27s to under 1s

### DIFF
--- a/tests/testthat/test-econometric-maive.R
+++ b/tests/testthat/test-econometric-maive.R
@@ -6,6 +6,7 @@ box::use(
     expect_match,
     expect_no_match,
     expect_true,
+    local_mocked_bindings,
     skip_if_not_installed,
     test_that
   ],
@@ -473,6 +474,18 @@ test_that("run_maive is reproducible across two bootstrap runs", {
   skip_if_not_installed("MAIVE")
   local_options(artma.verbose = 1)
   opts <- base_maive_options(se = 3L) # Wild bootstrap: needs the threaded seed.
+
+  # MAIVE hardcodes 999 wild-bootstrap replications with no public knob, which
+  # makes the two runs below take close to half a minute. The replication count
+  # is irrelevant to what this test guards (both runs seeing identical RNG
+  # state), so shrink B while keeping the real bootstrap and its seeding path.
+  real_boot <- utils::getFromNamespace("manual_wild_cluster_boot_se", "MAIVE")
+  local_mocked_bindings(
+    manual_wild_cluster_boot_se = function(model, data, cluster_var, B = 500, seed = 123) {
+      real_boot(model = model, data = data, cluster_var = cluster_var, B = 25L, seed = seed)
+    },
+    .package = "MAIVE"
+  )
 
   expect_equal(
     run_maive(make_maive_df(), opts)$summary,


### PR DESCRIPTION
## Why

`run_maive is reproducible across two bootstrap runs` took 27.3s serially, 48% of the whole 57s suite, and since testthat parallelises by file this one file dominated suite wall-clock time.

Profiling one `run_maive(se = 3L)` call showed 99.4% of the time inside `MAIVE:::manual_wild_cluster_boot_se` (999 replications per call, about 5 calls per run, no replication-count knob on the public `MAIVE::maive()` API).

## What

The test now wraps `manual_wild_cluster_boot_se` with `testthat::local_mocked_bindings(.package = "MAIVE")`, forwarding every argument to the real function but shrinking `B` to 25. The real bootstrap and its seeding path (`set.seed(seed)` inside the helper) still run, so the regression the test guards (both runs seeing identical RNG state) stays covered.

## Verification

- Simulated a seed-threading regression by making the wrapper feed a different seed per call: the two summaries diverge and the test fails, as it should.
- The test itself: 27.3s to 0.68s. Full file: 124 passing in about 1.4s of test time.
- Full suite: 0 failures, 2345 passing, wall time 30.7s (was about 57s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)