### PR TITLE
fix(ci): make test-e2e actually run both E2E test files

### DIFF
--- a/scripts/testE2E.sh
+++ b/scripts/testE2E.sh
@@ -13,7 +13,7 @@ TEST_FILES_COUNT=${#TEST_FILES[@]}
 
 info "Running $TEST_FILES_COUNT end-to-end tests..."
 
-for TEST_FILE in $TEST_FILES; do
+for TEST_FILE in "${TEST_FILES[@]}"; do
   info "Testing $TEST_FILE..."
   if ! Rscript "$TEST_FILE" 2>&1; then
     error "Error in $TEST_FILE" >&2


### PR DESCRIPTION
## Summary
- scripts/testE2E.sh built TEST_FILES as a bash array but iterated over the unquoted, unindexed variable, which under bash only expands to the first array element. make test-e2e reported "Running 2 end-to-end tests" but silently only ever ran test-smoke.R; test-installation.R never executed.
- Quote the array expansion so both fixture-backed E2E tests run.

Found while running make test-e2e on master to validate today's refactor wave (options accessors, BMA/FMA/BPE extraction, schema_reconcile split, Elliott C++ CDF path, etc.) against real mock data. test-smoke.R and test-installation.R both pass once actually executed.

## Test plan
- [x] ran `bash scripts/testE2E.sh` locally; confirmed both `Testing ./test-smoke.R...` and `Testing ./test-installation.R...` now print, ending in success