### PR TITLE
fix(data): guard imputation of mostly-missing columns and drop constant BMA moderators

### DIFF
--- a/inst/artma/data/na_handling.R
+++ b/inst/artma/data/na_handling.R
@@ -93,12 +93,13 @@ handle_na_remove <- function(df) {
 #' @param df *\[data.frame\]* The data frame to process
 #' @param stat_fun *\[function\]* Summary function applied with `na.rm = TRUE`
 #' @param strategy *\[character\]* Strategy label used in messages
+#' @param exclude_cols *\[character, optional\]* Columns to leave unimputed
 #' @return *\[data.frame\]* The data frame with imputed values
 #' @keywords internal
-impute_with_column_stat <- function(df, stat_fun, strategy) {
+impute_with_column_stat <- function(df, stat_fun, strategy, exclude_cols = character(0)) {
   imputed_count <- 0
 
-  for (col in colnames(df)) {
+  for (col in setdiff(colnames(df), exclude_cols)) {
     if (is.numeric(df[[col]]) && any(is.na(df[[col]]))) {
       na_indices <- is.na(df[[col]])
       stat_val <- stat_fun(df[[col]], na.rm = TRUE)
@@ -124,31 +125,34 @@ impute_with_column_stat <- function(df, stat_fun, strategy) {
 
 #' @title Handle missing values with median imputation
 #' @param df *\[data.frame\]* The data frame to process
+#' @param exclude_cols *\[character, optional\]* Columns to leave unimputed
 #' @return *\[data.frame\]* The data frame with imputed values
 #' @keywords internal
-handle_na_median <- function(df) {
-  impute_with_column_stat(df, stats::median, "median")
+handle_na_median <- function(df, exclude_cols = character(0)) {
+  impute_with_column_stat(df, stats::median, "median", exclude_cols = exclude_cols)
 }
 
 
 #' @title Handle missing values with mean imputation
 #' @param df *\[data.frame\]* The data frame to process
+#' @param exclude_cols *\[character, optional\]* Columns to leave unimputed
 #' @return *\[data.frame\]* The data frame with imputed values
 #' @keywords internal
-handle_na_mean <- function(df) {
-  impute_with_column_stat(df, mean, "mean")
+handle_na_mean <- function(df, exclude_cols = character(0)) {
+  impute_with_column_stat(df, mean, "mean", exclude_cols = exclude_cols)
 }
 
 
 #' @title Handle missing values with linear interpolation
 #' @description Use linear interpolation to fill missing values based on neighboring values. Works on all numeric columns (both required and optional).
 #' @param df *\[data.frame\]* The data frame to process
+#' @param exclude_cols *\[character, optional\]* Columns to leave unimputed
 #' @return *\[data.frame\]* The data frame with interpolated values
 #' @keywords internal
-handle_na_interpolate <- function(df) {
+handle_na_interpolate <- function(df, exclude_cols = character(0)) {
   imputed_count <- 0
 
-  for (col in colnames(df)) {
+  for (col in setdiff(colnames(df), exclude_cols)) {
     if (is.numeric(df[[col]]) && any(is.na(df[[col]]))) {
       na_indices <- is.na(df[[col]])
       initial_na_count <- sum(na_indices)
@@ -196,11 +200,14 @@ handle_na_interpolate <- function(df) {
 #' @title Handle missing values with MICE
 #' @description Use Multiple Imputation by Chained Equations to fill missing values.
 #' Includes automatic detection and exclusion of problematic columns (dummy groups,
-#' near-zero variance, high-NA) to prevent singularity errors.
+#' near-zero variance) to prevent singularity errors.
 #' @param df *\[data.frame\]* The data frame to process
+#' @param exclude_cols *\[character, optional\]* Columns to leave unimputed and
+#'   keep out of the MICE predictor set (e.g. mostly-missing columns caught by
+#'   the missingness-ratio guard)
 #' @return *\[data.frame\]* The data frame with imputed values
 #' @keywords internal
-handle_na_mice <- function(df) {
+handle_na_mice <- function(df, exclude_cols = character(0)) {
   box::use(artma / data / profile[detect_dummy_groups])
 
   if (!requireNamespace("mice", quietly = TRUE)) {
@@ -227,7 +234,7 @@ handle_na_mice <- function(df) {
   # --- Pre-MICE validation: detect problematic columns ---
 
   df_for_mice <- df
-  excluded_cols <- character(0)
+  excluded_cols <- exclude_cols
   dummy_groups <- data.frame()
 
   # 1. Detect dummy groups (e.g., gender_male/gender_female) - exclude non-reference
@@ -264,35 +271,13 @@ handle_na_mice <- function(df) {
     }
   }
 
-  # 3. Detect high-NA columns (>80% missing) - impute separately with median
-  high_na_threshold <- 0.8
-  high_na_cols <- vapply(cols_with_na, function(col) {
-    mean(is.na(df[[col]])) > high_na_threshold
-  }, logical(1))
-  high_na_col_names <- cols_with_na[high_na_cols]
-  if (length(high_na_col_names) > 0) {
-    excluded_cols <- c(excluded_cols, high_na_col_names)
-    if (get_verbosity() >= 3) {
-      cli::cli_alert_info(
-        "Excluding {length(high_na_col_names)} high-NA column{?s} (>{high_na_threshold * 100}% missing) from MICE: {.val {high_na_col_names}}"
-      )
-    }
-    # Pre-impute high-NA columns with median
-    for (col in high_na_col_names) {
-      col_median <- stats::median(df[[col]], na.rm = TRUE)
-      if (!is.na(col_median)) {
-        df[[col]][is.na(df[[col]])] <- col_median
-      }
-    }
-  }
-
   # Remove excluded columns from MICE predictor set
   excluded_cols <- unique(excluded_cols)
   keep_cols <- setdiff(colnames(df), excluded_cols)
   df_for_mice <- df[, keep_cols, drop = FALSE]
 
   # Update cols_with_na to exclude already-handled columns
-  cols_to_impute <- setdiff(cols_with_na, c(high_na_col_names, excluded_cols))
+  cols_to_impute <- setdiff(cols_with_na, excluded_cols)
   cols_to_impute <- intersect(cols_to_impute, keep_cols)
 
   if (length(cols_to_impute) == 0) {
@@ -321,13 +306,13 @@ handle_na_mice <- function(df) {
         }
         return(NULL)
       }
-      cli::cli_abort(e)
+      cli::cli_abort("MICE imputation failed: {conditionMessage(e)}")
     }
   )
 
   # Fallback to median if MICE failed
   if (is.null(mice_obj)) {
-    return(handle_na_median(df))
+    return(handle_na_median(df, exclude_cols = exclude_cols))
   }
 
   # Extract completed dataset and update original
@@ -378,6 +363,27 @@ handle_na_mice <- function(df) {
 }
 
 
+#' @title Identify columns too missing to impute
+#' @description Find optional numeric columns whose share of missing values
+#'   exceeds `threshold`. Imputing such columns collapses them to a
+#'   near-constant (e.g. a column with one valid value median-imputes into a
+#'   constant), so they are better left unimputed. Required numeric columns are
+#'   exempt: leaving them missing would break the analysis downstream.
+#' @param df *\[data.frame\]* The data frame to analyze
+#' @param threshold *\[numeric\]* Maximum tolerated missingness ratio in \[0, 1\]
+#' @return *\[numeric\]* Named vector of missingness ratios, one entry per
+#'   column exceeding the threshold
+#' @keywords internal
+identify_unimputable_columns <- function(df, threshold) {
+  optional_numeric <- setdiff(
+    colnames(df)[vapply(df, is.numeric, logical(1))],
+    get_required_colnames()
+  )
+  ratios <- vapply(optional_numeric, function(col) mean(is.na(df[[col]])), numeric(1))
+  ratios[ratios > threshold]
+}
+
+
 #' @title Handle missing values
 #' @description Main function to handle missing values according to the selected strategy.
 #'
@@ -386,13 +392,18 @@ handle_na_mice <- function(df) {
 #' - Numeric required columns (e.g., effect, se, n_obs) can be imputed if a non-"stop" strategy is selected
 #' - Optional columns are handled according to the selected strategy
 #'
+#' Imputation strategies skip optional numeric columns whose missingness ratio
+#' exceeds `artma.data.max_imputation_missingness`; those columns keep their
+#' missing values and a warning is emitted.
+#'
 #' @param df *\[data.frame\]* The data frame to process
 #' @return *\[data.frame\]* The processed data frame
 #' @keywords internal
 handle_missing_values <- function(df) {
   box::use(
     artma / const[CONST],
-    artma / options / typed_accessors[get_na_handling]
+    artma / libs / core / validation[assert],
+    artma / options / typed_accessors[get_na_handling, get_max_imputation_missingness]
   )
 
   # Detect missing values
@@ -477,6 +488,32 @@ handle_missing_values <- function(df) {
     cli::cli_alert_warning("Missing values detected in optional columns: {optional_cols_msg}")
   }
 
+  # Missingness-ratio guard: mostly-missing optional columns are left as-is
+  # instead of being imputed into near-constants.
+  skip_cols <- character(0)
+  if (na_handling %in% c("median", "mean", "interpolate", "mice")) {
+    max_missingness <- get_max_imputation_missingness()
+    assert(
+      is.numeric(max_missingness) && length(max_missingness) == 1 &&
+        !is.na(max_missingness) && max_missingness >= 0 && max_missingness <= 1,
+      "The option 'artma.data.max_imputation_missingness' must be a single number between 0 and 1."
+    )
+    skip_ratios <- identify_unimputable_columns(df, max_missingness)
+    skip_cols <- names(skip_ratios)
+    if (length(skip_cols) > 0 && get_verbosity() >= 2) {
+      skip_msg <- paste0(
+        skip_cols, " (", round(skip_ratios * 100, 1), "% missing)",
+        collapse = ", "
+      )
+      cli::cli_alert_warning(
+        "Skipping imputation for {length(skip_cols)} column{?s} with more than {.val {max_missingness * 100}%} missing values: {skip_msg}."
+      )
+      cli::cli_alert_info(
+        "These columns keep their missing values; adjust {.field artma.data.max_imputation_missingness} to change this."
+      )
+    }
+  }
+
   # Apply the selected strategy
   df_processed <- switch(na_handling,
     "stop" = {
@@ -488,10 +525,10 @@ handle_missing_values <- function(df) {
       ))
     },
     "remove" = handle_na_remove(df),
-    "median" = handle_na_median(df),
-    "mean" = handle_na_mean(df),
-    "interpolate" = handle_na_interpolate(df),
-    "mice" = handle_na_mice(df),
+    "median" = handle_na_median(df, exclude_cols = skip_cols),
+    "mean" = handle_na_mean(df, exclude_cols = skip_cols),
+    "interpolate" = handle_na_interpolate(df, exclude_cols = skip_cols),
+    "mice" = handle_na_mice(df, exclude_cols = skip_cols),
     {
       cli::cli_abort("Unknown missing value handling strategy: {.val {na_handling}}")
     }

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -262,6 +262,21 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
     bma_vars <- bma_vars[bma_vars %in% names(df)]
   }
 
+  # Constant columns carry no moderator information, and scaling one yields an
+  # all-NaN column that na.omit would then use to drop every observation.
+  constant_vars <- bma_vars[vapply(bma_vars, function(v) {
+    vals <- df[[v]]
+    length(unique(vals[!is.na(vals)])) <= 1L
+  }, logical(1))]
+  if (length(constant_vars)) {
+    if (verbosity >= 2) {
+      cli::cli_alert_warning(
+        "Excluding {length(constant_vars)} constant (zero-variance) variable{?s} from the BMA moderator set: {.val {constant_vars}}"
+      )
+    }
+    bma_vars <- setdiff(bma_vars, constant_vars)
+  }
+
   if (!length(bma_vars)) {
     return(list(skipped = "No valid BMA variables available"))
   }

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -902,6 +902,19 @@ data:
 
       If this option is not set (NA), you will be prompted interactively when missing values are detected.
 
+  max_imputation_missingness:
+    type: "numeric"
+    default: 0.5
+    help: |
+      Maximum share of missing values an optional numeric column may have and
+      still be imputed by the {.val median}, {.val mean}, {.val interpolate},
+      and {.val mice} strategies. Columns above the threshold keep their
+      missing values and are reported with a warning: imputing a mostly-missing
+      column collapses it to a near-constant, which can then distort moderator
+      sets (e.g. in BMA). Required numeric columns (effect, se, n_obs) are
+      always imputed regardless of this threshold, since leaving them missing
+      would break the analysis. Set to 1 to disable the guard.
+
   columns:
     type: "list"
     default: .na

--- a/inst/artma/options/typed_accessors.R
+++ b/inst/artma/options/typed_accessors.R
@@ -125,6 +125,16 @@ get_na_handling <- function() {
   opt_or("artma.data.na_handling", NA_HANDLING_DEFAULT)
 }
 
+#' @title Maximum imputation missingness accessor
+#' @description The maximum share of missing values an optional numeric column
+#'   may have and still be imputed. Falls back to the template-declared default
+#'   when unset.
+#' @return *\[numeric\]* The missingness-ratio threshold in \[0, 1\].
+#' @keywords internal
+get_max_imputation_missingness <- function() {
+  getOption("artma.data.max_imputation_missingness", option_template_default("artma.data.max_imputation_missingness"))
+}
+
 #' @title Zero-standard-error handling strategy accessor
 #' @description The strategy for handling zero standard errors in the compute
 #'   phase. Resolves the `.na` template sentinel to the documented `"remove"`
@@ -140,6 +150,7 @@ box::export(
   get_precision_type,
   get_winsorization_level,
   get_na_handling,
+  get_max_imputation_missingness,
   get_se_zero_handling,
   NA_HANDLING_DEFAULT,
   SE_ZERO_HANDLING_DEFAULT

--- a/tests/testthat/test-bma.R
+++ b/tests/testthat/test-bma.R
@@ -4,6 +4,7 @@ box::use(
     expect_false,
     expect_length,
     expect_match,
+    expect_message,
     expect_named,
     expect_null,
     expect_true,
@@ -337,4 +338,51 @@ test_that("bma skips with an explanatory reason instead of crashing on a single 
   expect_equal(nrow(result$tables$coefficients), 0)
   expect_true(is.null(result$meta$model))
   expect_match(result$meta$skipped, "at least 2 candidate moderator variables")
+})
+
+test_that("prepare_bma_inputs excludes constant moderators before scaling", {
+  local_options(list("artma.verbose" = 1))
+
+  df <- make_demo_bma_data()
+  # A constant column (the shape an over-imputed, mostly-missing column takes)
+  # would scale to all-NaN and let na.omit drop every observation.
+  df$const_mod <- 1
+  config <- list(
+    se = list(var_name = "se", bma = TRUE),
+    moderator1 = list(var_name = "moderator1", bma = TRUE),
+    const_mod = list(var_name = "const_mod", bma = TRUE)
+  )
+
+  prepared <- prepare_bma_inputs(
+    df, config,
+    use_vif_optimization = FALSE,
+    max_groups_to_remove = 3,
+    verbosity = 1
+  )
+
+  expect_true(is.null(prepared$skipped))
+  expect_false("const_mod" %in% colnames(prepared$bma_data))
+  expect_true(all(c("effect", "se", "moderator1") %in% colnames(prepared$bma_data)))
+  expect_true(nrow(prepared$bma_data) > 0)
+})
+
+test_that("prepare_bma_inputs warns about the excluded constant moderator", {
+  local_options(list("artma.verbose" = 1))
+
+  df <- make_demo_bma_data()
+  df$const_mod <- 1
+  config <- list(
+    moderator1 = list(var_name = "moderator1", bma = TRUE),
+    const_mod = list(var_name = "const_mod", bma = TRUE)
+  )
+
+  expect_message(
+    prepare_bma_inputs(
+      df, config,
+      use_vif_optimization = FALSE,
+      max_groups_to_remove = 3,
+      verbosity = 2
+    ),
+    "constant"
+  )
 })

--- a/tests/testthat/test-data-na-handling.R
+++ b/tests/testthat/test-data-na-handling.R
@@ -2,6 +2,8 @@ box::use(
   testthat[
     expect_equal,
     expect_error,
+    expect_false,
+    expect_message,
     expect_true,
     test_that
   ],
@@ -155,4 +157,143 @@ test_that("'median' imputes NAs in numeric required columns", {
 
   expect_equal(nrow(result), 3)
   expect_equal(result$effect[2], stats::median(c(0.1, 0.3)))
+})
+
+# -- missingness-ratio guard ---------------------------------------------------
+
+# 10-row frame with a mostly-missing (90%) and a lightly-missing (10%) optional
+# numeric column, so the default 0.5 guard splits them.
+make_guard_df <- function() {
+  data.frame(
+    study_id = rep(c("a", "b"), each = 5),
+    effect = seq(0.1, 1, length.out = 10),
+    se = seq(0.01, 0.1, length.out = 10),
+    n_obs = seq(10L, 100L, by = 10L),
+    mod_sparse = c(1.5, rep(NA_real_, 9)),
+    mod_dense = c(NA_real_, as.numeric(2:10)),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("imputation skips optional columns above the missingness threshold", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "median",
+    "artma.verbose" = 1
+  ))
+
+  result <- handle_missing_values(make_guard_df())
+
+  expect_equal(sum(is.na(result$mod_sparse)), 9)
+  expect_false(anyNA(result$mod_dense))
+})
+
+test_that("the missingness threshold is configurable via options", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "median",
+    "artma.data.max_imputation_missingness" = 0.95,
+    "artma.verbose" = 1
+  ))
+
+  result <- handle_missing_values(make_guard_df())
+
+  expect_false(anyNA(result$mod_sparse))
+  expect_equal(result$mod_sparse[2], 1.5)
+})
+
+test_that("a column exactly at the threshold is still imputed", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "median",
+    "artma.verbose" = 1
+  ))
+
+  df <- make_guard_df()
+  df$mod_half <- c(as.numeric(1:5), rep(NA_real_, 5))
+  result <- handle_missing_values(df)
+
+  expect_false(anyNA(result$mod_half))
+})
+
+test_that("required numeric columns are imputed regardless of the threshold", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "median",
+    "artma.verbose" = 1
+  ))
+
+  df <- make_guard_df()
+  df$effect[1:6] <- NA_real_
+  result <- handle_missing_values(df)
+
+  expect_false(anyNA(result$effect))
+})
+
+test_that("'interpolate' also honors the missingness guard", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "interpolate",
+    "artma.verbose" = 1
+  ))
+
+  result <- handle_missing_values(make_guard_df())
+
+  # Pre-guard, a single-valid-value column fell back to median imputation and
+  # became a constant; now it must keep its missing values.
+  expect_equal(sum(is.na(result$mod_sparse)), 9)
+  expect_false(anyNA(result$mod_dense))
+})
+
+test_that("the guard emits a warning naming the skipped columns", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "median",
+    "artma.verbose" = 2
+  ))
+
+  expect_message(
+    handle_missing_values(make_guard_df()),
+    "Skipping imputation"
+  )
+})
+
+test_that("an invalid threshold option aborts with a clear message", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "median",
+    "artma.data.max_imputation_missingness" = 1.5,
+    "artma.verbose" = 1
+  ))
+
+  expect_error(
+    handle_missing_values(make_guard_df()),
+    "max_imputation_missingness"
+  )
+})
+
+test_that("'mice' leaves guarded columns unimputed", {
+  box::use(artma / data / na_handling[handle_missing_values])
+  testthat::skip_if_not_installed("mice")
+
+  local_options(list(
+    "artma.data.na_handling" = "mice",
+    "artma.verbose" = 1
+  ))
+
+  # mice reads .Random.seed from the global environment and errors when the
+  # RNG was never initialized on this worker.
+  set.seed(42)
+  df <- rbind(make_guard_df(), make_guard_df())
+  result <- handle_missing_values(df)
+
+  expect_equal(sum(is.na(result$mod_sparse)), 18)
+  expect_false(anyNA(result$mod_dense))
 })


