### PR TITLE
refactor(methods): shared equal/gltl variable-group resolver (B5)

### DIFF
--- a/inst/artma/libs/core/grouping.R
+++ b/inst/artma/libs/core/grouping.R
@@ -1,0 +1,165 @@
+#' @title Shared equal/gltl variable-group resolver
+#' @description
+#' Splits a numeric variable's values into labelled groups driven by a data
+#' config entry, using the same equal / greater-or-less-than (gltl) semantics
+#' shared by `effect_summary_stats` and `best_practice_estimate`. Extracting the
+#' logic here keeps a single source of truth for label formatting, threshold
+#' resolution (literal, "mean", "median") and the greater-equal / less-than tie
+#' break.
+box::use(
+  stats
+)
+
+#' @title Whether a group-config value is unset
+#' @description
+#' A config value counts as "not set" when it is `NULL`, empty, or a single
+#' `NA`. Used for the `equal` / `gltl` keys, which are `NA` when the split is
+#' not requested. Mirrors the historical `is_bpe_override_na` predicate so the
+#' `best_practice_estimate` call site keeps its exact NULL/empty tolerance while
+#' `effect_summary_stats`, which previously used a bare `is.na()`, gains the same
+#' (strictly safer) guard without any change for its always-present `NA` values.
+#' @param value *\[any\]* Config value to test.
+#' @return *\[logical(1)\]* `TRUE` when the value is unset.
+#' @keywords internal
+is_group_value_na <- function(value) {
+  is.null(value) || length(value) == 0 || (length(value) == 1 && is.na(value))
+}
+
+#' @title Format a group-boundary value for a label
+#' @description
+#' Numeric boundaries are rounded to `round_to` decimals; anything else is
+#' coerced with `as.character()`.
+#' @param value *\[numeric|character\]* Boundary value.
+#' @param round_to *\[integer\]* Decimals to round numeric values to.
+#' @return *\[character(1)\]* Display string.
+#' @keywords internal
+format_group_value <- function(value, round_to) {
+  if (is.numeric(value)) {
+    return(as.character(round(value, round_to)))
+  }
+  as.character(value)
+}
+
+#' @title Resolve a gltl threshold expression to a numeric value
+#' @description
+#' A literal numeric threshold is returned as-is. The strings "mean" and
+#' "median" are resolved against `threshold_values` (NA values dropped first);
+#' any other string is parsed with `as.numeric()`. Empty basis data yields
+#' `NA_real_` for the "mean"/"median" forms.
+#'
+#' The `threshold_values` argument is what lets the two call sites keep their
+#' historically different bases: `effect_summary_stats` computes the mean/median
+#' over rows whose effect and study size are finite, while
+#' `best_practice_estimate` uses every non-NA value of the column.
+#' @param gltl_val *\[numeric|character\]* Threshold value or "mean"/"median".
+#' @param threshold_values *\[numeric\]* Values the mean/median is taken over.
+#' @return *\[numeric(1)\]* Resolved threshold, or `NA_real_` when unresolvable.
+#' @keywords internal
+resolve_group_threshold <- function(gltl_val, threshold_values) {
+  if (!is.character(gltl_val)) {
+    return(as.numeric(gltl_val))
+  }
+
+  filtered <- threshold_values[!is.na(threshold_values)]
+  switch(gltl_val,
+    mean = if (length(filtered)) mean(filtered) else NA_real_,
+    median = if (length(filtered)) stats::median(filtered) else NA_real_,
+    suppressWarnings(as.numeric(gltl_val))
+  )
+}
+
+#' @title Resolve a variable's values into equal / gltl split groups
+#' @description
+#' Produces the labelled groups for a single config-flagged variable:
+#'
+#' * an exact-match group when `equal_val` is set (`var == equal_val`);
+#' * greater-equal / less-than groups when `gltl_val` is set and its threshold
+#'   resolves to a non-NA number: values `>= threshold` and `< threshold` (ties
+#'   at the threshold fall in the greater-equal group);
+#' * when neither is set and `auto_levels` is `TRUE`, one group per distinct
+#'   level, but only when the number of distinct non-NA levels is in
+#'   `[2, max_auto_levels]`; otherwise an empty list.
+#'
+#' Both call sites share this equal/gltl core. Two behaviours stay under caller
+#' control via parameters so migration is exact:
+#'
+#' * `threshold_values` selects the basis for "mean"/"median" thresholds (see
+#'   [resolve_group_threshold]).
+#' * `auto_levels` enables the per-level fallback used by
+#'   `best_practice_estimate`; `effect_summary_stats` leaves it off and applies
+#'   its own all-data fallback outside this helper.
+#'
+#' One historical divergence is intentionally dropped because it is not
+#' observable: `effect_summary_stats` previously suppressed the " = " separator
+#' for an empty-string `equal_val`, but it only ever groups numeric columns, so
+#' that branch produced an empty (never-emitted) group. This helper always
+#' formats an equal label as `"<label> = <value>"`.
+#' @param var_label *\[character(1)\]* Human-readable variable label.
+#' @param equal_val *\[numeric|character|NA\]* Exact-match value, or unset.
+#' @param gltl_val *\[numeric|character|NA\]* Threshold value or "mean"/"median",
+#'   or unset.
+#' @param var_values *\[numeric\]* The variable's values; `row_idx` indexes into
+#'   this vector.
+#' @param round_to *\[integer\]* Decimals for label formatting.
+#' @param threshold_values *\[numeric, optional\]* Basis for mean/median
+#'   thresholds. Defaults to `var_values`.
+#' @param auto_levels *\[logical(1), optional\]* Enable the per-level fallback.
+#'   Defaults to `FALSE`.
+#' @param max_auto_levels *\[integer(1), optional\]* Upper bound on distinct
+#'   levels for the fallback. Defaults to `12L`.
+#' @return *\[list\]* A list of `list(label, row_idx)` entries, where `row_idx`
+#'   indexes into `var_values`.
+#' @keywords internal
+resolve_variable_groups <- function(var_label, equal_val, gltl_val, var_values, round_to,
+                                    threshold_values = var_values,
+                                    auto_levels = FALSE, max_auto_levels = 12L) {
+  groups <- list()
+
+  if (!is_group_value_na(equal_val)) {
+    groups[[length(groups) + 1]] <- list(
+      label = paste0(var_label, " = ", format_group_value(equal_val, round_to)),
+      row_idx = which(!is.na(var_values) & var_values == equal_val)
+    )
+  }
+
+  if (!is_group_value_na(gltl_val)) {
+    threshold <- resolve_group_threshold(gltl_val, threshold_values)
+    if (!is.na(threshold)) {
+      groups[[length(groups) + 1]] <- list(
+        label = paste0(var_label, " >= ", format_group_value(threshold, round_to)),
+        row_idx = which(!is.na(var_values) & var_values >= threshold)
+      )
+      groups[[length(groups) + 1]] <- list(
+        label = paste0(var_label, " < ", format_group_value(threshold, round_to)),
+        row_idx = which(!is.na(var_values) & var_values < threshold)
+      )
+    }
+  }
+
+  if (length(groups)) {
+    return(groups)
+  }
+
+  if (!isTRUE(auto_levels)) {
+    return(list())
+  }
+
+  levels_present <- sort(unique(stats::na.omit(var_values)))
+  if (length(levels_present) < 2 || length(levels_present) > max_auto_levels) {
+    return(list())
+  }
+
+  lapply(levels_present, function(level_value) {
+    list(
+      label = paste0(var_label, " = ", format_group_value(level_value, round_to)),
+      row_idx = which(!is.na(var_values) & var_values == level_value)
+    )
+  })
+}
+
+box::export(
+  is_group_value_na,
+  format_group_value,
+  resolve_group_threshold,
+  resolve_variable_groups
+)

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -943,12 +943,13 @@ compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_m
     }
 
     var_label <- var_cfg$var_name_verbose %||% var_name
