### PR TITLE
feat(coverage): measure inst/artma box modules and merge into Codecov

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -40,11 +40,16 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
+      - name: inst/artma coverage
+        run: Rscript scripts/R/inst_coverage.R
+        env:
+          ARTMA_COVERAGE_COBERTURA: "true"
+
       - uses: codecov/codecov-action@v5
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          files: ./cobertura.xml
+          files: ./cobertura.xml,./cobertura-inst.xml
           plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ share/python-wheels/
 MANIFEST
 
 # Unit test / coverage reports
+.artma-coverage.rds
+cobertura-inst.xml
 htmlcov/
 .tox/
 .nox/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Suggests:
     writexl (>= 1.4.0)
 VignetteBuilder:
     knitr
-Config/Needs/coverage: covr, xml2
+Config/Needs/coverage: covr, pkgload, xml2
 Config/Needs/dev: box.linters, devtools, languageserver, remotes
 Config/Needs/e2e: remotes
 Config/Needs/lint: box.linters, devtools, remotes

--- a/Makefile
+++ b/Makefile
@@ -159,15 +159,16 @@ clean:
 	@find . -name ".Rhistory" -delete
 	@find . -name ".DS_Store" -delete
 
-# Generate test coverage report
+# Generate test coverage report (inst/artma, the primary metric)
 coverage:
-	@echo "Generating test coverage report..."
-	@Rscript -e "covr::package_coverage()"
+	@echo "Generating inst/artma test coverage report..."
+	@Rscript scripts/R/inst_coverage.R
 
 # Interactive coverage report
 coverage-report:
 	@echo "Opening interactive coverage report..."
-	@Rscript -e "covr::report(covr::package_coverage())"
+	@ARTMA_COVERAGE_RDS=$(CURDIR)/.artma-coverage.rds Rscript scripts/R/inst_coverage.R
+	@Rscript -e "covr::report(readRDS('.artma-coverage.rds'))"
 
 # Auto-format code with styler
 style:

