### PR TITLE
refactor(options): declarative option-spec resolver for method files

### DIFF
--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -11,6 +11,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[export_named_plots]
   )
@@ -23,46 +24,46 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   }
 
   opt <- get_option_group("artma.methods.best_practice_estimate")
-  conf_level <- opt$conf_level %||% 0.95
-  include_intercept <- opt$include_intercept %||% TRUE
-  include_author_row <- opt$include_author_row %||% TRUE
-  include_study_rows <- opt$include_study_rows %||% TRUE
-  run_bma_if_missing <- opt$run_bma_if_missing %||% TRUE
-  include_economic_significance <- opt$include_economic_significance %||% TRUE
-  economic_significance_pip_threshold <- as.numeric(opt$economic_significance_pip_threshold %||% NA_real_)
-  include_factor_summary <- opt$include_factor_summary %||% TRUE
-  round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
 
-  validate(
-    is.numeric(conf_level),
-    length(conf_level) == 1,
-    is.logical(include_intercept),
-    length(include_intercept) == 1,
-    is.logical(include_author_row),
-    length(include_author_row) == 1,
-    is.logical(include_study_rows),
-    length(include_study_rows) == 1,
-    is.logical(run_bma_if_missing),
-    length(run_bma_if_missing) == 1,
-    is.logical(include_economic_significance),
-    length(include_economic_significance) == 1,
-    is.numeric(economic_significance_pip_threshold),
-    length(economic_significance_pip_threshold) == 1,
-    is.logical(include_factor_summary),
-    length(include_factor_summary) == 1,
-    is.numeric(round_to),
-    length(round_to) == 1
-  )
+  resolved <- resolve_options(opt, list(
+    conf_level = opt_spec(
+      default = 0.95, type = "numeric", scalar = TRUE,
+      constraint = function(x) x > 0 && x < 1,
+      constraint_msg = "conf_level must be between 0 and 1."
+    ),
+    include_intercept = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
+    include_author_row = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
+    include_study_rows = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
+    run_bma_if_missing = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
+    include_economic_significance = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
+    economic_significance_pip_threshold = opt_spec(
+      default = NA_real_, type = "numeric", allow_na = TRUE, scalar = TRUE,
+      cast = as.numeric,
+      constraint = function(x) x >= 0 && x <= 1,
+      constraint_msg = "economic_significance_pip_threshold must be between 0 and 1."
+    ),
+    include_factor_summary = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
+    round_to = opt_spec(
+      default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
+      cast = as.integer, scalar = TRUE
+    )
+  ))
 
-  assert(conf_level > 0 && conf_level < 1, "conf_level must be between 0 and 1.")
+  conf_level <- resolved$conf_level
+  include_intercept <- resolved$include_intercept
+  include_author_row <- resolved$include_author_row
+  include_study_rows <- resolved$include_study_rows
+  run_bma_if_missing <- resolved$run_bma_if_missing
+  include_economic_significance <- resolved$include_economic_significance
+  economic_significance_pip_threshold <- resolved$economic_significance_pip_threshold
+  include_factor_summary <- resolved$include_factor_summary
+  round_to <- resolved$round_to
+
+  # Cross-option constraint: at least one row scope must remain enabled. Kept
+  # outside the per-option resolver because it spans two options.
   assert(
     include_author_row || include_study_rows,
     "At least one of include_author_row or include_study_rows must be TRUE."
-  )
-  assert(
-    is.na(economic_significance_pip_threshold) ||
-      (economic_significance_pip_threshold >= 0 && economic_significance_pip_threshold <= 1),
-    "economic_significance_pip_threshold must be between 0 and 1."
   )
 
   resolved_bma <- resolve_bma_input_for_bpe(

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -17,9 +17,10 @@ bma <- function(df) {
       render_bma_comparison_plot
     ],
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options]
   )
 
