### PR TITLE
refactor(bma): extract shared unwrap_bma_result

### DIFF
--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -298,7 +298,7 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
   box::use(
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate],
-    artma / methods / bma[bma]
+    artma / methods / bma[bma, unwrap_bma_result]
   )
 
   validate(
@@ -307,7 +307,7 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
     length(run_bma_if_missing) == 1
   )
 
-  normalized <- normalize_bma_result_input(bma_result)
+  normalized <- unwrap_bma_result(bma_result)
   if (is_bma_input_ready(normalized)) {
     normalized$formula <- build_bma_formula_from_data(normalized$data)
     normalized$source <- "provided"
@@ -331,7 +331,7 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
     cli::cli_alert_info("Running BMA first because BPE needs BMA model inputs.")
   }
 
-  computed <- normalize_bma_result_input(bma(df))
+  computed <- unwrap_bma_result(bma(df))
   assert(
     is_bma_input_ready(computed),
     "BMA did not produce a usable model/data bundle for best-practice estimation."
@@ -340,29 +340,6 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
   computed$formula <- build_bma_formula_from_data(computed$data)
   computed$source <- "computed"
   computed
-}
-
-normalize_bma_result_input <- function(bma_result) {
-  empty <- list(model = NULL, data = NULL, var_list = NULL, params = NULL)
-
-  if (!is.list(bma_result)) {
-    return(empty)
-  }
-
-  # Accept the standard method contract (fields under meta) or a bare meta-like
-  # list for callers that pass one directly.
-  meta <- bma_result$meta %||% bma_result
-
-  if (!is.null(meta$model) || !is.null(meta$data) || !is.null(meta$var_list)) {
-    return(list(
-      model = meta$model,
-      data = meta$data,
-      var_list = meta$var_list,
-      params = meta$params
-    ))
-  }
-
-  empty
 }
 
 is_bma_input_ready <- function(result) {
@@ -1539,4 +1516,7 @@ run <- register_runtime_method(
   suggests = "BMS"
 )
 
-box::export(best_practice_estimate, run, infer_bpe_recommendation, format_bpe_recommendation)
+box::export(
+  best_practice_estimate, run, infer_bpe_recommendation, format_bpe_recommendation,
+  resolve_bma_input_for_bpe
+)

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -436,6 +436,40 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
   )
 }
 
+#' Unwrap a BMA result into its model/data/var_list/params fields
+#' @description
+#' Accepts either the standard method-result shape (fields nested under
+#' `$meta`) or a bare list carrying `model`/`data`/`var_list` directly, so
+#' callers that pass a previously computed `bma()` result or a hand-built
+#' list are both supported. Returns a list with `model`, `data`, `var_list`
+#' and `params` fields (all `NULL` when `bma_result` does not carry a usable
+#' bundle).
+#' @param bma_result *\[list, optional\]* Either a `bma()` method result or a
+#'   bare `list(model=, data=, var_list=, params=)`.
+#' @return *\[list\]* `list(model=, data=, var_list=, params=)`.
+unwrap_bma_result <- function(bma_result) {
+  empty <- list(model = NULL, data = NULL, var_list = NULL, params = NULL)
+
+  if (!is.list(bma_result)) {
+    return(empty)
+  }
+
+  # Accept the standard method contract (fields under meta) or a bare meta-like
+  # list for callers that pass one directly.
+  meta <- bma_result$meta %||% bma_result
+
+  if (!is.null(meta$model) || !is.null(meta$data) || !is.null(meta$var_list)) {
+    return(list(
+      model = meta$model,
+      data = meta$data,
+      var_list = meta$var_list,
+      params = meta$params
+    ))
+  }
+
+  empty
+}
+
 #' Prompt user to select BMA variables at runtime
 #' @param df *\[data.frame\]* The data frame
 #' @param config *\[list\]* The data config
@@ -797,5 +831,6 @@ run <- register_runtime_method(
   cached = TRUE
 )
 
-# prepare_bma_inputs is exported because the fma method reuses it directly.
-box::export(bma, run, prepare_bma_inputs)
+# prepare_bma_inputs and unwrap_bma_result are exported because the fma and
+# best_practice_estimate methods reuse them directly.
+box::export(bma, run, prepare_bma_inputs, unwrap_bma_result)

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -9,7 +9,7 @@ fma <- function(df, bma_result = NULL) {
     artma / econometric / fma[run_fma],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate, validate_columns],
-    artma / methods / bma[prepare_bma_inputs],
+    artma / methods / bma[prepare_bma_inputs, unwrap_bma_result],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group]
   )
@@ -78,24 +78,7 @@ fma <- function(df, bma_result = NULL) {
   }
   bma_params <- bma_params[[1]]
 