-    groups <- resolve_bpe_factor_groups(
+    groups <- resolve_variable_groups(
       var_label = var_label,
       equal_val = var_cfg$bpe_equal,
       gltl_val = var_cfg$bpe_gltl,
       var_values = bma_data[[var_name]],
-      round_to = round_to
+      round_to = round_to,
+      auto_levels = TRUE
     )
 
     for (group in groups) {
@@ -1126,12 +1127,13 @@ build_bpe_density_plots <- function(predictors, config, bma_data, study_index_gr
     var_label <- var_cfg$var_name_verbose %||% var_name
     study_level_values <- resolve_bpe_study_level_values(bma_data, study_index_groups, var_name)
 
-    groups <- resolve_bpe_factor_groups(
+    groups <- resolve_variable_groups(
       var_label = var_label,
       equal_val = var_cfg$bpe_equal,
       gltl_val = var_cfg$bpe_gltl,
       var_values = study_level_values,
-      round_to = round_to
+      round_to = round_to,
+      auto_levels = TRUE
     )
 
     plot_df <- build_bpe_density_plot_data(
@@ -1229,83 +1231,6 @@ is_bpe_factor_var <- function(var_cfg) {
   gltl <- var_cfg$bpe_gltl
 
   any(c(isTRUE(flag), !is_bpe_override_na(equal), !is_bpe_override_na(gltl)))
-}
-
-#' @title Split a Variable's Values into BPE Factor-Level Groups
-#' @description
-#' Mirrors the equal/gltl split used by `effect_summary_stats`: an exact-match
-#' group when `equal_val` is set, greater/less-than groups when `gltl_val` is
-#' set (accepting "mean"/"median" as well as a literal threshold), and,
-#' absent both, one group per distinct level for variables with a small
-#' number of unique values.
-#' @return *\[list\]* A list of `list(label, row_idx)` entries, where `row_idx`
-#'   indexes into `var_values`.
-#' @keywords internal
-resolve_bpe_factor_groups <- function(var_label, equal_val, gltl_val, var_values, round_to) {
-  groups <- list()
-
-  if (!is_bpe_override_na(equal_val)) {
-    row_idx <- which(!is.na(var_values) & var_values == equal_val)
-    groups[[length(groups) + 1]] <- list(
-      label = paste0(var_label, " = ", format_bpe_group_value(equal_val, round_to)),
-      row_idx = row_idx
-    )
-  }
-
-  if (!is_bpe_override_na(gltl_val)) {
-    threshold <- resolve_bpe_gltl_threshold(gltl_val, var_values)
-    if (!is.na(threshold)) {
-      groups[[length(groups) + 1]] <- list(
-        label = paste0(var_label, " >= ", format_bpe_group_value(threshold, round_to)),
-        row_idx = which(!is.na(var_values) & var_values >= threshold)
-      )
-      groups[[length(groups) + 1]] <- list(
-        label = paste0(var_label, " < ", format_bpe_group_value(threshold, round_to)),
-        row_idx = which(!is.na(var_values) & var_values < threshold)
-      )
-    }
-  }
-
-  if (length(groups)) {
-    return(groups)
-  }
-
-  max_auto_levels <- 12L
-  levels_present <- sort(unique(stats::na.omit(var_values)))
-  if (length(levels_present) < 2 || length(levels_present) > max_auto_levels) {
-    return(list())
-  }
-
-  lapply(levels_present, function(level_value) {
-    list(
-      label = paste0(var_label, " = ", format_bpe_group_value(level_value, round_to)),
-      row_idx = which(!is.na(var_values) & var_values == level_value)
-    )
-  })
-}
-
-#' @title Resolve a gltl Threshold to a Numeric Value
-#' @keywords internal
-resolve_bpe_gltl_threshold <- function(gltl_val, var_values) {
-  if (!is.character(gltl_val)) {
-    return(as.numeric(gltl_val))
-  }
-
-  filtered <- var_values[!is.na(var_values)]
-  switch(gltl_val,
-    mean = if (length(filtered)) mean(filtered) else NA_real_,
-    median = if (length(filtered)) stats::median(filtered) else NA_real_,
-    suppressWarnings(as.numeric(gltl_val))
-  )
-}
-
-#' @title Format a Group Boundary Value for Display
-#' @keywords internal
-format_bpe_group_value <- function(value, round_to) {
-  if (is.numeric(value)) {
-    return(as.character(round(value, round_to)))
-  }
-  as.character(value)
 }
 
 compute_context_values <- function(bma_data, row_idx, predictors, overrides) {
@@ -1528,6 +1453,7 @@ matches_any <- function(label, patterns) {
 
 
 box::use(
+  artma / libs / core / grouping[resolve_variable_groups],
   artma / modules / runtime_methods[register_runtime_method]
 )
 

--- a/inst/artma/methods/effect_summary_stats.R
+++ b/inst/artma/methods/effect_summary_stats.R
@@ -9,6 +9,11 @@ effect_summary_stats <- function(df) {
   box::use(
     artma / const[CONST],
     artma / data_config / read[get_data_config],
+    artma / libs / core / grouping[
+      is_group_value_na,
+      resolve_group_threshold,
+      resolve_variable_groups
+    ],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
@@ -104,24 +109,6 @@ effect_summary_stats <- function(df) {
       effect = effect_values[mask],
       study_size = study_sizes[mask]
     )
-  }
-
-  format_label <- function(base_label, suffix) {
-    if (nzchar(suffix)) {
-      paste0(base_label, suffix)
-    } else {
-      base_label
-    }
-  }
-
-  format_equal_suffix <- function(value) {
-    if (is.numeric(value)) {
-      return(paste0(" = ", round(value, round_to)))
-    }
-    if (is.character(value) && nzchar(value)) {
-      return(paste0(" = ", value))
-    }
-    ""
   }
 
   # Determine which variables to analyse ------------------------------------
@@ -229,35 +216,29 @@ effect_summary_stats <- function(df) {
     valid_mask <- !is.na(var_data) & is.finite(effect_values) & is.finite(study_sizes)
     filtered_var_data <- var_data[valid_mask]
 
-    added_any <- FALSE
+    # The threshold basis (filtered_var_data) intentionally differs from the
+    # grouping basis (var_data): mean/median thresholds are computed only over
+    # rows whose effect and study size are finite.
+    groups <- resolve_variable_groups(
+      var_label = var_label,
+      equal_val = equal_val,
+      gltl_val = gltl_val,
+      var_values = var_data,
+      round_to = round_to,
+      threshold_values = filtered_var_data
+    )
 
-    if (!is.na(equal_val)) {
-      subset <- prepare_subset(!is.na(var_data) & var_data == equal_val)
-      label <- format_label(var_label, format_equal_suffix(equal_val))
-      added_any <- add_row(label, var_class, subset) || added_any
+    added_any <- FALSE
+    for (group in groups) {
+      subset <- prepare_subset(seq_along(var_data) %in% group$row_idx)
+      added_any <- add_row(group$label, var_class, subset) || added_any
     }
 
-    if (!is.na(gltl_val)) {
-      if (is.character(gltl_val)) {
-        gltl_val <- switch(gltl_val,
-          mean = if (length(filtered_var_data)) mean(filtered_var_data, na.rm = TRUE) else NA_real_,
-          median = if (length(filtered_var_data)) stats::median(filtered_var_data, na.rm = TRUE) else NA_real_,
-          suppressWarnings(as.numeric(gltl_val))
-        )
-      }
-
-      if (is.na(gltl_val)) {
-        missing_vars <- c(missing_vars, var_name)
-      } else {
-        subset_ge <- prepare_subset(!is.na(var_data) & var_data >= gltl_val)
-        subset_lt <- prepare_subset(!is.na(var_data) & var_data < gltl_val)
-
-        label_ge <- format_label(var_label, paste0(" >= ", round(gltl_val, round_to)))
-        label_lt <- format_label(var_label, paste0(" < ", round(gltl_val, round_to)))
-
-        added_any <- add_row(label_ge, var_class, subset_ge) || added_any
-        added_any <- add_row(label_lt, var_class, subset_lt) || added_any
-      }
+    # A gltl split whose threshold cannot resolve to a number marks the
+    # variable as missing, as it did before the split logic was extracted.
+    if (!is_group_value_na(gltl_val) &&
+      is.na(resolve_group_threshold(gltl_val, filtered_var_data))) {
+      missing_vars <- c(missing_vars, var_name)
     }
 
     if (!added_any) {

--- a/tests/testthat/test-grouping.R
+++ b/tests/testthat/test-grouping.R
@@ -1,0 +1,164 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_identical,
+    expect_length,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
+  artma / libs / core / grouping[
+    format_group_value,
+    is_group_value_na,
+    resolve_group_threshold,
+    resolve_variable_groups
+  ]
+)
+
+# A compact view of a group list: label -> row indices. Pins both the label
+# formatting and the exact row membership produced by the resolver.
+group_map <- function(groups) {
+  stats::setNames(
+    lapply(groups, function(g) g$row_idx),
+    vapply(groups, function(g) g$label, character(1))
+  )
+}
+
+test_that("is_group_value_na treats NULL, empty and scalar NA as unset", {
+  expect_true(is_group_value_na(NULL))
+  expect_true(is_group_value_na(NA))
+  expect_true(is_group_value_na(character(0)))
+  expect_true(is_group_value_na(NA_character_))
+  expect_false(is_group_value_na(0))
+  expect_false(is_group_value_na("mean"))
+})
+
+test_that("resolve_group_threshold resolves literals, mean and median over the given basis", {
+  expect_equal(resolve_group_threshold(1.5, c(0, 1, 2)), 1.5)
+  expect_equal(resolve_group_threshold("mean", c(0, 1, 2, 5)), 2)
+  expect_equal(resolve_group_threshold("median", c(0, 1, 2, 5)), 1.5)
+  # NA values dropped before the reduction.
+  expect_equal(resolve_group_threshold("mean", c(0, NA, 2)), 1)
+  # Empty basis yields NA for mean/median.
+  expect_true(is.na(resolve_group_threshold("mean", numeric(0))))
+  expect_true(is.na(resolve_group_threshold("median", numeric(0))))
+})
+
+test_that("format_group_value rounds numerics and stringifies the rest", {
+  expect_identical(format_group_value(1.23456, 3), "1.235")
+  expect_identical(format_group_value(2, 3), "2")
+  expect_identical(format_group_value("high", 3), "high")
+})
+
+# Characterization: best_practice_estimate call-site profile ------------------
+# auto_levels = TRUE, threshold basis defaults to var_values. The expected
+# assignments below are the verbatim output of the pre-extraction
+# resolve_bpe_factor_groups() on the same fixtures.
+
+bpe_groups <- function(equal_val, gltl_val, var_values) {
+  resolve_variable_groups(
+    var_label = "Top",
+    equal_val = equal_val,
+    gltl_val = gltl_val,
+    var_values = var_values,
+    round_to = 3,
+    auto_levels = TRUE
+  )
+}
+
+test_that("bpe profile: equal split", {
+  v <- c(0, 1, 0, 1, 2, NA, 5)
+  expect_identical(
+    group_map(bpe_groups(1, NA, v)),
+    list(`Top = 1` = c(2L, 4L))
+  )
+})
+
+test_that("bpe profile: gltl mean/median/literal over full non-NA values", {
+  v <- c(0, 1, 0, 1, 2, NA, 5)
+  expect_identical(
+    group_map(bpe_groups(NA, "mean", v)),
+    list(`Top >= 1.5` = c(5L, 7L), `Top < 1.5` = c(1L, 2L, 3L, 4L))
+  )
+  expect_identical(
+    group_map(bpe_groups(NA, "median", v)),
+    list(`Top >= 1` = c(2L, 4L, 5L, 7L), `Top < 1` = c(1L, 3L))
+  )
+  expect_identical(
+    group_map(bpe_groups(NA, 1.5, v)),
+    list(`Top >= 1.5` = c(5L, 7L), `Top < 1.5` = c(1L, 2L, 3L, 4L))
+  )
+})
+
+test_that("bpe profile: equal and gltl combine, greater-equal takes the tie", {
+  v <- c(0, 1, 0, 1, 2, NA, 5)
+  expect_identical(
+    group_map(bpe_groups(0, 2, v)),
+    list(
+      `Top = 0` = c(1L, 3L),
+      `Top >= 2` = c(5L, 7L),
+      `Top < 2` = c(1L, 2L, 3L, 4L)
+    )
+  )
+})
+
+test_that("bpe profile: per-level fallback within [2, 12] distinct levels", {
+  v <- c(0, 1, 0, 1, 2, NA, 5)
+  expect_identical(
+    group_map(bpe_groups(NA, NA, v)),
+    list(
+      `Top = 0` = c(1L, 3L),
+      `Top = 1` = c(2L, 4L),
+      `Top = 2` = 5L,
+      `Top = 5` = 7L
+    )
+  )
+  # Too many distinct levels: no fallback groups.
+  expect_length(bpe_groups(NA, NA, 1:20), 0)
+  # Fewer than two distinct levels: no fallback groups.
+  expect_length(bpe_groups(NA, NA, c(3, 3, 3)), 0)
+})
+
+# Characterization: effect_summary_stats call-site profile --------------------
+# auto_levels = FALSE (its own all-data fallback lives outside the resolver),
+# threshold basis restricted to rows with finite effect and study size. The
+# expected assignments are the verbatim output of the pre-extraction inline
+# split logic in effect_summary_stats().
+
+ess_groups <- function(equal_val, gltl_val, var_values, threshold_values) {
+  resolve_variable_groups(
+    var_label = "Top",
+    equal_val = equal_val,
+    gltl_val = gltl_val,
+    var_values = var_values,
+    round_to = 3,
+    threshold_values = threshold_values
+  )
+}
+
+test_that("ess profile: threshold basis differs from the grouping basis", {
+  vd <- c(0, 1, 0, 1, 2, NA, 5)
+  # Row 7 (value 5) dropped from the mean basis because its effect is infinite;
+  # mean of c(0, 1, 0, 1, 2) is 0.8, not the 1.5 the full column would give.
+  filtered <- vd[c(1, 2, 3, 4, 5)]
+  expect_identical(
+    group_map(ess_groups(NA, "mean", vd, filtered)),
+    list(`Top >= 0.8` = c(2L, 4L, 5L, 7L), `Top < 0.8` = c(1L, 3L))
+  )
+})
+
+test_that("ess profile: equal split matches numeric label formatting", {
+  vd <- c(0, 1, 0, 1, 2, NA, 5)
+  expect_identical(
+    group_map(ess_groups(1, NA, vd, vd[!is.na(vd)])),
+    list(`Top = 1` = c(2L, 4L))
+  )
+})
+
+test_that("ess profile: no per-level fallback (auto_levels off)", {
+  vd <- c(0, 1, 0, 1, 2, NA, 5)
+  expect_length(ess_groups(NA, NA, vd, vd[!is.na(vd)]), 0)
+})


### PR DESCRIPTION
## What moved

Extracts the duplicated mean/median/threshold variable-split logic into one shared resolver.

New module `inst/artma/libs/core/grouping.R` exports:

- `resolve_variable_groups()`: the equal / gltl (greater-equal / less-than) split, returning `list(label, row_idx)` groups.
- `resolve_group_threshold()`: literal / "mean" / "median" threshold resolution.
- `format_group_value()` and `is_group_value_na()`: label formatting and the unset-value predicate.

Placement reasoning: this is pure, config-driven data-splitting logic with no dependency on options, econometrics, or plotting, so it sits in `libs/core/` next to the other general utilities (`utils`, `string`, `validation`) rather than in `methods/`, `econometric/`, or `visualization/`. That keeps it importable by both `methods/` files today and by the `econometric/` split planned in C1.

Removed from `methods/best_practice_estimate.R`: `resolve_bpe_factor_groups`, `resolve_bpe_gltl_threshold`, `format_bpe_group_value` (2 call sites migrated). `is_bpe_override_na` stays; it is still used elsewhere in that file.

Removed from `methods/effect_summary_stats.R`: the inline equal/gltl block plus its local `format_label` / `format_equal_suffix` helpers (1 call site migrated).

## What changed behavior

Nothing. Outputs are identical at both call sites.

Two call-site divergences are preserved via parameters, not flattened:

- Threshold basis: `effect_summary_stats` computes mean/median only over rows whose effect and study size are finite; `best_practice_estimate` uses every non-NA column value. Preserved with the `threshold_values` parameter (defaults to `var_values`).
- Fallback: `best_practice_estimate` falls back to one group per distinct level (2 to 12 levels); `effect_summary_stats` applies its own all-data fallback outside the resolver. Preserved with the `auto_levels` parameter (default `FALSE`).

The greater-equal / less-than tie break (values equal to the threshold go to the `>=` group) and NA handling are identical to before. One historical, unobservable divergence is documented and dropped: `effect_summary_stats` used to suppress the " = " separator for an empty-string `equal_val`, but it only groups numeric columns so that branch produced an empty (never-emitted) group; the shared helper always formats `"<label> = <value>"`. All divergences are documented in the helper's roxygen.

## Tests pinning the outputs

- New `tests/testthat/test-grouping.R` (26 assertions) pins both call sites' current group assignments (labels plus exact row membership) as characterization tests: the bpe profile (`auto_levels = TRUE`, full-column threshold basis) and the ess profile (`auto_levels = FALSE`, effect/study-finite threshold basis, verified to give mean 0.8 vs 1.5 on the same column). Expected values are the verbatim output of the pre-extraction functions.
- Existing suites unchanged and green: `test-best-practice-estimate.R` (43), `test-effect-summary-stats.R` (15), `test-effect-summary-stats-integration.R` (32), `test-effect-summary-stats-interactive.R` (40). Full suite: 0 failures, 2385 passing.

Note for the concurrent B6 agent: this diff is confined to the factor-group region of `best_practice_estimate.R` (removed three helpers, edited two call sites) and adds two new files, to ease the rebase.

Refs #322 (item B5).