--- a/scripts/R/inst_coverage.R
+++ b/scripts/R/inst_coverage.R
@@ -1,0 +1,165 @@
+# Measures test coverage of the box-managed `inst/artma` tree, which
+# covr::package_coverage() cannot see (it only instruments R/ and src/).
+#
+# How it works: every inst/artma module is force-loaded through box so it
+# lands in box's module registry, covr's tracer is then pointed at each
+# module namespace environment, and the testthat suite runs once with the
+# instrumented functions recording line hits. Force-loading first keeps
+# untested modules in the denominator instead of silently inflating the
+# percentage.
+#
+# This leans on non-exported covr and box internals (guarded below with a
+# clear error if a version bump removes them). Parallel testthat is disabled
+# for the run: covr's counters live in this process, and parallel workers
+# would record nothing.
+#
+# Run via `make coverage`, or directly with `Rscript scripts/R/inst_coverage.R`.
+# Environment switches:
+#   ARTMA_COVERAGE_COBERTURA=true  also write cobertura-inst.xml (CI upload)
+#   ARTMA_COVERAGE_RDS=<path>      also save the coverage object as RDS
+
+Sys.setenv(TESTTHAT_PARALLEL = "false")
+
+pkgload::load_all(quiet = TRUE)
+
+#' Fetch a non-exported object from a namespace, aborting with a clear
+#' message if it no longer exists (covr/box internals are not API).
+#'
+#' @param name *[character]* Object name to fetch.
+#' @param ns_name *[character]* Namespace to fetch it from.
+#' @return The object.
+.ic_internal <- function(name, ns_name) {
+  ns <- asNamespace(ns_name)
+  if (!exists(name, envir = ns, inherits = FALSE)) {
+    cli::cli_abort(c(
+      "x" = "{.pkg {ns_name}} {utils::packageVersion(ns_name)} no longer provides the internal {.code {name}}.",
+      "i" = "scripts/R/inst_coverage.R relies on non-exported {.pkg covr}/{.pkg box} internals; update the script for the new version."
+    ))
+  }
+  get(name, envir = ns)
+}
+
+covr_replacement <- .ic_internal("replacement", "covr")
+covr_replacements_box <- .ic_internal("replacements_box", "covr")
+covr_replace <- .ic_internal("replace", "covr")
+covr_reset_traces <- .ic_internal("reset_traces", "covr")
+covr_clear_counters <- .ic_internal("clear_counters", "covr")
+covr_as_coverage <- .ic_internal("as_coverage", "covr")
+covr_counters <- .ic_internal(".counters", "covr")
+covr_the <- .ic_internal("the", "covr")
+covr_compact <- .ic_internal("compact", "covr")
+box_loaded_mods <- .ic_internal("loaded_mods", "box")
+
+repo_root <- normalizePath(".", winslash = "/", mustWork = TRUE)
+inst_prefix <- paste0(repo_root, "/inst/artma/")
+
+#' Force-load every inst/artma module through box so that modules no test
+#' touches still count as 0% instead of vanishing from the denominator.
+#'
+#' @return *[character]* Relative paths of modules that failed to load.
+.ic_force_load_modules <- function() {
+  rel_paths <- list.files("inst/artma", pattern = "[.]R$", recursive = TRUE)
+  failed <- character(0)
+  for (i in seq_along(rel_paths)) {
+    import_path <- paste0("artma/", sub("[.]R$", "", rel_paths[i]))
+    stmt <- sprintf("box::use(ic_mod_%d = %s)", i, import_path)
+    ok <- tryCatch(
+      {
+        eval(parse(text = stmt), envir = new.env(parent = globalenv()))
+        TRUE
+      },
+      error = function(e) FALSE
+    )
+    if (!ok) {
+      failed <- c(failed, file.path("inst/artma", rel_paths[i]))
+    }
+  }
+  failed
+}
+
+cli::cli_alert_info("Force-loading all inst/artma modules...")
+failed_mods <- .ic_force_load_modules()
+if (length(failed_mods) > 0) {
+  cli::cli_warn(c(
+    "!" = "{length(failed_mods)} module{?s} failed to load and will be missing from the coverage denominator:",
+    stats::setNames(failed_mods, rep("*", length(failed_mods)))
+  ))
+}
+
+# Build the replacements for every loaded module env with a SINGLE counter
+# clear. covr's own trace_environment() clears counters on each call, which
+# would wipe the previously traced modules' counters if used per-module.
+cli::cli_alert_info("Instrumenting box module environments...")
+covr_clear_counters()
+all_replacements <- list()
+for (key in ls(box_loaded_mods, all.names = TRUE)) {
+  mod <- get(key, envir = box_loaded_mods)
+  if (!is.environment(mod)) next
+  reps <- tryCatch(
+    covr_compact(c(
+      covr_replacements_box(mod),
+      lapply(ls(mod, all.names = TRUE), covr_replacement, env = mod)
+    )),
+    error = function(e) list()
+  )
+  all_replacements <- c(all_replacements, reps)
+}
+covr_the$replacements <- all_replacements
+invisible(lapply(covr_the$replacements, covr_replace))
+cli::cli_alert_success("Instrumented {length(all_replacements)} function{?s}.")
+
+cli::cli_alert_info("Running the test suite (sequential; parallel is disabled under tracing)...")
+invisible(withr::with_envvar(c(R_COVR = "true"), {
+  testthat::test_dir(
+    "tests/testthat",
+    reporter = "progress",
+    stop_on_failure = FALSE
+  )
+}))
+
+coverage <- covr_as_coverage(covr_counters)
+covr_reset_traces()
+covr_clear_counters()
+
+# Keep only entries under <repo>/inst/artma: the traced set also picks up
+# tempdir test fixtures and the tests/testthat/modules scaffolding.
+.ic_entry_path <- function(entry) {
+  srcfile <- attr(entry$srcref, "srcfile")
+  normalizePath(srcfile$filename, winslash = "/", mustWork = FALSE)
+}
+keep <- vapply(
+  coverage,
+  function(entry) startsWith(.ic_entry_path(entry), inst_prefix),
+  logical(1)
+)
+coverage <- structure(
+  coverage[keep],
+  class = "coverage",
+  root = repo_root,
+  package = list(package = "artma", path = repo_root)
+)
+
+if (length(coverage) == 0) {
+  cli::cli_abort("No inst/artma coverage was recorded; the tracer likely failed to attach.")
+}
+
+overall <- covr::percent_coverage(coverage)
+by_line <- covr::tally_coverage(coverage, by = "line")
+per_file <- aggregate(value ~ filename, data = by_line, FUN = function(x) round(mean(x > 0) * 100, 1))
+per_file <- per_file[order(per_file$value, per_file$filename), ]
+names(per_file) <- c("file", "coverage_pct")
+
+cli::cli_h1("inst/artma coverage")
+print(per_file, row.names = FALSE, right = FALSE)
+cli::cli_alert_success("Overall inst/artma line coverage: {round(overall, 2)}%")
+
+if (identical(Sys.getenv("ARTMA_COVERAGE_COBERTURA"), "true")) {
+  covr::to_cobertura(coverage, filename = "cobertura-inst.xml")
+  cli::cli_alert_success("Wrote {.file cobertura-inst.xml}")
+}
+
+rds_path <- Sys.getenv("ARTMA_COVERAGE_RDS")
+if (nzchar(rds_path)) {
+  saveRDS(coverage, rds_path)
+  cli::cli_alert_success("Saved coverage object to {.file {rds_path}}")
+}


### PR DESCRIPTION
## Why

`covr::package_coverage()` only instruments `R/` and `src/`, so the Codecov badge reported ~50% while the 105 analytical modules under `inst/artma` (loaded via `box::use()`) were invisible to coverage entirely. Their real coverage is ~75%.

## What

- **`scripts/R/inst_coverage.R`**: traces box module namespace environments with covr's tracer, then runs the testthat suite once (sequentially; covr counters are in-process). Every `inst/artma` module is force-loaded first so untested files count in the denominator. Uses non-exported covr/box internals, guarded up front with a clear error naming the version if a bump removes them.
- **CI (`test-coverage.yaml`)**: keeps the existing `package_coverage` report (R/ + C++ via gcov) and adds `cobertura-inst.xml`; both upload to Codecov, which merges them into one whole-package number. The existing `R` / `inst` components in `codecov.yml` split them for drill-down.
- **`make coverage`** now prints the inst/artma per-file table (primary local metric); `make coverage-report` opens the interactive report on the same object.
- `pkgload` added to `Config/Needs/coverage`; report artifacts gitignored.

## Numbers

Local run: 74.79% line coverage across inst/artma (13,291 lines valid, 9,941 covered). Notable gaps surfaced: `methods/maive.R` at 1%, `data_config/parse.R` and `data_config/utils.R` at 0%.

## Verification

- `make coverage` prints the full per-file table and writes valid repo-relative cobertura XML under `ARTMA_COVERAGE_COBERTURA=true`
- Full test suite ran green inside the traced run
- New script passes lintr and styler

🤖 Generated with [Claude Code](https://claude.com/claude-code)