-  resolve_bma_result <- function(result) {
-    if (!is.list(result)) {
-      return(list())
-    }
-    # Accept the standard method contract (fields under meta) or a bare
-    # meta-like list for callers that pass one directly.
-    meta <- result$meta %||% result
-    if (!is.null(meta$model) || !is.null(meta$data) || !is.null(meta$var_list)) {
-      return(list(
-        model = meta$model,
-        data = meta$data,
-        var_list = meta$var_list
-      ))
-    }
-    list()
-  }
-
-  resolved <- resolve_bma_result(bma_result)
+  resolved <- unwrap_bma_result(bma_result)
   bma_model <- resolved$model
   bma_data <- resolved$data
   bma_var_list <- resolved$var_list

--- a/tests/testthat/test-bma-result-unwrap.R
+++ b/tests/testthat/test-bma-result-unwrap.R
@@ -1,0 +1,191 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_false,
+    expect_identical,
+    expect_named,
+    expect_true,
+    skip_if_not_installed,
+    test_that
+  ],
+  withr[local_options]
+)
+
+box::use(
+  artma / econometric / bma[get_bma_data, run_bma],
+  artma / methods / best_practice_estimate[resolve_bma_input_for_bpe],
+  artma / methods / fma[fma]
+)
+
+# resolve_bma_input_for_bpe accepts either the standard method-result shape
+# (fields nested under $meta) or a bare list carrying model/data/var_list
+# directly. These fixtures avoid running BMS: resolve_bma_input_for_bpe only
+# checks `inherits(model, "bma")`, it never calls a BMS S3 method itself.
+make_fake_bma_model <- function() {
+  structure(list(), class = "bma")
+}
+
+make_fake_bma_data <- function() {
+  data.frame(effect = c(0.1, 0.2, 0.3), moderator1 = c(1, 0, 1))
+}
+
+test_that("resolve_bma_input_for_bpe accepts the $meta bundle shape", {
+  model <- make_fake_bma_model()
+  bma_data <- make_fake_bma_data()
+
+  bma_result <- list(
+    meta = list(
+      model = model,
+      data = bma_data,
+      var_list = data.frame(var_name = c("effect", "moderator1")),
+      params = list(g = "UIP")
+    )
+  )
+
+  resolved <- resolve_bma_input_for_bpe(df = bma_data, bma_result = bma_result, run_bma_if_missing = TRUE)
+
+  expect_identical(resolved$model, model)
+  expect_identical(resolved$data, bma_data)
+  expect_equal(resolved$source, "provided")
+  expect_true(inherits(resolved$formula, "formula"))
+})
+
+test_that("resolve_bma_input_for_bpe accepts a bare model/data/var_list list", {
+  model <- make_fake_bma_model()
+  bma_data <- make_fake_bma_data()
+
+  bma_result <- list(
+    model = model,
+    data = bma_data,
+    var_list = data.frame(var_name = c("effect", "moderator1"))
+  )
+
+  resolved <- resolve_bma_input_for_bpe(df = bma_data, bma_result = bma_result, run_bma_if_missing = TRUE)
+
+  expect_identical(resolved$model, model)
+  expect_identical(resolved$data, bma_data)
+  expect_equal(resolved$source, "provided")
+})
+
+test_that("resolve_bma_input_for_bpe aborts on a malformed list with run_bma_if_missing = FALSE", {
+  bma_data <- make_fake_bma_data()
+
+  expect_error(
+    resolve_bma_input_for_bpe(df = bma_data, bma_result = list(unrelated = 1), run_bma_if_missing = FALSE),
+    "Best-practice estimate requires a BMA result and run_bma_if_missing is FALSE"
+  )
+})
+
+test_that("resolve_bma_input_for_bpe aborts on a non-list bma_result with run_bma_if_missing = FALSE", {
+  bma_data <- make_fake_bma_data()
+
+  expect_error(
+    resolve_bma_input_for_bpe(df = bma_data, bma_result = "not-a-list", run_bma_if_missing = FALSE),
+    "Best-practice estimate requires a BMA result and run_bma_if_missing is FALSE"
+  )
+})
+
+# fma()'s local resolve_bma_result has the same "$meta bundle or bare list"
+# contract. A malformed bma_result should fall back to computing BMA inputs
+# from df, exactly as if no bma_result had been provided at all.
+test_that("fma treats a malformed bma_result identically to no bma_result at all", {
+  skip_if_not_installed("BMS")
+  skip_if_not_installed("quadprog")
+
+  n <- 20L
+  df <- data.frame(
+    effect = rnorm(n, mean = 0.2, sd = 0.1),
+    se = runif(n, min = 0.05, max = 0.15),
+    moderator1 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE),
+    moderator1 = list(var_name = "moderator1", var_name_verbose = "Moderator 1", bma = TRUE)
+  )
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.methods.bma.burn = 100L,
+    artma.methods.bma.iter = 500L,
+    artma.methods.bma.nmodel = 10L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  set.seed(99)
+  result_no_bma_result <- fma(df, bma_result = NULL)
+  set.seed(99)
+  result_malformed <- fma(df, bma_result = "not-a-list")
+
+  expect_equal(result_malformed$tables$coefficients, result_no_bma_result$tables$coefficients)
+  expect_equal(result_malformed$meta$weights, result_no_bma_result$meta$weights)
+})
+
+test_that("fma reuses a provided BMA result in both the $meta bundle and bare-list shapes", {
+  skip_if_not_installed("BMS")
+  skip_if_not_installed("quadprog")
+
+  set.seed(11)
+  n <- 30L
+  df <- data.frame(
+    effect = rnorm(n, mean = 0.2, sd = 0.1),
+    se = runif(n, min = 0.05, max = 0.15),
+    moderator1 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+
+  var_list <- data.frame(
+    var_name = c("effect", "se", "moderator1"),
+    var_name_verbose = c("Effect", "SE", "Moderator 1"),
+    bma = c(TRUE, TRUE, TRUE),
+    to_log_for_bma = c(FALSE, FALSE, FALSE),
+    bma_reference_var = c(FALSE, FALSE, FALSE),
+    stringsAsFactors = FALSE
+  )
+
+  bma_data <- get_bma_data(
+    df,
+    var_list,
+    variable_info = c("effect", "se", "moderator1"),
+    scale_data = FALSE,
+    from_vector = TRUE,
+    include_reference_groups = FALSE
+  )
+
+  params <- list(burn = 100L, iter = 500L, nmodel = 10L, g = "UIP", mprior = "uniform", mcmc = "bd")
+  model <- run_bma(bma_data, params)
+
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE),
+    moderator1 = list(var_name = "moderator1", var_name_verbose = "Moderator 1", bma = TRUE)
+  )
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.methods.bma.burn = 100L,
+    artma.methods.bma.iter = 500L,
+    artma.methods.bma.nmodel = 10L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd"
+  ))
+
+  meta_bundle <- list(meta = list(model = model, data = bma_data, var_list = var_list))
+  bare_list <- list(model = model, data = bma_data, var_list = var_list)
+
+  result_meta_bundle <- fma(df, bma_result = meta_bundle)
+  result_bare_list <- fma(df, bma_result = bare_list)
+
+  expect_identical(result_meta_bundle$meta$model, model)
+  expect_identical(result_bare_list$meta$model, model)
+  expect_named(result_meta_bundle$tables$coefficients, names(result_bare_list$tables$coefficients))
+})


