### PR TITLE
fix(bma): skip gracefully instead of crashing with a single moderator

### DIFF
--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -334,7 +334,11 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
   computed <- unwrap_bma_result(bma(df))
   assert(
     is_bma_input_ready(computed),
-    "BMA did not produce a usable model/data bundle for best-practice estimation."
+    if (!is.null(computed$skipped)) {
+      sprintf("Best-practice estimate requires BMA, but BMA was skipped: %s.", computed$skipped)
+    } else {
+      "BMA did not produce a usable model/data bundle for best-practice estimation."
+    }
   )
 
   computed$formula <- build_bma_formula_from_data(computed$data)

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -81,7 +81,7 @@ bma <- function(df) {
 
   if (!is.null(prepared$skipped)) {
     if (get_verbosity() >= 2) {
-      cli::cli_alert_warning("No valid BMA variables available. Skipping BMA analysis.")
+      cli::cli_alert_warning("{prepared$skipped}. Skipping BMA analysis.")
     }
     empty_coefs <- data.frame(
       variable = character(0),
@@ -429,6 +429,21 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
     }
   }
 
+  # BMS::bms() crashes with "subscript out of bounds" when the model space has
+  # exactly one candidate regressor (its internal XtX.big matrix collapses to
+  # 1x1 but position indices assume at least two candidates). Two or more
+  # moderators are required to reach the codepath BMS actually supports.
+  n_moderators <- ncol(bma_data) - 1
+  if (n_moderators == 1) {
+    sole_moderator <- setdiff(colnames(bma_data), "effect")
+    return(list(
+      skipped = sprintf(
+        "BMA requires at least 2 candidate moderator variables, but only 1 remains (%s). The BMS package cannot fit a model with a single regressor",
+        sole_moderator
+      )
+    ))
+  }
+
   list(
     bma_data = bma_data,
     bma_var_list = bma_var_list,
@@ -441,14 +456,15 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
 #' Accepts either the standard method-result shape (fields nested under
 #' `$meta`) or a bare list carrying `model`/`data`/`var_list` directly, so
 #' callers that pass a previously computed `bma()` result or a hand-built
-#' list are both supported. Returns a list with `model`, `data`, `var_list`
-#' and `params` fields (all `NULL` when `bma_result` does not carry a usable
-#' bundle).
+#' list are both supported. Returns a list with `model`, `data`, `var_list`,
+#' `params` and `skipped` fields (all `NULL` except `skipped` when
+#' `bma_result` does not carry a usable bundle; `skipped` carries the reason
+#' string when the source `bma()` run was itself skipped).
 #' @param bma_result *\[list, optional\]* Either a `bma()` method result or a
 #'   bare `list(model=, data=, var_list=, params=)`.
-#' @return *\[list\]* `list(model=, data=, var_list=, params=)`.
+#' @return *\[list\]* `list(model=, data=, var_list=, params=, skipped=)`.
 unwrap_bma_result <- function(bma_result) {
-  empty <- list(model = NULL, data = NULL, var_list = NULL, params = NULL)
+  empty <- list(model = NULL, data = NULL, var_list = NULL, params = NULL, skipped = NULL)
 
   if (!is.list(bma_result)) {
     return(empty)
@@ -463,10 +479,12 @@ unwrap_bma_result <- function(bma_result) {
       model = meta$model,
       data = meta$data,
       var_list = meta$var_list,
-      params = meta$params
+      params = meta$params,
+      skipped = meta$skipped
     ))
   }
 
+  empty$skipped <- meta$skipped
   empty
 }
 

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -95,7 +95,7 @@ fma <- function(df, bma_result = NULL) {
 
     if (!is.null(prepared$skipped)) {
       if (get_verbosity() >= 2) {
-        cli::cli_alert_warning("No valid BMA variables available. Skipping FMA analysis.")
+        cli::cli_alert_warning("{prepared$skipped}. Skipping FMA analysis.")
       }
       empty_coefs <- data.frame(
         variable = character(0),

--- a/tests/testthat/test-bma-result-unwrap.R
+++ b/tests/testthat/test-bma-result-unwrap.R
@@ -4,7 +4,9 @@ box::use(
     expect_error,
     expect_false,
     expect_identical,
+    expect_match,
     expect_named,
+    expect_null,
     expect_true,
     skip_if_not_installed,
     test_that
@@ -188,4 +190,57 @@ test_that("fma reuses a provided BMA result in both the $meta bundle and bare-li
   expect_identical(result_meta_bundle$meta$model, model)
   expect_identical(result_bare_list$meta$model, model)
   expect_named(result_meta_bundle$tables$coefficients, names(result_bare_list$tables$coefficients))
+})
+
+# BMS::bms() crashes with "subscript out of bounds" for a model space with
+# exactly one candidate regressor; prepare_bma_inputs() now catches this
+# before run_bma() is ever reached, and every consumer should surface the
+# reason instead of propagating a NULL model.
+make_single_moderator_df <- function() {
+  set.seed(7)
+  n <- 20L
+  data.frame(
+    effect = rnorm(n, mean = 0.2, sd = 0.1),
+    se = runif(n, min = 0.05, max = 0.15),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("fma skips gracefully instead of crashing when only one moderator is available", {
+  df <- make_single_moderator_df()
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE)
+  )
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config
+  ))
+
+  result <- fma(df, bma_result = NULL)
+
+  expect_equal(nrow(result$tables$coefficients), 0)
+  expect_null(result$meta$model)
+  expect_match(result$meta$skipped, "at least 2 candidate moderator variables")
+})
+
+test_that("resolve_bma_input_for_bpe surfaces the BMA skip reason when BMA cannot run", {
+  df <- make_single_moderator_df()
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE)
+  )
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config
+  ))
+
+  expect_error(
+    resolve_bma_input_for_bpe(df = df, bma_result = NULL, run_bma_if_missing = TRUE),
+    "BMA was skipped"
+  )
 })

