### PR TITLE
refactor(options): template-sourced typed option accessors

### DIFF
--- a/inst/artma/calc/meta.R
+++ b/inst/artma/calc/meta.R
@@ -39,9 +39,12 @@ reg_dof <- function(n_obs, n_predictors) n_obs - n_predictors
 #' @param reg_dof *\[numeric, optional\]* The degrees of freedom for the regression. Has to be provided if `se` is not provided.
 #' @return *\[numeric\]* The precision of the effect estimates
 precision <- function(se = NULL, reg_dof = NULL) {
-  box::use(artma / libs / core / utils[get_verbosity])
+  box::use(
+    artma / libs / core / utils[get_verbosity],
+    artma / options / typed_accessors[get_precision_type]
+  )
 
-  precision_type <- getOption("artma.calc.precision_type", "1/SE")
+  precision_type <- get_precision_type()
   if (precision_type == "1/SE") {
     zero_se_rows <- which(se == 0)
     if (length(zero_se_rows) > 0) {

--- a/inst/artma/data/compute.R
+++ b/inst/artma/data/compute.R
@@ -203,10 +203,11 @@ add_reg_dof_column <- function(df) {
 add_precision_column <- function(df) {
   box::use(
     calc = artma / calc / index,
-    artma / libs / core / utils[get_verbosity]
+    artma / libs / core / utils[get_verbosity],
+    artma / options / typed_accessors[get_precision_type, get_winsorization_level]
   )
 
-  winsorization_level <- getOption("artma.data.winsorization_level", default = 0)
+  winsorization_level <- get_winsorization_level()
   winsorization_active <- !is.null(winsorization_level) &&
     !is.na(winsorization_level) && winsorization_level != 0
 
@@ -238,7 +239,7 @@ add_precision_column <- function(df) {
     }
   } else {
     # Calculate precision based on option
-    precision_type <- getOption("artma.calc.precision_type", default = "1/SE")
+    precision_type <- get_precision_type()
     df$precision <- calc$precision(se = df$se, reg_dof = df$reg_dof)
 
     if (get_verbosity() >= 4) {

--- a/inst/artma/data/configure.R
+++ b/inst/artma/data/configure.R
@@ -16,6 +16,7 @@ resolve_na_handling <- function(df) {
     artma / libs / core / utils[get_verbosity],
     artma / data / na_handling[detect_missing_values],
     artma / options / prompts[prompt_na_handling],
+    artma / options / typed_accessors[NA_HANDLING_DEFAULT],
     artma / interactive / save_preference[prompt_save_preference]
   )
 
@@ -55,7 +56,7 @@ resolve_na_handling <- function(df) {
     if (get_verbosity() >= 2) {
       cli::cli_warn("Running in non-interactive mode with missing values. Defaulting to 'stop' strategy.")
     }
-    options(artma.data.na_handling = "stop")
+    options(artma.data.na_handling = NA_HANDLING_DEFAULT)
   }
 
   invisible(NULL)
@@ -79,6 +80,7 @@ resolve_se_zero_handling <- function(df) {
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / autonomy[should_prompt_user],
     artma / options / prompts[prompt_se_zero_handling],
+    artma / options / typed_accessors[SE_ZERO_HANDLING_DEFAULT],
     artma / interactive / save_preference[prompt_save_preference]
   )
 
@@ -124,7 +126,7 @@ resolve_se_zero_handling <- function(df) {
         "i" = "Defaulting to the {.val remove} strategy. Set {.field artma.calc.se_zero_handling} to {.val stop} for stricter validation."
       ))
     }
-    options(artma.calc.se_zero_handling = "remove")
+    options(artma.calc.se_zero_handling = SE_ZERO_HANDLING_DEFAULT)
   }
 
   invisible(NULL)

--- a/inst/artma/data/na_handling.R
+++ b/inst/artma/data/na_handling.R
@@ -392,14 +392,14 @@ handle_na_mice <- function(df) {
 handle_missing_values <- function(df) {
   box::use(
     artma / const[CONST],
-    artma / libs / core / utils[opt_or]
+    artma / options / typed_accessors[get_na_handling]
   )
 
   # Detect missing values
   na_summary <- detect_missing_values(df)
 
   # Get the handling strategy
-  na_handling <- opt_or("artma.data.na_handling", "stop")
+  na_handling <- get_na_handling()
 
   non_numeric_required_with_na <- character(0)
   numeric_required_with_na <- character(0)

--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -104,15 +104,18 @@ enforce_data_types <- function(df) {
 #' @return *\[data.frame\]* The data frame with the invalid values enforced
 #' @keywords internal
 enforce_correct_values <- function(df) {
-  box::use(artma / libs / core / utils[get_verbosity, opt_or])
+  box::use(artma / libs / core / utils[get_verbosity])
 
   if (get_verbosity() >= 4) {
     cli::cli_inform("Checking for invalid values...")
   }
 
-  box::use(artma / libs / core / validation[assert])
+  box::use(
+    artma / libs / core / validation[assert],
+    artma / options / typed_accessors[get_se_zero_handling]
+  )
 
-  se_zero_handling <- opt_or("artma.calc.se_zero_handling", "remove")
+  se_zero_handling <- get_se_zero_handling()
 
   zero_se_rows <- which(df$se == 0)
 
@@ -210,9 +213,12 @@ apply_subset_conditions <- function(df) {
 #' @return *\[data.frame\]* The data frame with winsorized values
 #' @keywords internal
 winsorize_data <- function(df) {
-  box::use(artma / libs / core / utils[get_verbosity])
+  box::use(
+    artma / libs / core / utils[get_verbosity],
+    artma / options / typed_accessors[get_winsorization_level]
+  )
 
-  winsorization_level <- getOption("artma.data.winsorization_level", default = 0)
+  winsorization_level <- get_winsorization_level()
 
   # Skip if winsorization is disabled
   if (is.null(winsorization_level) || is.na(winsorization_level) || winsorization_level == 0) {

--- a/inst/artma/options/typed_accessors.R
+++ b/inst/artma/options/typed_accessors.R
@@ -1,0 +1,146 @@
+#' @title Typed option accessors with template-sourced defaults
+#' @description Single home for the option defaults that runtime code used to
+#'   re-hardcode inline. Two concerns live here:
+#'
+#'   1. `option_template_default()` reads the default straight from the parsed
+#'      options template and coerces it through the B4 type registry, so a
+#'      template edit cannot silently drift from the value runtime code falls back
+#'      to. The template is parsed once (via the memoised `read_template`) and the
+#'      flattened definition map is cached in a module-level environment, so no
+#'      option access re-reads the YAML.
+#'
+#'   2. The typed accessors (`get_precision_type()`, `get_winsorization_level()`,
+#'      `get_na_handling()`, `get_se_zero_handling()`) each mirror the exact
+#'      `getOption`/`opt_or` call their former inline call sites used, so the
+#'      migration is behavior-preserving.
+#'
+#'   `precision_type` sources its fallback from the template (its template default
+#'   equals the value that was inlined). `na_handling` and `se_zero_handling`
+#'   declare a `.na` template sentinel (`allow_na`): the template deliberately
+#'   carries no concrete default, and the documented runtime strategy is resolved
+#'   at read time. Those runtime defaults live in one place here so the compute
+#'   readers and the configure-phase setters cannot drift. `winsorization_level`
+#'   keeps the compute-layer "unset means disabled" default of `0`, which is a
+#'   distinct contract from the template's load-time default of `0.01`; it is
+#'   centralized here rather than duplicated across the two readers.
+
+box::use(
+  artma / options / template[flatten_template_options, read_template],
+  artma / options / type_registry[get_option_type_spec],
+  artma / libs / core / utils[opt_or],
+  artma / paths[PATHS]
+)
+
+# Runtime resolution of the `.na` template sentinel. The template declares no
+# concrete default for these options (they are `allow_na`), so the compute phase
+# falls back to the documented strategy. Kept here so na_handling.R,
+# preprocess.R, and configure.R all reference one value.
+NA_HANDLING_DEFAULT <- "stop"
+SE_ZERO_HANDLING_DEFAULT <- "remove"
+
+# Compute-layer "winsorization disabled" default. Distinct from the template's
+# load-time default (0.01): an option that was never loaded means "do not
+# winsorize", which is what both compute readers assume.
+WINSORIZATION_DISABLED_LEVEL <- 0
+
+# Cache of option-name -> definition, keyed by template path and mtime so an
+# on-disk template change invalidates it. Avoids re-flattening on every access;
+# the YAML read itself is already memoised in `read_template`.
+.defs_cache <- new.env(parent = emptyenv()) # nolint: object_name_linter.
+
+.option_defs_by_name <- function(template_path) { # nolint: object_name_linter.
+  mtime <- as.numeric(file.mtime(template_path))
+  key <- paste0(template_path, "@", mtime)
+  cached <- .defs_cache[[key]]
+  if (!is.null(cached)) {
+    return(cached)
+  }
+  defs <- flatten_template_options(read_template(template_path))
+  by_name <- list()
+  for (def in defs) {
+    by_name[[def$name]] <- def
+  }
+  .defs_cache[[key]] <- by_name
+  by_name
+}
+
+# Strip the `artma.` namespace prefix to reach the template leaf name.
+.leaf_name <- function(name) sub("^artma\\.", "", name) # nolint: object_name_linter.
+
+#' @title Read an option's template-declared default
+#' @description Return the default declared for `name` in the options template,
+#'   coerced through the B4 type registry. A `.na` sentinel default (`allow_na`)
+#'   is returned as `NA`; an option with no declared default returns `NULL`.
+#' @param name *\[character\]* Full option name, e.g. `"artma.calc.precision_type"`.
+#' @param template_path *\[character, optional\]* Path to the template YAML file.
+#'   Defaults to the packaged template.
+#' @return The coerced template default, or `NA`/`NULL` for sentinel/undeclared
+#'   defaults.
+#' @keywords internal
+option_template_default <- function(name, template_path = PATHS$FILE_OPTIONS_TEMPLATE) {
+  defs <- .option_defs_by_name(template_path)
+  opt <- defs[[.leaf_name(name)]]
+  if (is.null(opt)) {
+    cli::cli_abort("No template definition found for option {.field {name}}.")
+  }
+
+  raw_default <- opt$default
+  if (is.null(raw_default)) {
+    return(if (isTRUE(opt$allow_na)) NA else NULL)
+  }
+
+  spec <- get_option_type_spec(opt$type)
+  na_allowed <- isTRUE(opt$allow_na) && isTRUE(spec$allows_na)
+  if (length(raw_default) == 1L && is.na(raw_default) && na_allowed) {
+    return(raw_default)
+  }
+
+  spec$coerce(raw_default, opt)
+}
+
+#' @title Precision type accessor
+#' @description The precision definition used when deriving a precision column.
+#'   Falls back to the template-declared default when unset.
+#' @return *\[character\]* The precision type.
+#' @keywords internal
+get_precision_type <- function() {
+  getOption("artma.calc.precision_type", option_template_default("artma.calc.precision_type"))
+}
+
+#' @title Winsorization level accessor
+#' @description The winsorization level applied to effect and standard error
+#'   columns. Returns the compute-layer disabled default (`0`) when unset.
+#' @return *\[numeric\]* The winsorization level.
+#' @keywords internal
+get_winsorization_level <- function() {
+  getOption("artma.data.winsorization_level", default = WINSORIZATION_DISABLED_LEVEL)
+}
+
+#' @title Missing-value handling strategy accessor
+#' @description The strategy for handling missing values in the compute phase.
+#'   Resolves the `.na` template sentinel to the documented `"stop"` default.
+#' @return *\[character\]* The missing-value handling strategy.
+#' @keywords internal
+get_na_handling <- function() {
+  opt_or("artma.data.na_handling", NA_HANDLING_DEFAULT)
+}
+
+#' @title Zero-standard-error handling strategy accessor
+#' @description The strategy for handling zero standard errors in the compute
+#'   phase. Resolves the `.na` template sentinel to the documented `"remove"`
+#'   default.
+#' @return *\[character\]* The zero-standard-error handling strategy.
+#' @keywords internal
+get_se_zero_handling <- function() {
+  opt_or("artma.calc.se_zero_handling", SE_ZERO_HANDLING_DEFAULT)
+}
+
+box::export(
+  option_template_default,
+  get_precision_type,
+  get_winsorization_level,
+  get_na_handling,
+  get_se_zero_handling,
+  NA_HANDLING_DEFAULT,
+  SE_ZERO_HANDLING_DEFAULT
+)

--- a/tests/testthat/test-options-typed-accessors.R
+++ b/tests/testthat/test-options-typed-accessors.R
@@ -1,0 +1,86 @@
+box::use(
+  testthat[expect_equal, expect_true, expect_null, test_that],
+  artma / options / typed_accessors[
+    option_template_default,
+    get_precision_type,
+    get_winsorization_level,
+    get_na_handling,
+    get_se_zero_handling
+  ]
+)
+
+# option_template_default reads the real packaged template, so these pin the
+# accessors to whatever the template declares. If a template default changes,
+# the runtime fallback follows automatically instead of drifting.
+
+test_that("option_template_default sources concrete defaults from the template", {
+  expect_equal(option_template_default("artma.calc.precision_type"), "1/SE")
+  expect_equal(option_template_default("artma.data.winsorization_level"), 0.01)
+})
+
+test_that("option_template_default returns NA for allow_na sentinel defaults", {
+  expect_true(is.na(option_template_default("artma.data.na_handling")))
+  expect_true(is.na(option_template_default("artma.calc.se_zero_handling")))
+})
+
+test_that("option_template_default coerces via the type registry", {
+  # numeric option arrives coerced to double, not left as a raw YAML scalar.
+  expect_true(is.numeric(option_template_default("artma.data.winsorization_level")))
+})
+
+test_that("get_precision_type returns the template default when unset", {
+  withr::local_options(list("artma.calc.precision_type" = NULL))
+  expect_equal(get_precision_type(), "1/SE")
+})
+
+test_that("get_precision_type returns the set value when present", {
+  withr::local_options(list("artma.calc.precision_type" = "DoF"))
+  expect_equal(get_precision_type(), "DoF")
+})
+
+test_that("get_winsorization_level returns the disabled default when unset", {
+  withr::local_options(list("artma.data.winsorization_level" = NULL))
+  expect_equal(get_winsorization_level(), 0)
+})
+
+test_that("get_winsorization_level returns the set value when present", {
+  withr::local_options(list("artma.data.winsorization_level" = 0.05))
+  expect_equal(get_winsorization_level(), 0.05)
+})
+
+test_that("get_na_handling returns the documented default when unset", {
+  withr::local_options(list("artma.data.na_handling" = NULL))
+  expect_equal(get_na_handling(), "stop")
+})
+
+test_that("get_na_handling treats the NA sentinel as unset", {
+  withr::local_options(list("artma.data.na_handling" = NA))
+  expect_equal(get_na_handling(), "stop")
+})
+
+test_that("get_na_handling returns the set value when present", {
+  withr::local_options(list("artma.data.na_handling" = "remove"))
+  expect_equal(get_na_handling(), "remove")
+})
+
+test_that("get_se_zero_handling returns the documented default when unset", {
+  withr::local_options(list("artma.calc.se_zero_handling" = NULL))
+  expect_equal(get_se_zero_handling(), "remove")
+})
+
+test_that("get_se_zero_handling treats the NA sentinel as unset", {
+  withr::local_options(list("artma.calc.se_zero_handling" = NA))
+  expect_equal(get_se_zero_handling(), "remove")
+})
+
+test_that("get_se_zero_handling returns the set value when present", {
+  withr::local_options(list("artma.calc.se_zero_handling" = "ignore"))
+  expect_equal(get_se_zero_handling(), "ignore")
+})
+
+test_that("option_template_default aborts for an unknown option", {
+  testthat::expect_error(
+    option_template_default("artma.does.not.exist"),
+    "No template definition"
+  )
+})


### PR DESCRIPTION
## What moved

New module `inst/artma/options/typed_accessors.R` is the single home for the option defaults that runtime code previously re-hardcoded inline. It exposes:

- `option_template_default(name)`: reads a default straight from the parsed options template and coerces it through the B4 type registry (`options/type_registry.R`). The template is parsed once via the memoised `read_template`, and the flattened definition map is cached in a module-level environment, so no option access re-reads the YAML.
- Typed accessors: `get_precision_type()`, `get_winsorization_level()`, `get_na_handling()`, `get_se_zero_handling()`.

Migrated readers (each accessor mirrors the exact `getOption`/`opt_or` call it replaced):

- `precision_type`: `inst/artma/calc/meta.R`, `inst/artma/data/compute.R`.
- `winsorization_level`: `inst/artma/data/preprocess.R`, `inst/artma/data/compute.R`.
- `na_handling`: `inst/artma/data/na_handling.R`.
- `se_zero_handling`: `inst/artma/data/preprocess.R`.

De-duplicated the configure-phase setters: `inst/artma/data/configure.R` now references the exported `NA_HANDLING_DEFAULT` / `SE_ZERO_HANDLING_DEFAULT` constants instead of re-typing `"stop"` / `"remove"`, so the compute readers and the configure setters cannot drift.

## What changed behavior

Nothing. Every accessor returns the identical value its former inline call site returned.

Correcting the item's premise against the current code: only `precision_type` actually re-hardcodes its template default (`"1/SE"` in both), so it is the one truly template-sourced migration. The other three do NOT inline the template default:

- `na_handling` / `se_zero_handling` declare a `.na` template sentinel (`allow_na`): the template carries no concrete default, and the documented runtime strategy (`"stop"` / `"remove"`) is resolved at read time. Sourcing the literal `.na` here would change behavior (break `== "stop"`), so the runtime default lives once in the accessor module instead.
- `winsorization_level` keeps the compute-layer "unset means disabled" default of `0`, a distinct contract from the template's load-time default `0.01`. `test-data-compute.R` ("keeps a user-supplied precision column when winsorization is disabled") pins that `0` behavior, so it is centralized here rather than repointed at the template.

## Tests pinning the outputs

`tests/testthat/test-options-typed-accessors.R`: for each migrated option, asserts the accessor returns its default when the option is unset (and the NA sentinel too, for the `.na` options) and the set value when present, plus `option_template_default` returning the template values (`"1/SE"`, `0.01`, `NA`, `NA`) and coercing via the registry. Existing `test-data-compute.R`, `test-data-preprocess.R`, `test-data-na-handling.R`, `test-data-configure.R`, and `test-calc-meta.R` continue to pass unchanged.

Refs #322 (item C7).