### PR DESCRIPTION
## What moved

`normalize_bma_result_input` (private helper in `best_practice_estimate.R`) and the local `resolve_bma_result` closure inside `fma()` both duplicated the same "accept either the `$meta` bundle or a bare `list(model=, data=, var_list=, params=)`" unwrap logic. Both are replaced by one `unwrap_bma_result()` in `inst/artma/methods/bma.R`, placed right after the existing shared `prepare_bma_inputs` and exported alongside it.

- `resolve_bma_input_for_bpe()` in `best_practice_estimate.R` now calls `unwrap_bma_result()` instead of the deleted `normalize_bma_result_input()`. Its own signature, error messages, and `is_bma_input_ready()` gate are unchanged.
- `fma()` now calls `unwrap_bma_result()` instead of its inline `resolve_bma_result` closure.
- `resolve_bma_input_for_bpe` is now exported from `best_practice_estimate.R` (it previously was not) so it can be exercised directly by tests.

## What changed behavior

Nothing. This is a pure extraction: both call sites only ever read `$model`/`$data`/`$var_list`(/`$params`) off the returned list, so unifying the "not ready" shape (both now return `list(model=NULL, data=NULL, var_list=NULL, params=NULL)` instead of `fma`'s previous bare `list()`) does not change any observable behavior.

## Tests

New file `tests/testthat/test-bma-result-unwrap.R`, written and passing against the pre-refactor code before the extraction, covers:

- `resolve_bma_input_for_bpe` accepting the `$meta` bundle shape.
- `resolve_bma_input_for_bpe` accepting the bare `model`/`data`/`var_list` shape.
- `resolve_bma_input_for_bpe` aborting on a malformed list input (with `run_bma_if_missing = FALSE`), pinning the existing error message.
- `resolve_bma_input_for_bpe` aborting on a non-list input the same way.
- `fma()` treating a malformed `bma_result` identically to no `bma_result` at all (same coefficients/weights, seeded).
- `fma()` reusing a provided BMA result end to end, for both accepted shapes, without recomputing it.

Existing `test-bma.R`, `test-fma.R`, and `test-best-practice-estimate.R` all still pass unchanged. Full `make test` suite: 0 failures.

Refs #322 (item B6).