### PR DESCRIPTION
## Problem

The missing-value handling step imputed columns that are almost entirely missing. Observed with the bachelor-thesis dataset: `t_adjusted` had 1 valid value out of 1655 rows, fell back from interpolation to median imputation, and became a constant column that was then flagged as a BMA moderator. A constant moderator also scales to all-NaN in `get_bma_data`, after which `na.omit` can drop every observation.

## Changes

- New option `data.max_imputation_missingness` (default 0.5): optional numeric columns whose missingness ratio exceeds the threshold are left unimputed by the `median`, `mean`, `interpolate`, and `mice` strategies, with a cli warning naming the skipped columns and their missingness. Required numeric columns (effect, se, n_obs) are exempt, since leaving them missing would break the analysis; set the threshold to 1 to disable the guard.
- Typed accessor `get_max_imputation_missingness()` sourcing its fallback from the options template, following the existing pattern.
- `handle_na_mice` now routes high-NA exclusion through the shared guard instead of its internal 0.8 threshold, and no longer median pre-imputes those columns (that pre-impute was the exact constant-column failure mode). Also fixed its error handler, which passed a condition object to `cli::cli_abort()` and masked the real MICE error.
- `prepare_bma_inputs` excludes constant (zero-variance) variables from the BMA moderator set up front, with a warning, before scaling can turn them into all-NaN columns.

## Tests

- Guard behavior under `median`, `interpolate`, and `mice`: mostly-missing optional columns keep their NAs, lightly-missing ones are imputed; the threshold is configurable; a column exactly at the threshold is still imputed; required columns stay exempt; invalid threshold values abort; the warning names the skipped columns.
- `prepare_bma_inputs` drops a constant moderator, keeps the rest, and warns about the exclusion.

Full suite: 2432 passing, 0 failures. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)