@@ -34,41 +35,48 @@ bma <- function(df) {
   opt <- get_option_group("artma.methods.bma")
   vis <- get_visualization_options()
 
-  burn <- opt$burn %||% 10000L
-  iter <- opt$iter %||% 50000L
-  g <- opt$g %||% "UIP"
-  mprior <- opt$mprior %||% "uniform"
-  nmodel <- opt$nmodel %||% 1000L
-  mcmc <- opt$mcmc %||% "bd"
-  use_vif_optimization <- opt$use_vif_optimization %||% FALSE
-  max_groups_to_remove <- opt$max_groups_to_remove %||% 30L
-  verbose_output <- opt$verbose_output %||% FALSE
-  print_results <- opt$print_results %||% "fast"
+  resolved <- resolve_options(opt, list(
+    burn = opt_spec(
+      default = 10000L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "burn must be positive"
+    ),
+    iter = opt_spec(
+      default = 50000L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "iter must be positive"
+    ),
+    g = opt_spec(default = "UIP", type = "character"),
+    mprior = opt_spec(default = "uniform", type = "character"),
+    nmodel = opt_spec(
+      default = 1000L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "nmodel must be positive"
+    ),
+    mcmc = opt_spec(default = "bd", type = "character"),
+    use_vif_optimization = opt_spec(default = FALSE, type = "logical"),
+    max_groups_to_remove = opt_spec(
+      default = 30L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "max_groups_to_remove must be positive"
+    ),
+    verbose_output = opt_spec(default = FALSE, type = "logical"),
+    print_results = opt_spec(
+      default = "fast", type = "character",
+      constraint = function(x) x %in% c("none", "fast", "verbose", "all", "table"),
+      constraint_msg = "print_results must be one of: none, fast, verbose, all, table"
+    )
+  ))
+
+  burn <- resolved$burn
+  iter <- resolved$iter
+  g <- resolved$g
+  mprior <- resolved$mprior
+  nmodel <- resolved$nmodel
+  mcmc <- resolved$mcmc
+  use_vif_optimization <- resolved$use_vif_optimization
+  max_groups_to_remove <- resolved$max_groups_to_remove
+  verbose_output <- resolved$verbose_output
+  print_results <- resolved$print_results
   export_graphics <- vis$export_graphics
   export_path <- vis$export_path
   graph_scale <- vis$graph_scale
-
-  validate(
-    is.numeric(burn),
-    is.numeric(iter),
-    is.character(g),
-    is.character(mprior),
-    is.numeric(nmodel),
-    is.character(mcmc),
-    is.logical(use_vif_optimization),
-    is.numeric(max_groups_to_remove),
-    is.logical(verbose_output),
-    is.character(print_results)
-  )
-
-  assert(burn > 0, "burn must be positive")
-  assert(iter > 0, "iter must be positive")
-  assert(nmodel > 0, "nmodel must be positive")
-  assert(max_groups_to_remove > 0, "max_groups_to_remove must be positive")
-  assert(
-    print_results %in% c("none", "fast", "verbose", "all", "table"),
-    "print_results must be one of: none, fast, verbose, all, table"
-  )
 
   prepared <- prepare_bma_inputs(
     df = df,

--- a/inst/artma/methods/box_plot.R
+++ b/inst/artma/methods/box_plot.R
@@ -7,10 +7,11 @@ box_plot <- function(df) {
   box::use(
     artma / data_config / read[get_data_config],
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / libs / core / autonomy[should_prompt_user],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[export_named_plots]
   )
@@ -26,22 +27,25 @@ box_plot <- function(df) {
   opt <- get_option_group("artma.methods.box_plot")
   vis <- get_visualization_options()
 
-  factor_by <- opt$factor_by %||% NA_character_
-  max_per_plot <- opt$max_boxes_per_plot %||% 60L
+  resolved <- resolve_options(opt, list(
+    factor_by = opt_spec(default = NA_character_, type = "character", allow_na = TRUE),
+    max_per_plot = opt_spec(
+      default = 60L, type = "numeric", from = "max_boxes_per_plot",
+      constraint = function(x) x > 0,
+      constraint_msg = "max_boxes_per_plot must be positive"
+    ),
+    show_mean_line = opt_spec(default = TRUE, type = "logical"),
+    effect_label = opt_spec(default = "effect", type = "character")
+  ))
+
+  factor_by <- resolved$factor_by
+  max_per_plot <- resolved$max_per_plot
+  show_mean_line <- resolved$show_mean_line
+  effect_label <- resolved$effect_label
   theme_name <- vis$theme
-  show_mean_line <- opt$show_mean_line %||% TRUE
-  effect_label <- opt$effect_label %||% "effect"
   export_graphics <- vis$export_graphics
   export_path <- vis$export_path
   graph_scale <- vis$graph_scale
-
-  validate(
-    is.numeric(max_per_plot),
-    is.logical(show_mean_line),
-    is.character(effect_label)
-  )
-
-  assert(max_per_plot > 0, "max_boxes_per_plot must be positive")
 
   factor_by <- resolve_factor_by(df, config, factor_by)
 

--- a/inst/artma/methods/effect_summary_stats.R
+++ b/inst/artma/methods/effect_summary_stats.R
@@ -15,9 +15,10 @@ effect_summary_stats <- function(df) {
       resolve_variable_groups
     ],
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
-    artma / options / index[get_option_group]
+    artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options]
   )
 
   validate(is.data.frame(df))
@@ -29,20 +30,24 @@ effect_summary_stats <- function(df) {
 
   config <- get_data_config()
   opt <- get_option_group("artma.methods.effect_summary_stats")
-  conf_level <- opt$conf_level %||% 0.95
-  formal_output <- opt$formal_output %||% FALSE
-  round_to <- getOption("artma.output.number_of_decimals", 3)
 
-  validate(
-    length(conf_level) == 1,
-    is.numeric(conf_level),
-    length(formal_output) == 1,
-    is.logical(formal_output),
-    is.numeric(round_to)
-  )
+  resolved <- resolve_options(opt, list(
+    conf_level = opt_spec(
+      default = 0.95, type = "numeric", scalar = TRUE,
+      constraint = function(x) x >= 0 && x <= 1,
+      constraint_msg = "Confidence level must be between 0 and 1."
+    ),
+    formal_output = opt_spec(default = FALSE, type = "logical", scalar = TRUE),
+    round_to = opt_spec(
+      default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
+      constraint = function(x) x >= 0,
+      constraint_msg = "Number of decimals must be greater than or equal to 0."
+    )
+  ))
 
-  assert(conf_level >= 0 && conf_level <= 1, "Confidence level must be between 0 and 1.")
-  assert(round_to >= 0, "Number of decimals must be greater than or equal to 0.")
+  conf_level <- resolved$conf_level
+  formal_output <- resolved$formal_output
+  round_to <- resolved$round_to
 
   z_value <- stats::qnorm((1 - conf_level) / 2, lower.tail = FALSE)
 

--- a/inst/artma/methods/exogeneity_tests.R
+++ b/inst/artma/methods/exogeneity_tests.R
@@ -5,12 +5,13 @@
 #' The function returns both detailed coefficients and a publication-ready summary table.
 exogeneity_tests <- function(df) {
   box::use(
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
     artma / libs / formatting / results[print_summary_table],
     artma / econometric / exogeneity[run_exogeneity_tests],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
 
@@ -19,29 +20,23 @@ exogeneity_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.exogeneity_tests")
 
-  add_marks <- resolve_add_significance_marks()
-  iv_instrument <- opt$iv_instrument %||% "automatic"
-  puniform_alpha <- opt$puniform_alpha %||% 0.05
-  puniform_method <- opt$puniform_method %||% "ML"
-  round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
-
-  validate(
-    is.logical(add_marks),
-    is.character(iv_instrument),
-    is.numeric(puniform_alpha),
-    is.character(puniform_method),
-    is.numeric(round_to)
-  )
-
-  assert(puniform_alpha > 0 && puniform_alpha < 1, "puniform_alpha must lie in the (0, 1) interval.")
-  assert(round_to >= 0, "Number of decimals must be non-negative.")
-
-  resolved_options <- list(
-    add_significance_marks = add_marks,
-    iv_instrument = iv_instrument,
-    puniform_alpha = puniform_alpha,
-    puniform_method = puniform_method,
-    round_to = round_to
+  resolved_options <- c(
+    list(add_significance_marks = resolve_add_significance_marks()),
+    resolve_options(opt, list(
+      iv_instrument = opt_spec(default = "automatic", type = "character"),
+      puniform_alpha = opt_spec(
+        default = 0.05, type = "numeric",
+        constraint = function(x) x > 0 && x < 1,
+        constraint_msg = "puniform_alpha must lie in the (0, 1) interval."
+      ),
+      puniform_method = opt_spec(default = "ML", type = "character"),
+      round_to = opt_spec(
+        default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
+        cast = as.integer,
+        constraint = function(x) x >= 0,
+        constraint_msg = "Number of decimals must be non-negative."
+      )
+    ))
   )
 
   results <- run_exogeneity_tests(df, resolved_options)

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -8,10 +8,11 @@ fma <- function(df, bma_result = NULL) {
     artma / econometric / bma[handle_bma_params, run_bma],
     artma / econometric / fma[run_fma],
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / methods / bma[prepare_bma_inputs, unwrap_bma_result],
     artma / modules / runtime_methods[new_method_result],
-    artma / options / index[get_option_group]
+    artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options]
   )
 
   validate(is.data.frame(df))
@@ -25,43 +26,42 @@ fma <- function(df, bma_result = NULL) {
   fma_opt <- get_option_group("artma.methods.fma")
   bma_opt <- get_option_group("artma.methods.bma")
 
-  verbose_output <- fma_opt$verbose_output %||% FALSE
-  print_results <- fma_opt$print_results %||% "fast"
-  round_to <- fma_opt$round_to %||% NA_integer_
+  fma_resolved <- resolve_options(fma_opt, list(
+    verbose_output = opt_spec(default = FALSE, type = "logical"),
+    print_results = opt_spec(
+      default = "fast", type = "character",
+      constraint = function(x) x %in% c("none", "fast", "verbose", "all"),
+      constraint_msg = "print_results must be one of: none, fast, verbose, all"
+    ),
+    round_to = opt_spec(default = NA_integer_, type = "numeric", allow_na = TRUE)
+  ))
 
-  validate(
-    is.logical(verbose_output),
-    is.character(print_results),
-    is.numeric(round_to) || is.na(round_to)
-  )
-
-  assert(
-    print_results %in% c("none", "fast", "verbose", "all"),
-    "print_results must be one of: none, fast, verbose, all"
-  )
+  verbose_output <- fma_resolved$verbose_output
+  print_results <- fma_resolved$print_results
+  round_to <- fma_resolved$round_to
 
   # Suppress individual FMA text output unless verbose_output is enabled
   effective_print <- if (verbose_output) print_results else "none"
 
-  burn <- bma_opt$burn %||% 10000L
-  iter <- bma_opt$iter %||% 50000L
-  g <- bma_opt$g %||% "UIP"
-  mprior <- bma_opt$mprior %||% "uniform"
-  nmodel <- bma_opt$nmodel %||% 1000L
-  mcmc <- bma_opt$mcmc %||% "bd"
-  use_vif_optimization <- bma_opt$use_vif_optimization %||% FALSE
-  max_groups_to_remove <- bma_opt$max_groups_to_remove %||% 30L
+  bma_resolved <- resolve_options(bma_opt, list(
+    burn = opt_spec(default = 10000L, type = "numeric"),
+    iter = opt_spec(default = 50000L, type = "numeric"),
+    g = opt_spec(default = "UIP", type = "character"),
+    mprior = opt_spec(default = "uniform", type = "character"),
+    nmodel = opt_spec(default = 1000L, type = "numeric"),
+    mcmc = opt_spec(default = "bd", type = "character"),
+    use_vif_optimization = opt_spec(default = FALSE, type = "logical"),
+    max_groups_to_remove = opt_spec(default = 30L, type = "numeric")
+  ))
 
-  validate(
-    is.numeric(burn),
-    is.numeric(iter),
-    is.character(g),
-    is.character(mprior),
-    is.numeric(nmodel),
-    is.character(mcmc),
-    is.logical(use_vif_optimization),
-    is.numeric(max_groups_to_remove)
-  )
+  burn <- bma_resolved$burn
+  iter <- bma_resolved$iter
+  g <- bma_resolved$g
+  mprior <- bma_resolved$mprior
+  nmodel <- bma_resolved$nmodel
+  mcmc <- bma_resolved$mcmc
+  use_vif_optimization <- bma_resolved$use_vif_optimization
+  max_groups_to_remove <- bma_resolved$max_groups_to_remove
 
   bma_params_list <- list(
     burn = as.integer(burn),

--- a/inst/artma/methods/funnel_plot.R
+++ b/inst/artma/methods/funnel_plot.R
@@ -6,9 +6,10 @@
 funnel_plot <- function(df) {
   box::use(
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[export_named_plots]
   )
@@ -23,32 +24,31 @@ funnel_plot <- function(df) {
   opt <- get_option_group("artma.methods.funnel_plot")
   vis <- get_visualization_options()
 
-  effect_proximity <- opt$effect_proximity %||% 0.2
-  maximum_precision <- opt$maximum_precision %||% 0.2
-  precision_to_log <- opt$precision_to_log %||% FALSE
-  use_study_medians <- opt$use_study_medians %||% FALSE
-  add_zero <- opt$add_zero %||% TRUE
+  resolved <- resolve_options(opt, list(
+    effect_proximity = opt_spec(
+      default = 0.2, type = "numeric",
+      constraint = function(x) x >= 0 && x <= 1,
+      constraint_msg = "effect_proximity must be between 0 and 1"
+    ),
+    maximum_precision = opt_spec(
+      default = 0.2, type = "numeric",
+      constraint = function(x) x >= 0 && x <= 1,
+      constraint_msg = "maximum_precision must be between 0 and 1"
+    ),
+    precision_to_log = opt_spec(default = FALSE, type = "logical"),
+    use_study_medians = opt_spec(default = FALSE, type = "logical"),
+    add_zero = opt_spec(default = TRUE, type = "logical")
+  ))
+
+  effect_proximity <- resolved$effect_proximity
+  maximum_precision <- resolved$maximum_precision
+  precision_to_log <- resolved$precision_to_log
+  use_study_medians <- resolved$use_study_medians
+  add_zero <- resolved$add_zero
   theme_name <- vis$theme
   export_graphics <- vis$export_graphics
   export_path <- vis$export_path
   graph_scale <- vis$graph_scale
-
-  validate(
-    is.numeric(effect_proximity),
-    is.numeric(maximum_precision),
-    is.logical(precision_to_log),
-    is.logical(use_study_medians),
-    is.logical(add_zero)
-  )
-
-  assert(
-    effect_proximity >= 0 && effect_proximity <= 1,
-    "effect_proximity must be between 0 and 1"
-  )
-  assert(
-    maximum_precision >= 0 && maximum_precision <= 1,
-    "maximum_precision must be between 0 and 1"
-  )
 
   if (use_study_medians) {
     validate_columns(df, c("study_id"))

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -5,43 +5,19 @@
 #' coefficient estimates and a publication-ready summary table.
 linear_tests <- function(df) {
   box::use(
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
     artma / libs / formatting / results[print_summary_table],
     artma / econometric / linear[run_linear_models],
-    artma / modules / runtime_methods[new_method_result],
-    artma / options / index[get_option_group],
-    artma / options / significance_marks[resolve_add_significance_marks]
+    artma / modules / runtime_methods[new_method_result]
   )
 
   validate(is.data.frame(df))
   validate_columns(df, c("effect", "se", "study_id"))
 
-  opt <- get_option_group("artma.methods.linear_tests")
-
-  add_marks <- resolve_add_significance_marks()
-  bootstrap_replications <- opt$bootstrap_replications %||% 999L
-  conf_level <- opt$conf_level %||% 0.95
-  round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
-
-  validate(
-    is.logical(add_marks),
-    is.numeric(bootstrap_replications),
-    is.numeric(conf_level),
-    is.numeric(round_to)
-  )
-
-  bootstrap_replications <- as.integer(bootstrap_replications)
-  assert(bootstrap_replications >= 0, "Bootstrap replications must be greater than or equal to 0.")
-  assert(conf_level > 0 && conf_level < 1, "Confidence level must lie in the (0, 1) interval.")
-  assert(round_to >= 0, "Number of decimals must be non-negative.")
-
-  resolved_options <- list(
-    add_significance_marks = add_marks,
-    bootstrap_replications = bootstrap_replications,
-    conf_level = conf_level,
-    round_to = round_to
-  )
+  resolved_options <- resolve_linear_tests_options()
+  bootstrap_replications <- resolved_options$bootstrap_replications
+  conf_level <- resolved_options$conf_level
 
   verbosity <- get_verbosity()
 
@@ -100,6 +76,43 @@ linear_tests <- function(df) {
   ))
 }
 
+#' @title Resolve the linear_tests options
+#' @description Read and validate the option group for `linear_tests` through
+#'   the declarative option-spec resolver, returning the `resolved_options` list
+#'   the method passes to `run_linear_models`. Exposed as its own function so a
+#'   characterization test can pin the resolved values.
+#' @return *\[list\]* The resolved options.
+resolve_linear_tests_options <- function() {
+  box::use(
+    artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
+    artma / options / significance_marks[resolve_add_significance_marks]
+  )
+
+  opt <- get_option_group("artma.methods.linear_tests")
+
+  resolved <- resolve_options(opt, list(
+    bootstrap_replications = opt_spec(
+      default = 999L, type = "numeric", cast = as.integer,
+      constraint = function(x) x >= 0,
+      constraint_msg = "Bootstrap replications must be greater than or equal to 0."
+    ),
+    conf_level = opt_spec(
+      default = 0.95, type = "numeric",
+      constraint = function(x) x > 0 && x < 1,
+      constraint_msg = "Confidence level must lie in the (0, 1) interval."
+    ),
+    round_to = opt_spec(
+      default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
+      cast = as.integer,
+      constraint = function(x) x >= 0,
+      constraint_msg = "Number of decimals must be non-negative."
+    )
+  ))
+
+  c(list(add_significance_marks = resolve_add_significance_marks()), resolved)
+}
+
 box::use(
   artma / modules / runtime_methods[register_runtime_method]
 )
@@ -110,4 +123,4 @@ run <- register_runtime_method(
   required_columns = c("effect", "se", "study_id")
 )
 
-box::export(linear_tests, run)
+box::export(linear_tests, resolve_linear_tests_options, run)

--- a/inst/artma/methods/maive.R
+++ b/inst/artma/methods/maive.R
@@ -59,9 +59,6 @@ maive_estimator <- function(df) {
       constraint_msg = "maive first_stage must be 0, 1, or 2"
     ),
     seed = opt_spec(default = 123L, type = "numeric", cast = as.integer),
-    add_significance_marks = opt_spec(
-      default = TRUE, type = "logical", key = "artma.methods.add_significance_marks"
-    ),
     round_to = opt_spec(
       default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
       cast = as.integer,
@@ -69,6 +66,7 @@ maive_estimator <- function(df) {
       constraint_msg = "Number of decimals must be non-negative"
     )
   ))
+  resolved_options$add_significance_marks <- resolve_add_significance_marks()
 
   # show_interpretation drives display only and is not part of resolved_options
   # (which is echoed into the method result meta), so it is resolved separately.

--- a/inst/artma/methods/maive.R
+++ b/inst/artma/methods/maive.R
@@ -7,12 +7,13 @@
 #' model (PET, PEESE, PET-PEESE, or the endogenous kink).
 maive_estimator <- function(df) {
   box::use(
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
     artma / libs / formatting / results[print_sectioned_table, print_paragraph],
     artma / econometric / maive[maive_first_stage_f, maive_first_stage_is_weak, run_maive],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
 
@@ -21,54 +22,63 @@ maive_estimator <- function(df) {
 
   opt <- get_option_group("artma.methods.maive")
 
-  method <- opt$method %||% 3L
-  weight <- opt$weight %||% 0L
-  instrument <- opt$instrument %||% 1L
-  studylevel <- opt$studylevel %||% 2L
-  se <- opt$se %||% 1L
-  ar <- opt$ar %||% 0L
-  first_stage <- opt$first_stage %||% 0L
-  seed <- opt$seed %||% 123L
-  show_interpretation <- opt$show_interpretation %||% TRUE
+  resolved_options <- resolve_options(opt, list(
+    method = opt_spec(
+      default = 3L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(1, 2, 3, 4),
+      constraint_msg = "maive method must be 1, 2, 3, or 4"
+    ),
+    weight = opt_spec(
+      default = 0L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(0, 1, 2),
+      constraint_msg = "maive weight must be 0, 1, or 2"
+    ),
+    instrument = opt_spec(
+      default = 1L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(0, 1),
+      constraint_msg = "maive instrument must be 0 or 1"
+    ),
+    studylevel = opt_spec(
+      default = 2L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(0, 1, 2),
+      constraint_msg = "maive studylevel must be 0, 1, or 2"
+    ),
+    se = opt_spec(
+      default = 1L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(1, 2, 3, 4, 5),
+      constraint_msg = "maive se must be 1, 2, 3, 4, or 5"
+    ),
+    ar = opt_spec(
+      default = 0L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(0, 1),
+      constraint_msg = "maive ar must be 0 or 1"
+    ),
+    first_stage = opt_spec(
+      default = 0L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(0, 1, 2),
+      constraint_msg = "maive first_stage must be 0, 1, or 2"
+    ),
+    seed = opt_spec(default = 123L, type = "numeric", cast = as.integer),
+    add_significance_marks = opt_spec(
+      default = TRUE, type = "logical", key = "artma.methods.add_significance_marks"
+    ),
+    round_to = opt_spec(
+      default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
+      cast = as.integer,
+      constraint = function(x) x >= 0,
+      constraint_msg = "Number of decimals must be non-negative"
+    )
+  ))
 
-  add_significance_marks <- resolve_add_significance_marks()
-  round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
+  # show_interpretation drives display only and is not part of resolved_options
+  # (which is echoed into the method result meta), so it is resolved separately.
+  show_interpretation <- resolve_options(opt, list(
+    show_interpretation = opt_spec(default = TRUE, type = "logical")
+  ))$show_interpretation
 
-  validate(
-    is.numeric(method),
-    is.numeric(weight),
-    is.numeric(instrument),
-    is.numeric(studylevel),
-    is.numeric(se),
-    is.numeric(ar),
-    is.numeric(first_stage),
-    is.numeric(seed),
-    is.logical(show_interpretation),
-    is.logical(add_significance_marks),
-    is.numeric(round_to)
-  )
-
-  assert(method %in% c(1, 2, 3, 4), "maive method must be 1, 2, 3, or 4")
-  assert(weight %in% c(0, 1, 2), "maive weight must be 0, 1, or 2")
-  assert(instrument %in% c(0, 1), "maive instrument must be 0 or 1")
-  assert(studylevel %in% c(0, 1, 2), "maive studylevel must be 0, 1, or 2")
-  assert(se %in% c(1, 2, 3, 4, 5), "maive se must be 1, 2, 3, 4, or 5")
-  assert(ar %in% c(0, 1), "maive ar must be 0 or 1")
-  assert(first_stage %in% c(0, 1, 2), "maive first_stage must be 0, 1, or 2")
-  assert(round_to >= 0, "Number of decimals must be non-negative")
-
-  resolved_options <- list(
-    method = as.integer(method),
-    weight = as.integer(weight),
-    instrument = as.integer(instrument),
-    studylevel = as.integer(studylevel),
-    se = as.integer(se),
-    ar = as.integer(ar),
-    first_stage = as.integer(first_stage),
-    seed = as.integer(seed),
-    add_significance_marks = add_significance_marks,
-    round_to = round_to
-  )
+  method <- resolved_options$method
+  instrument <- resolved_options$instrument
+  add_significance_marks <- resolved_options$add_significance_marks
 
   result <- run_maive(df, resolved_options)
 

--- a/inst/artma/methods/nonlinear_tests.R
+++ b/inst/artma/methods/nonlinear_tests.R
@@ -8,6 +8,7 @@ nonlinear_tests <- function(df) {
     artma / econometric / nonlinear[run_nonlinear_methods],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
 
@@ -16,47 +17,41 @@ nonlinear_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.nonlinear_tests")
 
-  add_marks <- resolve_add_significance_marks()
+  # round_to has a bespoke default: the method's own (NA) option falls back to
+  # the global output decimals rather than a fixed literal, so it is resolved
+  # before the spec-driven block.
   round_to_opt <- opt$round_to
   if (length(round_to_opt) == 1 && is.na(round_to_opt)) {
     round_to_opt <- NULL
   }
-  round_to <- round_to_opt %||% as.integer(getOption("artma.output.number_of_decimals", 3))
-  stem_sample <- opt$stem_representative_sample %||% "medians"
-  selection_cutoffs <- opt$selection_cutoffs %||% c(1.96)
-  selection_symmetric <- opt$selection_symmetric %||% FALSE
-  selection_model <- opt$selection_model %||% "normal"
-  hierarchical_iterations <- opt$hierarchical_iterations %||% 6000L
-
-  validate(
-    is.logical(add_marks),
-    is.numeric(round_to),
-    is.character(stem_sample),
-    is.numeric(selection_cutoffs),
-    is.logical(selection_symmetric),
-    is.character(selection_model),
-    is.numeric(hierarchical_iterations)
-  )
-
-  round_to <- as.integer(round_to)
-  hierarchical_iterations <- as.integer(hierarchical_iterations)
-
+  round_to <- as.integer(round_to_opt %||% getOption("artma.output.number_of_decimals", 3))
   assert(round_to >= 0, "Number of decimals must be non-negative.")
-  assert(length(selection_cutoffs) > 0, "Selection model requires at least one cutoff value.")
-  assert(all(selection_cutoffs > 0), "Selection cutoffs must be positive.")
-  assert(selection_model %in% c("normal", "t"), "Selection model must be either 'normal' or 't'.")
-  assert(hierarchical_iterations > 0, "Hierarchical iterations must be positive.")
-  assert(stem_sample %in% c("medians", "first", "all"), "Invalid STEM representative sample option.")
 
-  resolved_options <- list(
-    add_significance_marks = add_marks,
-    round_to = round_to,
-    stem_representative_sample = stem_sample,
-    selection_cutoffs = selection_cutoffs,
-    selection_symmetric = selection_symmetric,
-    selection_model = selection_model,
-    hierarchical_iterations = hierarchical_iterations
+  resolved_options <- c(
+    list(add_significance_marks = resolve_add_significance_marks(), round_to = round_to),
+    resolve_options(opt, list(
+      stem_representative_sample = opt_spec(
+        default = "medians", type = "character",
+        constraint = function(x) x %in% c("medians", "first", "all"),
+        constraint_msg = "Invalid STEM representative sample option."
+      ),
+      selection_cutoffs = opt_spec(default = c(1.96), type = "numeric"),
+      selection_symmetric = opt_spec(default = FALSE, type = "logical"),
+      selection_model = opt_spec(
+        default = "normal", type = "character",
+        constraint = function(x) x %in% c("normal", "t"),
+        constraint_msg = "Selection model must be either 'normal' or 't'."
+      ),
+      hierarchical_iterations = opt_spec(
+        default = 6000L, type = "numeric", cast = as.integer,
+        constraint = function(x) x > 0,
+        constraint_msg = "Hierarchical iterations must be positive."
+      )
+    ))
   )
+
+  assert(length(resolved_options$selection_cutoffs) > 0, "Selection model requires at least one cutoff value.")
+  assert(all(resolved_options$selection_cutoffs > 0), "Selection cutoffs must be positive.")
 
   results <- run_nonlinear_methods(df, resolved_options)
 

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -9,11 +9,12 @@
 #' than a test, and its diagnostics do not read as p-hacking p-values.
 p_hacking_tests <- function(df) {
   box::use(
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
     artma / econometric / p_hacking[run_p_hacking_tests],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / options / significance_marks[resolve_add_significance_marks]
   )
 
@@ -22,97 +23,99 @@ p_hacking_tests <- function(df) {
 
   opt <- get_option_group("artma.methods.p_hacking_tests")
 
-  # Caliper options
-  include_caliper <- opt$include_caliper %||% TRUE
-  caliper_thresholds <- opt$caliper_thresholds %||% c(1.645, 1.96, 2.58)
-  caliper_widths <- opt$caliper_widths %||% c(0.05, 0.1, 0.15)
-  caliper_display_ratios <- opt$caliper_display_ratios %||% TRUE
-  caliper_tail <- opt$caliper_tail %||% "auto"
-  caliper_cluster <- opt$caliper_cluster %||% TRUE
+  resolved <- resolve_options(opt, list(
+    include_caliper = opt_spec(default = TRUE, type = "logical"),
+    caliper_thresholds = opt_spec(
+      default = c(1.645, 1.96, 2.58), type = "numeric",
+      constraint = function(x) length(x) > 0,
+      constraint_msg = "caliper_thresholds must not be empty"
+    ),
+    caliper_widths = opt_spec(
+      default = c(0.05, 0.1, 0.15), type = "numeric",
+      constraint = function(x) length(x) > 0,
+      constraint_msg = "caliper_widths must not be empty"
+    ),
+    caliper_display_ratios = opt_spec(default = TRUE, type = "logical"),
+    caliper_tail = opt_spec(
+      default = "auto", type = "character",
+      constraint = function(x) x %in% c("auto", "positive", "negative", "absolute"),
+      constraint_msg = "caliper_tail must be one of: auto, positive, negative, absolute"
+    ),
+    caliper_cluster = opt_spec(default = TRUE, type = "logical"),
+    include_elliott = opt_spec(default = TRUE, type = "logical"),
+    lcm_iterations = opt_spec(
+      default = 10000L, type = "numeric", cast = as.integer,
+      constraint = function(x) x > 0, constraint_msg = "lcm_iterations must be positive"
+    ),
+    lcm_grid_points = opt_spec(
+      default = 3000L, type = "numeric", cast = as.integer,
+      constraint = function(x) x > 0, constraint_msg = "lcm_grid_points must be positive"
+    ),
+    simulate_cdfs_chunk_size = opt_spec(
+      default = 512L, type = "numeric", from = "simulate_cdfs.chunk_size", cast = as.integer,
+      constraint = function(x) x > 0, constraint_msg = "simulate_cdfs.chunk_size must be positive"
+    ),
+    simulate_cdfs_seed = opt_spec(
+      default = 123L, type = "numeric", from = "simulate_cdfs.seed",
+      allow_na = TRUE, cast = as.integer
+    ),
+    include_discontinuity = opt_spec(default = TRUE, type = "logical"),
+    discontinuity_bandwidth = opt_spec(
+      default = NA_real_, type = "numeric", allow_na = TRUE,
+      constraint = function(x) x > 0, constraint_msg = "discontinuity_bandwidth must be positive"
+    ),
+    include_cox_shi = opt_spec(default = TRUE, type = "logical"),
+    cox_shi_bins = opt_spec(
+      default = 10L, type = "numeric", cast = as.integer,
+      constraint = function(x) x > 0, constraint_msg = "cox_shi_bins must be positive"
+    ),
+    cox_shi_order = opt_spec(
+      default = 2L, type = "numeric", cast = as.integer,
+      constraint = function(x) x >= 0, constraint_msg = "cox_shi_order must be non-negative"
+    ),
+    cox_shi_bounds = opt_spec(
+      default = 1L, type = "numeric", cast = as.integer,
+      constraint = function(x) x %in% c(0, 1), constraint_msg = "cox_shi_bounds must be 0 or 1"
+    ),
+    round_to = opt_spec(
+      default = 3L, type = "numeric", key = "artma.output.number_of_decimals", cast = as.integer,
+      constraint = function(x) x >= 0, constraint_msg = "Number of decimals must be non-negative"
+    )
+  ))
 
-  # Elliott options
-  include_elliott <- opt$include_elliott %||% TRUE
-  lcm_iterations <- opt$lcm_iterations %||% 10000L
-  lcm_grid_points <- opt$lcm_grid_points %||% 3000L
-  simulate_cdfs_chunk_size <- opt[["simulate_cdfs.chunk_size"]] %||% 512L
-  simulate_cdfs_seed <- opt[["simulate_cdfs.seed"]] %||% 123L
-  if (length(simulate_cdfs_seed) == 1 && is.na(simulate_cdfs_seed)) {
-    simulate_cdfs_seed <- NULL
+  # An NA sentinel means "unset" for these two; convert to NULL, matching the
+  # prior code that turned an unset seed/bandwidth into NULL before dispatch.
+  simulate_cdfs_seed <- if (length(resolved$simulate_cdfs_seed) == 1 && is.na(resolved$simulate_cdfs_seed)) {
+    NULL
+  } else {
+    resolved$simulate_cdfs_seed
   }
-  include_discontinuity <- opt$include_discontinuity %||% TRUE
-  discontinuity_bandwidth <- opt$discontinuity_bandwidth %||% NA
-  if (length(discontinuity_bandwidth) == 1 && is.na(discontinuity_bandwidth)) {
-    discontinuity_bandwidth <- NULL
+  discontinuity_bandwidth <- if (length(resolved$discontinuity_bandwidth) == 1 && is.na(resolved$discontinuity_bandwidth)) {
+    NULL
+  } else {
+    resolved$discontinuity_bandwidth
   }
-  include_cox_shi <- opt$include_cox_shi %||% TRUE
-  cox_shi_bins <- opt$cox_shi_bins %||% 10L
-  cox_shi_order <- opt$cox_shi_order %||% 2L
-  cox_shi_bounds <- opt$cox_shi_bounds %||% 1L
-
-  # General options
-  add_significance_marks <- resolve_add_significance_marks()
-  round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
-
-  validate(
-    is.logical(include_caliper),
-    is.numeric(caliper_thresholds),
-    is.numeric(caliper_widths),
-    is.logical(caliper_display_ratios),
-    is.character(caliper_tail),
-    is.logical(caliper_cluster),
-    is.logical(include_elliott),
-    is.numeric(lcm_iterations),
-    is.numeric(lcm_grid_points),
-    is.numeric(simulate_cdfs_chunk_size),
-    is.null(simulate_cdfs_seed) || is.numeric(simulate_cdfs_seed),
-    is.logical(include_discontinuity),
-    is.null(discontinuity_bandwidth) || is.numeric(discontinuity_bandwidth),
-    is.logical(include_cox_shi),
-    is.numeric(cox_shi_bins),
-    is.numeric(cox_shi_order),
-    is.numeric(cox_shi_bounds),
-    is.logical(add_significance_marks),
-    is.numeric(round_to)
-  )
-
-  assert(length(caliper_thresholds) > 0, "caliper_thresholds must not be empty")
-  assert(
-    caliper_tail %in% c("auto", "positive", "negative", "absolute"),
-    "caliper_tail must be one of: auto, positive, negative, absolute"
-  )
-  assert(length(caliper_widths) > 0, "caliper_widths must not be empty")
-  assert(lcm_iterations > 0, "lcm_iterations must be positive")
-  assert(lcm_grid_points > 0, "lcm_grid_points must be positive")
-  assert(simulate_cdfs_chunk_size > 0, "simulate_cdfs.chunk_size must be positive")
-  assert(
-    is.null(discontinuity_bandwidth) || discontinuity_bandwidth > 0,
-    "discontinuity_bandwidth must be positive"
-  )
-  assert(cox_shi_bins > 0, "cox_shi_bins must be positive")
-  assert(cox_shi_order >= 0, "cox_shi_order must be non-negative")
-  assert(cox_shi_bounds %in% c(0, 1), "cox_shi_bounds must be 0 or 1")
-  assert(round_to >= 0, "Number of decimals must be non-negative")
 
   resolved_options <- list(
-    include_caliper = include_caliper,
-    caliper_thresholds = caliper_thresholds,
-    caliper_widths = caliper_widths,
-    caliper_display_ratios = caliper_display_ratios,
-    caliper_tail = caliper_tail,
-    caliper_cluster = caliper_cluster,
-    include_elliott = include_elliott,
-    lcm_iterations = as.integer(lcm_iterations),
-    lcm_grid_points = as.integer(lcm_grid_points),
-    simulate_cdfs_chunk_size = as.integer(simulate_cdfs_chunk_size),
-    simulate_cdfs_seed = if (is.null(simulate_cdfs_seed)) NULL else as.integer(simulate_cdfs_seed),
-    include_discontinuity = include_discontinuity,
+    include_caliper = resolved$include_caliper,
+    caliper_thresholds = resolved$caliper_thresholds,
+    caliper_widths = resolved$caliper_widths,
+    caliper_display_ratios = resolved$caliper_display_ratios,
+    caliper_tail = resolved$caliper_tail,
+    caliper_cluster = resolved$caliper_cluster,
+    include_elliott = resolved$include_elliott,
+    lcm_iterations = resolved$lcm_iterations,
+    lcm_grid_points = resolved$lcm_grid_points,
+    simulate_cdfs_chunk_size = resolved$simulate_cdfs_chunk_size,
+    simulate_cdfs_seed = simulate_cdfs_seed,
+    include_discontinuity = resolved$include_discontinuity,
     discontinuity_bandwidth = discontinuity_bandwidth,
-    include_cox_shi = include_cox_shi,
-    cox_shi_bins = as.integer(cox_shi_bins),
-    cox_shi_order = as.integer(cox_shi_order),
-    cox_shi_bounds = as.integer(cox_shi_bounds),
-    add_significance_marks = add_significance_marks,
-    round_to = round_to
+    include_cox_shi = resolved$include_cox_shi,
+    cox_shi_bins = resolved$cox_shi_bins,
+    cox_shi_order = resolved$cox_shi_order,
+    cox_shi_bounds = resolved$cox_shi_bounds,
+    add_significance_marks = resolve_add_significance_marks(),
+    round_to = resolved$round_to
   )
 
   results <- run_p_hacking_tests(df, resolved_options)

--- a/inst/artma/methods/prima_facie_graphs.R
+++ b/inst/artma/methods/prima_facie_graphs.R
@@ -7,10 +7,11 @@ prima_facie_graphs <- function(df) {
   box::use(
     artma / data_config / read[get_data_config],
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / libs / core / autonomy[should_prompt_user],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / variable / detection[detect_variable_groups],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[export_named_plots]
@@ -27,25 +28,29 @@ prima_facie_graphs <- function(df) {
   opt <- get_option_group("artma.methods.prima_facie_graphs")
   vis <- get_visualization_options()
 
-  graph_type <- opt$type %||% "automatic"
-  hide_outliers <- opt$hide_outliers %||% TRUE
-  n_bins <- opt$n_bins %||% 80L
-  legend_font_size <- opt$legend_font_size %||% 14
+  resolved <- resolve_options(opt, list(
+    graph_type = opt_spec(
+      default = "automatic", type = "character", from = "type",
+      constraint = function(x) x %in% c("density", "histogram", "automatic"),
+      constraint_msg = "type must be one of: density, histogram, automatic"
+    ),
+    hide_outliers = opt_spec(default = TRUE, type = "logical"),
+    n_bins = opt_spec(
+      default = 80L, type = "numeric",
+      constraint = function(x) x > 0,
+      constraint_msg = "n_bins must be positive"
+    ),
+    legend_font_size = opt_spec(default = 14, type = "numeric")
+  ))
+
+  graph_type <- resolved$graph_type
+  hide_outliers <- resolved$hide_outliers
+  n_bins <- resolved$n_bins
+  legend_font_size <- resolved$legend_font_size
   theme_name <- vis$theme
   export_graphics <- vis$export_graphics
   export_path <- vis$export_path
   graph_scale <- vis$graph_scale
-
-  validate(
-    is.character(graph_type),
-    is.logical(hide_outliers),
-    is.numeric(n_bins), n_bins > 0,
-    is.numeric(legend_font_size)
-  )
-  assert(
-    graph_type %in% c("density", "histogram", "automatic"),
-    "type must be one of: density, histogram, automatic"
-  )
 
   groups <- resolve_groups(df, config, opt)
 

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -17,9 +17,10 @@ MIN_OBSERVATIONS <- 3L
 robma <- function(df) {
   box::use(
     artma / libs / core / utils[get_verbosity],
-    artma / libs / core / validation[assert, validate, validate_columns],
+    artma / libs / core / validation[validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
-    artma / options / index[get_option_group]
+    artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options]
   )
 
   validate(is.data.frame(df))
@@ -31,44 +32,62 @@ robma <- function(df) {
 
   opt <- get_option_group("artma.methods.robma")
 
-  chains <- opt$chains %||% 3L
-  samples <- opt$samples %||% 5000L
-  burnin <- opt$burnin %||% 2000L
-  adapt <- opt$adapt %||% 500L
+  resolved <- resolve_options(opt, list(
+    chains = opt_spec(
+      default = 3L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "chains must be positive"
+    ),
+    samples = opt_spec(
+      default = 5000L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "samples must be positive"
+    ),
+    burnin = opt_spec(
+      default = 2000L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "burnin must be positive"
+    ),
+    adapt = opt_spec(
+      default = 500L, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "adapt must be positive"
+    ),
+    autofit = opt_spec(default = TRUE, type = "logical"),
+    measure = opt_spec(
+      default = "SMD", type = "character",
+      constraint = function(x) x %in% c("SMD", "ZCOR", "RR", "OR", "HR", "RD", "IRR", "GEN"),
+      constraint_msg = "measure must be one of: SMD, ZCOR, RR, OR, HR, RD, IRR, GEN"
+    ),
+    effect_prior_scale = opt_spec(
+      default = 0.707, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "effect_prior_scale must be positive"
+    ),
+    heterogeneity_shape = opt_spec(
+      default = 1, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "heterogeneity_shape must be positive"
+    ),
+    heterogeneity_scale = opt_spec(
+      default = 0.15, type = "numeric",
+      constraint = function(x) x > 0, constraint_msg = "heterogeneity_scale must be positive"
+    ),
+    round_to = opt_spec(
+      default = 3L, type = "numeric", key = "artma.output.number_of_decimals"
+    )
+  ))
+
+  chains <- resolved$chains
+  samples <- resolved$samples
+  burnin <- resolved$burnin
+  adapt <- resolved$adapt
+  autofit <- resolved$autofit
+  measure <- resolved$measure
+  effect_prior_scale <- resolved$effect_prior_scale
+  heterogeneity_shape <- resolved$heterogeneity_shape
+  heterogeneity_scale <- resolved$heterogeneity_scale
+  round_to <- resolved$round_to
+
+  # parallel is auto-detected from a possibly-NA option and seed permits NA, so
+  # both stay outside the spec-driven block.
   parallel <- resolve_parallel(opt$parallel, chains)
-  autofit <- opt$autofit %||% TRUE
   seed <- opt$seed %||% NA_integer_
-  measure <- opt$measure %||% "SMD"
-  effect_prior_scale <- opt$effect_prior_scale %||% 0.707
-  heterogeneity_shape <- opt$heterogeneity_shape %||% 1
-  heterogeneity_scale <- opt$heterogeneity_scale %||% 0.15
-  round_to <- getOption("artma.output.number_of_decimals", 3)
-
-  validate(
-    is.numeric(chains),
-    is.numeric(samples),
-    is.numeric(burnin),
-    is.numeric(adapt),
-    is.logical(parallel),
-    is.logical(autofit),
-    is.numeric(seed) || is.na(seed),
-    is.character(measure),
-    is.numeric(effect_prior_scale),
-    is.numeric(heterogeneity_shape),
-    is.numeric(heterogeneity_scale)
-  )
-
-  assert(
-    measure %in% c("SMD", "ZCOR", "RR", "OR", "HR", "RD", "IRR", "GEN"),
-    "measure must be one of: SMD, ZCOR, RR, OR, HR, RD, IRR, GEN"
-  )
-  assert(chains > 0, "chains must be positive")
-  assert(samples > 0, "samples must be positive")
-  assert(burnin > 0, "burnin must be positive")
-  assert(adapt > 0, "adapt must be positive")
-  assert(effect_prior_scale > 0, "effect_prior_scale must be positive")
-  assert(heterogeneity_shape > 0, "heterogeneity_shape must be positive")
-  assert(heterogeneity_scale > 0, "heterogeneity_scale must be positive")
+  validate(is.numeric(seed) || is.na(seed))
 
   usable <- is.finite(df$effect) & is.finite(df$se) & df$se > 0
   fit_data <- df[usable, , drop = FALSE]

--- a/inst/artma/methods/t_stat_histogram.R
+++ b/inst/artma/methods/t_stat_histogram.R
@@ -12,6 +12,7 @@ t_stat_histogram <- function(df) {
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
     artma / visualization / export[export_named_plots]
   )
@@ -26,47 +27,52 @@ t_stat_histogram <- function(df) {
   opt <- get_option_group("artma.methods.t_stat_histogram")
   vis <- get_visualization_options()
 
-  lower_cutoff <- opt$lower_cutoff %||% -120
-  upper_cutoff <- opt$upper_cutoff %||% 120
-  critical_values <- opt$critical_values %||% 1.96
-  n_bins <- opt$n_bins %||% 80L
-  show_mean_line <- opt$show_mean_line %||% TRUE
-  show_density_curve <- opt$show_density_curve %||% TRUE
-  min_tick_distance <- opt$min_tick_distance %||% 0.5
-  close_up_enabled <- opt$close_up_enabled %||% TRUE
-  close_up_lower <- opt$close_up_lower %||% -10
-  close_up_upper <- opt$close_up_upper %||% 10
-  close_up_min_tick_distance <- opt$close_up_min_tick_distance %||% 0.3
+  resolved <- resolve_options(opt, list(
+    lower_cutoff = opt_spec(default = -120, type = "numeric"),
+    upper_cutoff = opt_spec(default = 120, type = "numeric"),
+    critical_values = opt_spec(
+      default = 1.96, type = "numeric",
+      constraint = function(x) all(x > 0),
+      constraint_msg = "critical_values must be positive (symmetric +/- applied automatically)"
+    ),
+    n_bins = opt_spec(
+      default = 80L, type = "numeric", cast = as.integer,
+      constraint = function(x) x > 0,
+      constraint_msg = "n_bins must be positive"
+    ),
+    show_mean_line = opt_spec(default = TRUE, type = "logical"),
+    show_density_curve = opt_spec(default = TRUE, type = "logical"),
+    min_tick_distance = opt_spec(
+      default = 0.5, type = "numeric",
+      constraint = function(x) x > 0,
+      constraint_msg = "min_tick_distance must be positive"
+    ),
+    close_up_enabled = opt_spec(default = TRUE, type = "logical"),
+    close_up_lower = opt_spec(default = -10, type = "numeric"),
+    close_up_upper = opt_spec(default = 10, type = "numeric"),
+    close_up_min_tick_distance = opt_spec(default = 0.3, type = "numeric")
+  ))
+
+  lower_cutoff <- resolved$lower_cutoff
+  upper_cutoff <- resolved$upper_cutoff
+  critical_values <- resolved$critical_values
+  n_bins <- resolved$n_bins
+  show_mean_line <- resolved$show_mean_line
+  show_density_curve <- resolved$show_density_curve
+  min_tick_distance <- resolved$min_tick_distance
+  close_up_enabled <- resolved$close_up_enabled
+  close_up_lower <- resolved$close_up_lower
+  close_up_upper <- resolved$close_up_upper
+  close_up_min_tick_distance <- resolved$close_up_min_tick_distance
   theme_name <- vis$theme
   export_graphics <- vis$export_graphics
   export_path <- vis$export_path
   graph_scale <- vis$graph_scale
 
-  validate(
-    is.numeric(lower_cutoff),
-    is.numeric(upper_cutoff),
-    is.numeric(critical_values),
-    is.numeric(n_bins),
-    is.logical(show_mean_line),
-    is.logical(show_density_curve),
-    is.numeric(min_tick_distance),
-    is.logical(close_up_enabled),
-    is.numeric(close_up_lower),
-    is.numeric(close_up_upper),
-    is.numeric(close_up_min_tick_distance)
-  )
-
-  n_bins <- as.integer(n_bins)
   assert(
     lower_cutoff < upper_cutoff,
     "lower_cutoff must be less than upper_cutoff"
   )
-  assert(n_bins > 0, "n_bins must be positive")
-  assert(
-    all(critical_values > 0),
-    "critical_values must be positive (symmetric +/- applied automatically)"
-  )
-  assert(min_tick_distance > 0, "min_tick_distance must be positive")
 
   if (close_up_enabled) {
     assert(

--- a/inst/artma/methods/variable_summary_stats.R
+++ b/inst/artma/methods/variable_summary_stats.R
@@ -9,15 +9,26 @@
 variable_summary_stats <- function(df) {
   box::use(
     artma / const[CONST],
-    artma / libs / core / validation[assert],
     artma / data_config / read[get_data_config],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
+    artma / options / resolver[opt_spec, resolve_options],
     artma / libs / core / utils[get_verbosity]
   )
 
   config <- get_data_config()
   opt <- get_option_group("artma.methods.variable_summary_stats")
+
+  resolved <- resolve_options(opt, list(
+    use_verbose_names = opt_spec(default = TRUE, type = "logical"),
+    round_to = opt_spec(
+      default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
+      constraint = function(x) x >= 0,
+      constraint_msg = "Number of decimals must be greater than or equal to 0."
+    )
+  ))
+  use_verbose_names <- resolved$use_verbose_names
+  round_to <- resolved$round_to
 
   if (get_verbosity() >= 4) {
     cli::cli_alert_info("Computing variable summary statistics")
@@ -37,16 +48,13 @@ variable_summary_stats <- function(df) {
   df_out <- data.frame(matrix(nrow = length(desired_vars), ncol = length(variable_stat_names)))
   colnames(df_out) <- variable_stat_names
 
-  round_to <- getOption("artma.output.number_of_decimals", 3)
-  assert(round_to >= 0, "Number of decimals must be greater than or equal to 0.")
-
   # Iterate over all desired variables and append summary statistics to the main DF
   missing_data_vars <- c()
   for (row_idx in seq_along(desired_vars)) {
     var_name <- desired_vars[[row_idx]]
     var_data <- as.vector(unlist(subset(df, select = var_name))) # Roundabout way, because types
     var_class <- config[[var_name]]$data_type
-    var_name_display <- if (isTRUE(opt$use_verbose_names %||% TRUE)) config[[var_name]]$var_name_verbose else var_name
+    var_name_display <- if (isTRUE(use_verbose_names)) config[[var_name]]$var_name_verbose else var_name
 
     # Missing all data
     if (!any(is.numeric(var_data), na.rm = TRUE) || all(is.na(var_data))) {

--- a/inst/artma/options/resolver.R
+++ b/inst/artma/options/resolver.R
@@ -1,0 +1,123 @@
+#' @title Declarative option-spec resolver
+#' @description Every runtime method used to read its options with the same
+#'   four-touch pattern: read (`get_option_group` + `%||%` default), a
+#'   `validate()` type block, an `assert()` range block, and a re-cast into the
+#'   `resolved_options` list. This module replaces that with a single
+#'   spec-driven resolver: a method declares a table of specs (name, default,
+#'   type, constraint, cast) and `resolve_options()` returns the validated,
+#'   cast, range-checked values.
+#'
+#'   Type coercion and validation are delegated to the shared option type
+#'   registry (`options/type_registry.R`, item B4) via `validate_option_value`,
+#'   so this module never re-implements the per-type `switch` logic that the
+#'   registry already owns.
+
+box::use(
+  artma / libs / core / validation[assert],
+  artma / options / utils[validate_option_value]
+)
+
+#' @title Build one option spec
+#' @description Construct a single spec consumed by `resolve_options()`. Only
+#'   `default` and `type` are required; the remaining fields are opt-in and
+#'   default to "do nothing", so a spec with just a default and a type performs
+#'   a read plus a registry type-check.
+#' @param default *\[any\]* Value used when the option is unset. Must match the
+#'   template default for the option.
+#' @param type *\[character\]* Registry type key used for validation, e.g.
+#'   `"numeric"`, `"integer"`, `"logical"`, `"character"`. Match the type the
+#'   method historically validated (an integer template option validated with
+#'   `is.numeric` uses `type = "numeric"` plus `cast = as.integer`).
+#' @param allow_na *\[logical\]* Whether `NA` is a permitted value. When `TRUE`
+#'   and the resolved value is a scalar `NA`, the cast and constraint are
+#'   skipped, matching the historical `is.na(x) || ...` guards.
+#' @param from *\[character, optional\]* Group key to read the raw value from
+#'   when it differs from the output name (e.g. a nested `"simulate_cdfs.seed"`
+#'   key resolving into a `simulate_cdfs_seed` output).
+#' @param key *\[character, optional\]* Fully-qualified option name read via
+#'   `getOption()` instead of from the passed group (for global options such as
+#'   `"artma.output.number_of_decimals"`).
+#' @param cast *\[function, optional\]* Applied to a non-`NA` value after
+#'   validation, e.g. `as.integer`.
+#' @param scalar *\[logical\]* When `TRUE`, assert the value is length one.
+#' @param constraint *\[function, optional\]* Predicate applied to the non-`NA`
+#'   value; when it does not return `TRUE`, the resolver aborts with
+#'   `constraint_msg`.
+#' @param constraint_msg *\[character, optional\]* Error message paired with
+#'   `constraint`.
+#' @return *\[list\]* A single option spec.
+opt_spec <- function(default,
+                     type,
+                     allow_na = FALSE,
+                     from = NULL,
+                     key = NULL,
+                     cast = NULL,
+                     scalar = FALSE,
+                     constraint = NULL,
+                     constraint_msg = NULL) {
+  list(
+    default = default,
+    type = type,
+    allow_na = allow_na,
+    from = from,
+    key = key,
+    cast = cast,
+    scalar = scalar,
+    constraint = constraint,
+    constraint_msg = constraint_msg
+  )
+}
+
+is_scalar_na <- function(x) length(x) == 1L && is.na(x)
+
+#' @title Resolve a group of options from a spec table
+#' @description Read, type-validate, cast, and range-check a set of options
+#'   declared as specs. The output is a named list keyed by the spec names,
+#'   suitable for use directly as a method's `resolved_options`.
+#' @param group *\[list\]* The option group returned by `get_option_group()` for
+#'   the method (e.g. `get_option_group("artma.methods.box_plot")`). Specs with
+#'   a `key` read past this group via `getOption()`.
+#' @param specs *\[list\]* Named list of specs built with `opt_spec()`.
+#' @return *\[list\]* Named list of resolved option values.
+resolve_options <- function(group, specs) {
+  resolved <- vector("list", length(specs))
+  names(resolved) <- names(specs)
+
+  for (name in names(specs)) {
+    spec <- specs[[name]]
+
+    raw <- if (!is.null(spec$key)) {
+      getOption(spec$key, spec$default)
+    } else {
+      read_key <- spec$from %||% name
+      group[[read_key]] %||% spec$default
+    }
+
+    # Type coercion/validation is owned by the shared option type registry.
+    err <- validate_option_value(raw, spec$type, name, allow_na = spec$allow_na)
+    if (!is.null(err)) {
+      cli::cli_abort(err, .subclass = "validation_error")
+    }
+
+    if (isTRUE(spec$scalar)) {
+      assert(length(raw) == 1L, sprintf("Option '%s' must be a single value.", name))
+    }
+
+    val <- raw
+    skip_transforms <- is_scalar_na(val)
+
+    if (!is.null(spec$cast) && !skip_transforms) {
+      val <- spec$cast(val)
+    }
+
+    if (!is.null(spec$constraint) && !skip_transforms) {
+      assert(isTRUE(spec$constraint(val)), spec$constraint_msg)
+    }
+
+    resolved[[name]] <- val
+  }
+
+  resolved
+}
+
+box::export(opt_spec, resolve_options)

--- a/tests/testthat/test-options-resolver.R
+++ b/tests/testthat/test-options-resolver.R
@@ -1,0 +1,151 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_error,
+    expect_identical,
+    expect_named,
+    expect_null,
+    expect_true,
+    test_that
+  ],
+  withr[local_options]
+)
+
+box::use(
+  artma / options / resolver[opt_spec, resolve_options],
+  artma / methods / linear_tests[resolve_linear_tests_options]
+)
+
+
+# --- resolver unit behavior -------------------------------------------------
+
+test_that("resolve_options applies template defaults for unset options", {
+  resolved <- resolve_options(list(), list(
+    a = opt_spec(default = 3L, type = "numeric"),
+    b = opt_spec(default = "x", type = "character")
+  ))
+  expect_identical(resolved$a, 3L)
+  expect_identical(resolved$b, "x")
+})
+
+test_that("resolve_options reads set values from the group", {
+  resolved <- resolve_options(list(a = 7L), list(
+    a = opt_spec(default = 3L, type = "numeric")
+  ))
+  expect_identical(resolved$a, 7L)
+})
+
+test_that("resolve_options casts values with the spec cast", {
+  resolved <- resolve_options(list(n = 80.9), list(
+    n = opt_spec(default = 80L, type = "numeric", cast = as.integer)
+  ))
+  expect_identical(resolved$n, 80L)
+})
+
+test_that("resolve_options enforces constraints with the spec message", {
+  expect_error(
+    resolve_options(list(x = -1), list(
+      x = opt_spec(
+        default = 1, type = "numeric",
+        constraint = function(v) v >= 0,
+        constraint_msg = "x must be non-negative."
+      )
+    )),
+    "x must be non-negative.",
+    class = "assertion_error"
+  )
+})
+
+test_that("resolve_options rejects a value of the wrong type", {
+  expect_error(
+    resolve_options(list(flag = "nope"), list(
+      flag = opt_spec(default = TRUE, type = "logical")
+    )),
+    class = "validation_error"
+  )
+})
+
+test_that("resolve_options skips cast and constraint for allow_na NA values", {
+  resolved <- resolve_options(list(), list(
+    x = opt_spec(
+      default = NA_real_, type = "numeric", allow_na = TRUE,
+      cast = as.integer,
+      constraint = function(v) v > 0,
+      constraint_msg = "must be positive"
+    )
+  ))
+  expect_true(is.na(resolved$x))
+})
+
+test_that("resolve_options reads global options through key", {
+  local_options("artma.output.number_of_decimals" = 2L)
+  resolved <- resolve_options(list(), list(
+    round_to = opt_spec(
+      default = 3L, type = "numeric",
+      key = "artma.output.number_of_decimals", cast = as.integer
+    )
+  ))
+  expect_identical(resolved$round_to, 2L)
+})
+
+test_that("resolve_options reads a renamed group key with from", {
+  resolved <- resolve_options(list(`nested.key` = 5L), list(
+    flat = opt_spec(default = 1L, type = "numeric", from = "nested.key")
+  ))
+  expect_identical(resolved$flat, 5L)
+})
+
+
+# --- linear_tests characterization ------------------------------------------
+# Pins the resolved_options that linear_tests passes to run_linear_models. The
+# values here reproduce the pre-refactor inline read/validate/assert/cast block
+# exactly, so the resolver migration is a no-behavior-change move.
+
+local_linear_options <- function(..., .env = parent.frame()) {
+  local_options(
+    list(
+      "artma.methods.add_significance_marks" = TRUE,
+      "artma.output.number_of_decimals" = 3L,
+      ...
+    ),
+    .local_envir = .env
+  )
+}
+
+test_that("resolve_linear_tests_options returns template defaults", {
+  local_linear_options()
+  resolved <- resolve_linear_tests_options()
+
+  expect_named(
+    resolved,
+    c("add_significance_marks", "bootstrap_replications", "conf_level", "round_to")
+  )
+  expect_identical(resolved$add_significance_marks, TRUE)
+  expect_identical(resolved$bootstrap_replications, 999L)
+  expect_equal(resolved$conf_level, 0.95)
+  expect_identical(resolved$round_to, 3L)
+})
+
+test_that("resolve_linear_tests_options honours non-default values", {
+  local_linear_options(
+    "artma.methods.add_significance_marks" = FALSE,
+    "artma.methods.linear_tests.bootstrap_replications" = 100L,
+    "artma.methods.linear_tests.conf_level" = 0.9,
+    "artma.output.number_of_decimals" = 2L
+  )
+  resolved <- resolve_linear_tests_options()
+
+  expect_identical(resolved$add_significance_marks, FALSE)
+  expect_identical(resolved$bootstrap_replications, 100L)
+  expect_equal(resolved$conf_level, 0.9)
+  expect_identical(resolved$round_to, 2L)
+})
+
+test_that("resolve_linear_tests_options rejects an out-of-range conf_level", {
+  local_linear_options("artma.methods.linear_tests.conf_level" = 1.5)
+  expect_error(
+    resolve_linear_tests_options(),
+    "Confidence level must lie in the \\(0, 1\\) interval.",
+    class = "assertion_error"
+  )
+})


### PR DESCRIPTION
## What moved

Introduces one declarative option-spec resolver and migrates every `inst/artma/methods/*.R` file to it, replacing the repeated four-touch per-option pattern (read via `get_option_group` + `%||%`, a `validate()` type block, an `assert()` range block, and a re-cast into `resolved_options`).

- New `inst/artma/options/resolver.R`: `opt_spec()` builds one spec (default, type, allow_na, from, key, cast, scalar, constraint, constraint_msg); `resolve_options(group, specs)` reads, type-validates, casts, and range-checks a group and returns the `resolved_options` list.
- Type coercion and validation are delegated to the B4 option type registry via `validate_option_value` (`options/utils.R` to `options/type_registry.R`). The resolver does not reimplement any per-type switch.
- Migrated: `bma`, `best_practice_estimate`, `box_plot`, `effect_summary_stats`, `exogeneity_tests`, `fma`, `funnel_plot`, `linear_tests`, `maive`, `nonlinear_tests`, `p_hacking_tests`, `prima_facie_graphs`, `robma`, `t_stat_histogram`, `variable_summary_stats`.

## What changed behavior

Nothing. Same defaults, same error conditions on invalid values (an option rejected before is still rejected with a comparable message). Cross-option and NA-sentinel special cases are deliberately kept outside the spec table so behavior is preserved:

- `best_practice_estimate`: the cross-option `include_author_row || include_study_rows` assert stays inline (it spans two options).
- `p_hacking_tests`: `simulate_cdfs_seed` and `discontinuity_bandwidth` resolve through the spec table with `allow_na`, then an NA sentinel is converted to `NULL` exactly as before.
- `robma`: `seed` (NA-permitting) and `parallel` (auto-detected via `resolve_parallel`) stay inline; `prima_facie_graphs`: the interactive `groups` read stays inline.

## Template-default reconciliation

Every spec `default` was checked against `inst/artma/options/templates/options_template.yaml`. No inline default disagreed with the template, so none had to be overridden.

## C7 interaction

C7's typed accessors (`options/typed_accessors.R`) cover compute/data-layer options (`precision_type`, `winsorization_level`, `na_handling`, `se_zero_handling`); no method option block reads those, and C7 has no accessor for `number_of_decimals`. No duplication, nothing to reconcile.

## Elliott / D3 note

`p_hacking_tests` is elliott-related. Its diff is strictly the mechanical resolver migration, so a later rebase against #328 stays trivial.

## Tests

- New `tests/testthat/test-options-resolver.R`: resolver unit behavior (defaults, group reads, cast, constraint, wrong-type rejection, allow_na skip, `key`, `from`) plus a `linear_tests` characterization test pinning every resolved option on defaults, a non-default set, and an out-of-range rejection. It exercises `resolve_linear_tests_options()`, exported from `linear_tests.R` as the worked example.
- Full `make test`: 0 failures, 2431 pass. `make lint`: clean. `make check`: 0 errors, 0 notes; the single install WARNING is a pre-existing compiler warning from R's own `R_ext/Boolean.h` (`-Wfixed-enum-extension`), unrelated to this R-only change.

Refs #322 (item C2).
