### PR TITLE
fix(run): pin BLAS/OpenMP to one thread while forking method layers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Suggests:
     rddensity (>= 2.5),
     readxl (>= 1.4.0),
     rex (>= 1.2.1),
+    RhpcBLASctl (>= 0.23-42),
     rjags (>= 4.15),
     rmarkdown (>= 2.30),
     RoBMA (>= 4.0.0),

--- a/inst/artma/modules/method_execution.R
+++ b/inst/artma/modules/method_execution.R
@@ -17,7 +17,9 @@ box::use(
   artma / libs / core / autonomy[get_autonomy_level, get_default_autonomy_level],
   artma / libs / core / utils[opt_or],
   artma / libs / core / validation[assert],
-  artma / visualization / fork_safety[graphics_survive_fork, in_forked_worker, with_forked_worker_flag]
+  artma / visualization / fork_safety[
+    graphics_survive_fork, in_forked_worker, with_forked_worker_flag, with_single_threaded_blas
+  ]
 )
 
 #' @title Group methods into dependency layers
@@ -350,13 +352,13 @@ execute_method_layer <- function(method_names, run_one, streams = list(), worker
   }
 
   if (workers > 1L) {
-    outcomes <- parallel::mclapply(
+    outcomes <- with_single_threaded_blas(parallel::mclapply(
       method_names,
       function(method_name) with_forked_worker_flag(run_task(method_name)),
       mc.cores = workers,
       mc.preschedule = FALSE,
       mc.set.seed = TRUE
-    )
+    ))
     # A worker that dies outright rather than signalling an R error comes back
     # as a try-error, or as NULL when the child was killed before it could
     # answer at all. Neither carries a usable message, so describe what

--- a/inst/artma/visualization/fork_safety.R
+++ b/inst/artma/visualization/fork_safety.R
@@ -128,6 +128,48 @@ use_fork_safe_png_device <- function() {
   in_forked_worker() && graphics_fork_is_hostile() && fork_safe_png_available()
 }
 
+#' @title Run an expression with BLAS/OpenMP pinned to one thread per process
+#' @description
+#' Forking while a multithreaded BLAS/OpenMP backend (OpenBLAS, Apple's
+#' Accelerate/vecLib) already has worker threads running is a well-known
+#' deadlock hazard: `fork()` duplicates only the calling thread, so a mutex
+#' another BLAS thread held at fork time is held forever in the child, which
+#' then hangs on its first BLAS call with no error. Even short of a deadlock,
+#' every forked worker would otherwise try to use every core for its own BLAS
+#' calls, oversubscribing the machine badly enough to look like a hang. Pins
+#' both to a single thread for the duration of `expr` and restores the
+#' previous count afterwards; a no-op when {RhpcBLASctl} is not installed,
+#' since without it there is no reliable way to reconfigure an
+#' already-initialised BLAS library from R.
+#' @param expr *\[any\]* Expression to evaluate.
+#' @return The value of `expr`.
+#' @keywords internal
+with_single_threaded_blas <- function(expr) {
+  if (!requireNamespace("RhpcBLASctl", quietly = TRUE)) {
+    return(expr)
+  }
+
+  # BLAS libraries expose no getter for their currently configured thread
+  # count, only the number of procs they can see, so that stands in as the
+  # restore target: "let it use everything again" rather than an exact
+  # rollback. OpenMP's runtime does expose the real current value, so that one
+  # is captured and restored precisely.
+  full_blas_threads <- RhpcBLASctl::blas_get_num_procs()
+  previous_omp_threads <- RhpcBLASctl::omp_get_max_threads()
+
+  RhpcBLASctl::blas_set_num_threads(1L)
+  RhpcBLASctl::omp_set_num_threads(1L)
+  on.exit(
+    {
+      RhpcBLASctl::blas_set_num_threads(full_blas_threads)
+      RhpcBLASctl::omp_set_num_threads(previous_omp_threads)
+    },
+    add = TRUE
+  )
+
+  expr
+}
+
 #' @title Evaluate an expression with the forked-worker flag set
 #' @description
 #' Marks the current process as a forked method worker so the graphics helpers
@@ -184,5 +226,6 @@ box::export(
   in_forked_worker,
   probe_cairo_png,
   use_fork_safe_png_device,
-  with_forked_worker_flag
+  with_forked_worker_flag,
+  with_single_threaded_blas
 )

--- a/tests/testthat/test-method-execution.R
+++ b/tests/testthat/test-method-execution.R
@@ -8,6 +8,7 @@ box::use(
     expect_null,
     expect_true,
     skip_if,
+    skip_if_not_installed,
     test_that
   ]
 )
