### PR TITLE
test(linear-tests): speed up bootstrap fast-path agreement test

### DIFF
--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -6,6 +6,7 @@ box::use(
     expect_message,
     expect_named,
     expect_no_message,
+    expect_null,
     expect_true,
     skip_if_not_installed,
     test_that
@@ -307,7 +308,7 @@ test_that("bootstrap fast paths match slow-path refits on resampled data", {
   compared <- stats::setNames(integer(length(fast_path_specs)), fast_path_specs)
 
   set.seed(1234)
-  for (replication in seq_len(5L)) {
+  for (replication in seq_len(2L)) {
     rows <- resample_cluster_rows(nrow(df), cluster_splits)
     boot_data <- df[rows, , drop = FALSE]
 
@@ -337,6 +338,17 @@ test_that("bootstrap fast paths match slow-path refits on resampled data", {
   }
 
   expect_true(all(compared > 0L))
+
+  # Under set.seed(1234) no sampled replication is degenerate (every draw
+  # keeps at least six distinct clusters), so force a two-cluster resample:
+  # too few groups for Swamy-Arora, and both random effects paths must fail
+  # identically on it.
+  degenerate_rows <- unlist(cluster_splits[rep(c("S1", "S2"), 6L)], use.names = FALSE)
+  re_spec <- specs[["re"]]
+  expect_null(tryCatch(re_spec$boot_estimate(df, degenerate_rows), error = function(e) NULL))
+  expect_null(suppressWarnings(
+    tryCatch(re_spec$fit(df[degenerate_rows, , drop = FALSE]), error = function(e) NULL)
+  ))
 })
 
 test_that("within fast path merges duplicated resampled clusters like plm", {


### PR DESCRIPTION
## Summary

The test "bootstrap fast paths match slow-path refits on resampled data" took 0.88s of the file's 1.86s serial runtime: 5 bootstrap replications, each fitting 6 model specs twice (fast path and full plm/lm refit).

Before cutting replications, I checked which of the 5 draws under set.seed(1234) actually produce a degenerate resample: none do. Every draw keeps at least 6 of the 12 distinct clusters, so the failure branch (both paths must fail identically) was dead code in this test; with 12 clusters resampled with replacement, no seed realistically hits it.

Changes:

- Reduce the loop to 2 sampled replications. Both compare all 6 specs successfully, so the "compared > 0 per spec" floor still holds.
- Add a handcrafted two-cluster resample that deterministically exercises the degenerate branch: too few groups for Swamy-Arora, so the random effects fast path and the plm refit must both fail. This complements the broader dedicated tests ("random/between effects fast path fails on degenerate resamples exactly like plm") on this test's own 12-study dataset.

The test now runs in about 0.10s (was 0.88s).

## Test plan

- `make test-file FILE=test-linear-tests.R`: 87 pass, 0 warnings
- `make lint`: no lints
