### PR TITLE
fix(data): silence duplicate drop_conflicting_raw log in configure phase

### DIFF
--- a/inst/artma/data/index.R
+++ b/inst/artma/data/index.R
@@ -57,8 +57,10 @@ configure_data <- function(df_raw) {
   reconcile_schema(df_raw, mode = mode)
 
   # Decide the missing-value and zero-SE strategies on the cleaned, standardized
-  # frame so the compute phase can handle both without prompting.
-  df_std <- standardize_column_names(df_raw)
+  # frame so the compute phase can handle both without prompting. Standardize
+  # quietly: this frame is a configure-phase intermediate, and the compute phase
+  # standardizes the same raw frame again with messages on.
+  df_std <- standardize_column_names(df_raw, quiet = TRUE)
   df_clean <- clean_data(df_std)
   resolve_na_handling(df_clean)
   resolve_se_zero_handling(df_clean)

--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -76,8 +76,11 @@ get_number_of_studies <- function(df) {
 #'   `artma / data / interactive_mapping`) and persist the result before
 #'   calling this function.
 #' @param df *\[data.frame\]* The data frame to standardize
+#' @param quiet *\[logical, optional\]* Suppress informational messages. Used by
+#'   callers that standardize an intermediate frame (e.g. the configure phase)
+#'   so a single run does not announce the same action twice. Defaults to `FALSE`.
 #' @return *\[data.frame\]* The standardized data frame
-standardize_column_names <- function(df) {
+standardize_column_names <- function(df, quiet = FALSE) {
   box::use(
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[validate, assert]
@@ -141,7 +144,7 @@ standardize_column_names <- function(df) {
 
     store_entry <- column_store[[target_col]]
     if (is.list(store_entry) && isTRUE(store_entry[["drop_conflicting_raw"]])) {
-      if (get_verbosity() >= 3) {
+      if (!quiet && get_verbosity() >= 3) {
         cli::cli_alert_info(
           "Dropping the raw {.val {target_col}} column: {.val {source_col}} is configured to supply it."
         )

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -1,5 +1,5 @@
 box::use(
-  testthat[expect_equal, expect_error, expect_false, expect_true, test_that]
+  testthat[expect_equal, expect_error, expect_false, expect_message, expect_no_message, expect_true, test_that]
 )
 
 box::use(

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -245,6 +245,28 @@ test_that("standardize_column_names drops the raw column when drop_conflicting_r
   )
 })
 
+test_that("standardize_column_names with quiet = TRUE drops the raw column without a message", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  mock_df <- build_collision_df("study_name", paste("Study", 1:5))
+
+  withr::with_options(
+    list(
+      "artma.data.columns" = list(
+        study_id = list(source_name = "study_name", drop_conflicting_raw = TRUE)
+      ),
+      "artma.verbose" = 3L
+    ),
+    {
+      expect_message(standardize_column_names(mock_df), "Dropping the raw")
+      expect_no_message(standardize_column_names(mock_df, quiet = TRUE))
+      standardized_df <- standardize_column_names(mock_df, quiet = TRUE)
+      expect_equal(standardized_df$study_id, paste("Study", 1:5))
+      expect_false("study_name" %in% colnames(standardized_df))
+    }
+  )
+})
+
 test_that("standardize_column_names allows an identity mapping through quietly", {
   box::use(artma / data / utils[standardize_column_names])
 


### PR DESCRIPTION
## Why

A single `artma()` run printed the `drop_conflicting_raw` info line twice:

```
ℹ Dropping the raw "study_id" column: "study_name" is configured to supply it.
ℹ Dropping the raw "study_id" column: "study_name" is configured to supply it.
```

`prepare_data()` standardizes the raw frame twice by design: once in the interactive, uncached configure phase (to resolve NA and zero-SE strategies on a standardized frame) and once in the cached compute phase (the pure pipeline that produces the analysis frame). Both passes hit the same `study_id`/`study_name` collision and each logged the drop.

The phase split itself is correct: configure prompts and writes options, which must stay outside the cache, and compute must be a pure function of the raw frame plus resolved config. Only the logging is duplicated.

## What

- `standardize_column_names()` gains an optional `quiet` argument that suppresses the drop message.
- The configure phase standardizes quietly; the compute phase keeps the message, matching its neighboring pipeline messages (winsorization, optional columns), which also only appear on cold-cache runs.
- Test covering the suppression.