@@ -324,6 +325,35 @@ test_that("execute_method_layer explains a worker that died without an error", {
   expect_null(outcomes[[2L]]$value)
   expect_true(nzchar(outcomes[[2L]]$error))
   expect_match(outcomes[[2L]]$error, "b", fixed = TRUE)
+})
+
+test_that("execute_method_layer pins BLAS/OpenMP to one thread only while forking", {
+  box::use(artma / modules / method_execution[execute_method_layer])
+
+  skip_if(!can_fork(), "forking is unavailable")
+  skip_if_not_installed("RhpcBLASctl")
+  # RhpcBLASctl reports NA for every OpenMP query when R itself was not built
+  # with OpenMP support (common on macOS toolchains); there is nothing to
+  # verify restored in that case, but the layer must still run correctly.
+  has_omp <- !is.na(RhpcBLASctl::omp_get_max_threads())
+
+  if (has_omp) {
+    RhpcBLASctl::omp_set_num_threads(2L)
+    withr::defer(RhpcBLASctl::omp_set_num_threads(RhpcBLASctl::omp_get_num_procs()))
+  }
+
+  outcomes <- execute_method_layer(
+    c("a", "b"),
+    run_one = function(name) name,
+    workers = 2L
+  )
+
+  expect_equal(vapply(outcomes, function(o) o$value, character(1)), c("a", "b"))
+  if (has_omp) {
+    # The pin-and-restore happens around `mclapply()` in the parent process,
+    # so the parent's own thread count is unaffected once the layer returns.
+    expect_equal(RhpcBLASctl::omp_get_max_threads(), 2L)
+  }
 })
 
 test_that("execute_method_layer captures output from forked workers", {

--- a/tests/testthat/test-visualization-fork-safety.R
+++ b/tests/testthat/test-visualization-fork-safety.R
@@ -1,10 +1,12 @@
 box::use(
   testthat[
     expect_equal,
+    expect_error,
     expect_false,
     expect_null,
     expect_true,
     skip_if,
+    skip_if_not_installed,
     test_that
   ]
 )
@@ -205,6 +207,33 @@ test_that("resolve_worker_count stays sequential when a fork cannot draw", {
     ),
     4L
   )
+})
+
+test_that("with_single_threaded_blas evaluates and returns expr's value", {
+  box::use(artma / visualization / fork_safety[with_single_threaded_blas])
+
+  expect_equal(with_single_threaded_blas(1 + 1), 2)
+  expect_error(with_single_threaded_blas(stop("boom")), "boom")
+})
+
+test_that("with_single_threaded_blas pins BLAS/OpenMP to one thread and restores them", {
+  box::use(artma / visualization / fork_safety[with_single_threaded_blas])
+
+  skip_if_not_installed("RhpcBLASctl")
+  # RhpcBLASctl reports NA for every OpenMP query when R itself was not built
+  # with OpenMP support (common on macOS toolchains); there is nothing to pin
+  # or restore in that case.
+  skip_if(is.na(RhpcBLASctl::omp_get_max_threads()), "R was not built with OpenMP support")
+
+  # Start from a known, non-default OpenMP thread count so restoration can be
+  # told apart from the pinned-down value used during `expr`.
+  RhpcBLASctl::omp_set_num_threads(2L)
+  withr::defer(RhpcBLASctl::omp_set_num_threads(RhpcBLASctl::omp_get_num_procs()))
+
+  during <- with_single_threaded_blas(RhpcBLASctl::omp_get_max_threads())
+
+  expect_equal(during, 1L)
+  expect_equal(RhpcBLASctl::omp_get_max_threads(), 2L)
 })
 
 test_that("resolve_worker_count ignores fork-unsafe graphics when not exporting", {


### PR DESCRIPTION
## Summary

Selecting 2+ independent runtime methods interactively forks each into its own worker via `parallel::mclapply()` (`execute_method_layer()` in `inst/artma/modules/method_execution.R`). A single selected method always runs sequentially, which is why that path looked fine while multi-method runs appeared to freeze indefinitely.

Forking a process while a multithreaded BLAS/OpenMP backend (OpenBLAS, Apple's Accelerate/vecLib) already has worker threads running is a known deadlock hazard: `fork()` only duplicates the calling thread, so a mutex another BLAS thread held at fork time is held forever in the child, which then hangs on its first BLAS call with no error and no output (all console output for a layer is buffered and only replayed once every forked worker returns, so this reads as a total, silent freeze). Even short of an outright deadlock, every forked worker trying to use every core for its own BLAS calls badly oversubscribes the machine, which alone can make a run look like it never finishes.

## Change

- Adds `with_single_threaded_blas()` to `inst/artma/visualization/fork_safety.R`, which pins BLAS and OpenMP to one thread per process around the `mclapply()` call and restores the previous count afterwards. It's a no-op when `{RhpcBLASctl}` isn't installed, added as a new `Suggests` dependency, since there's no reliable way to reconfigure an already-initialised BLAS library from R without it.
- Wires it around the `mclapply()` call in `execute_method_layer()`.

## Test plan

- [x] `make test` — 0 failures (2418 passed, 1 pre-existing skip plus a new skip for the OpenMP-specific assertion on this machine, whose R build lacks OpenMP support)
- [x] `make lint` — no lints
- [x] `styler::style_file()` on all changed files — no changes needed
- [x] New unit tests for `with_single_threaded_blas()` (pin + restore, and a graceful no-op when `RhpcBLASctl`/OpenMP is unavailable)
- [x] New integration test confirming `execute_method_layer()` with 2 forked workers still produces correct results and restores the parent's thread count