--- a/tests/testthat/test-bma.R
+++ b/tests/testthat/test-bma.R
@@ -3,7 +3,9 @@ box::use(
     expect_equal,
     expect_false,
     expect_length,
+    expect_match,
     expect_named,
+    expect_null,
     expect_true,
     expect_type,
     skip_if_not_installed,
@@ -18,7 +20,7 @@ box::use(
     handle_bma_params,
     get_bma_data
   ],
-  artma / methods / bma[bma]
+  artma / methods / bma[bma, prepare_bma_inputs]
 )
 
 make_demo_bma_data <- function() {
@@ -290,4 +292,49 @@ test_that("bma does not export a comparison plot for a single parameter set", {
 
   expect_length(result$meta$all, 1)
   expect_false(file.exists(file.path(export_dir, "bma_comparison.png")))
+})
+
+test_that("prepare_bma_inputs skips gracefully when config selects a single moderator variable", {
+  # BMS::bms() crashes with "subscript out of bounds" for a model space with
+  # exactly one candidate regressor; a single selected moderator must be
+  # caught here instead of reaching run_bma().
+  df <- make_demo_bma_data()
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE)
+  )
+
+  prepared <- prepare_bma_inputs(
+    df = df,
+    config = config,
+    use_vif_optimization = FALSE,
+    max_groups_to_remove = 30L,
+    scale_data = TRUE,
+    verbosity = 0
+  )
+
+  expect_null(prepared$bma_data)
+  expect_match(prepared$skipped, "at least 2 candidate moderator variables")
+  expect_match(prepared$skipped, "se")
+})
+
+test_that("bma skips with an explanatory reason instead of crashing on a single moderator", {
+  df <- make_demo_bma_data()
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE)
+  )
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = config,
+    artma.output.save_results = FALSE
+  ))
+
+  result <- bma(df)
+
+  expect_equal(nrow(result$tables$coefficients), 0)
+  expect_true(is.null(result$meta$model))
+  expect_match(result$meta$skipped, "at least 2 candidate moderator variables")
 })


### PR DESCRIPTION
## Summary

`bma`, `fma`, and `best_practice_estimate` crashed with a cryptic `subscript out of bounds` error whenever BMA variable selection resolved to exactly one non-collinear moderator (e.g. only `se` selected by the priority-moderator convention).

Root cause: `BMS::bms()` (v0.3.5) has an internal bug where its model-space enumeration produces out-of-range column positions into a 1x1 `XtX.big` matrix whenever there is exactly one candidate regressor. This reproduces upstream regardless of MCMC sampler (`bd`, `enumeration`) and is unrelated to this repo's own code; it's already latent on master (verified against commit `52db830`, pre-dating today's refactor wave). It only surfaced now because `tests/E2E/fixtures/smoke_data.csv` (added today) is a tiny fixture nobody had previously run `bma`/`fma`/`best_practice_estimate` against.

## Fix

`prepare_bma_inputs()` now detects when exactly one moderator remains after variable selection/collinearity removal and returns the existing `skipped` sentinel (reusing the same graceful-skip mechanism already used for "no valid BMA variables") instead of ever reaching `run_bma()`/`BMS::bms()`. The skip reason is now propagated end-to-end:
- `bma()`/`fma()` print the actual reason instead of a generic message.
- `unwrap_bma_result()` now also carries a `skipped` field.
- `best_practice_estimate()`'s `resolve_bma_input_for_bpe()` surfaces the specific reason in its abort message when BMA can't be computed.

## Test plan
- [x] Added regression tests covering `prepare_bma_inputs`, `bma()`, `fma()`, and `resolve_bma_input_for_bpe()` for the single-moderator case.
- [x] Reproduced the original crash end-to-end via `artma::artma(methods = c("bma"), ...)` against `tests/E2E/fixtures/smoke_data.csv` and confirmed it now completes with a clear skip message.
- [x] `make lint` clean.
- [x] `make test`: 0 failures, 2406 passed.
- [x] `make test-e2e` passes.