### PR TITLE
fix(viz): skip plot previews in forked workers to avoid quartz fork crash

### DIFF
--- a/inst/artma/methods/box_plot.R
+++ b/inst/artma/methods/box_plot.R
@@ -13,7 +13,7 @@ box_plot <- function(df) {
     artma / options / index[get_option_group],
     artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[export_named_plots]
+    artma / visualization / export[export_named_plots, preview_plot]
   )
 
   validate(is.data.frame(df))
@@ -80,7 +80,7 @@ box_plot <- function(df) {
       if (n_plots > 1) {
         cli::cli_alert_info("Displaying plot {i}/{n_plots}")
       }
-      suppressWarnings(print(result$plots[[i]])) # nolint: undesirable_function_linter.
+      preview_plot(result$plots[[i]])
     }
   }
 

--- a/inst/artma/methods/funnel_plot.R
+++ b/inst/artma/methods/funnel_plot.R
@@ -11,7 +11,7 @@ funnel_plot <- function(df) {
     artma / options / index[get_option_group],
     artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[export_named_plots]
+    artma / visualization / export[export_named_plots, preview_plot]
   )
 
   validate(is.data.frame(df))
@@ -117,7 +117,7 @@ funnel_plot <- function(df) {
 
   if (get_verbosity() >= 3) {
     cli::cli_h3("Funnel Plot: Effect vs Precision")
-    suppressWarnings(print(plot)) # nolint: undesirable_function_linter.
+    preview_plot(plot)
   }
 
   if (export_graphics) {

--- a/inst/artma/methods/prima_facie_graphs.R
+++ b/inst/artma/methods/prima_facie_graphs.R
@@ -14,7 +14,7 @@ prima_facie_graphs <- function(df) {
     artma / options / resolver[opt_spec, resolve_options],
     artma / variable / detection[detect_variable_groups],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[export_named_plots]
+    artma / visualization / export[export_named_plots, preview_plot]
   )
 
   validate(is.data.frame(df))
@@ -111,7 +111,7 @@ prima_facie_graphs <- function(df) {
           "Displaying plot {i}/{length(plots)}: {.field {names(plots)[i]}}"
         )
       }
-      suppressWarnings(print(plots[[i]])) # nolint: undesirable_function_linter.
+      preview_plot(plots[[i]])
     }
   }
 

--- a/inst/artma/methods/t_stat_histogram.R
+++ b/inst/artma/methods/t_stat_histogram.R
@@ -14,7 +14,7 @@ t_stat_histogram <- function(df) {
     artma / options / index[get_option_group],
     artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[export_named_plots]
+    artma / visualization / export[export_named_plots, preview_plot]
   )
 
   validate(is.data.frame(df))
@@ -109,7 +109,7 @@ t_stat_histogram <- function(df) {
         lower_cutoff, ", ", upper_cutoff, "] excluded"
       ))
     }
-    suppressWarnings(print(main_result$plot)) # nolint: undesirable_function_linter.
+    preview_plot(main_result$plot)
   }
 
   # Build the close-up plot (if enabled)
@@ -133,7 +133,7 @@ t_stat_histogram <- function(df) {
         "T-Statistic Distribution (Close-up: [",
         close_up_lower, ", ", close_up_upper, "])"
       ))
-      suppressWarnings(print(close_up_result$plot)) # nolint: undesirable_function_linter.
+      preview_plot(close_up_result$plot)
     }
   }
 

--- a/inst/artma/visualization/export.R
+++ b/inst/artma/visualization/export.R
@@ -115,6 +115,31 @@ open_png_device <- function(path, width, height, units = "px", res = 90) {
 }
 
 
+#' Print a plot to the interactive device, unless inside a forked worker
+#'
+#' @description
+#' Methods preview their plots at verbosity >= 3 by printing them, which opens
+#' the session's default interactive device. In a forked method worker that
+#' device must not be touched: on macOS it is quartz, whose Objective-C runtime
+#' aborts a forked child outright (killing the method before its file exports
+#' run), and on other platforms each child would pop its own on-screen device.
+#' Previews are therefore skipped inside forked workers; file exports are
+#' unaffected.
+#'
+#' @param plot *\[any\]* A printable plot object. `NULL` is skipped.
+#' @return NULL (invisibly)
+preview_plot <- function(plot) {
+  box::use(artma / visualization / fork_safety[in_forked_worker])
+
+  if (is.null(plot) || in_forked_worker()) {
+    return(invisible(NULL))
+  }
+
+  suppressWarnings(print(plot)) # nolint: undesirable_function_linter.
+  invisible(NULL)
+}
+
+
 #' Save a ggplot2 plot to file
 #'
 #' @description
@@ -380,6 +405,7 @@ box::export(
   ensure_export_dir,
   build_export_filename,
   open_png_device,
+  preview_plot,
   save_plot,
   save_plot_html,
   export_base_plot,

--- a/tests/testthat/test-visualization-fork-safety.R
+++ b/tests/testthat/test-visualization-fork-safety.R
@@ -250,3 +250,66 @@ test_that("resolve_worker_count ignores fork-unsafe graphics when not exporting"
     4L
   )
 })
+
+test_that("preview_plot prints in the parent but not inside a forked worker", {
+  box::use(
+    artma / visualization / export[preview_plot],
+    artma / visualization / fork_safety[with_forked_worker_flag]
+  )
+
+  # `preview_plot()` calls `print()` from inside a box module, whose scope
+  # chain bypasses the global environment, so the probe method must go through
+  # the S3 registration table to be dispatched. The registration is process
+  # local and the class is fake, so no cleanup is needed.
+  calls <- new.env(parent = emptyenv())
+  calls$n <- 0L
+  registerS3method(
+    "print", "artma_preview_probe",
+    function(x, ...) {
+      calls$n <- calls$n + 1L
+      invisible(x)
+    },
+    envir = globalenv()
+  )
+
+  probe <- structure(list(), class = "artma_preview_probe")
+
+  with_forked_worker_flag(preview_plot(probe))
+  expect_equal(calls$n, 0L)
+
+  preview_plot(probe)
+  expect_equal(calls$n, 1L)
+
+  expect_null(preview_plot(NULL))
+  expect_equal(calls$n, 1L)
+})
+
+test_that("a forked worker previewing a plot survives", {
+  box::use(
+    artma / modules / method_execution[execute_method_layer],
+    artma / visualization / export[preview_plot]
+  )
+
+  skip_if(!can_fork(), "forking is unavailable")
+
+  # The regression: methods previewed plots at verbosity >= 3 with a bare
+  # `print()`, which opens the default interactive device. On macOS that is
+  # quartz, and the Objective-C runtime kills a forked child that touches it,
+  # so the whole method died before its exports ran.
+  plot <- ggplot2::ggplot(data.frame(x = 1:10, y = 1:10), ggplot2::aes(x, y)) +
+    ggplot2::geom_point()
+
+  outcomes <- execute_method_layer(
+    c("first", "second"),
+    run_one = function(name) {
+      preview_plot(plot)
+      name
+    },
+    workers = 2L
+  )
+
+  for (outcome in outcomes) {
+    expect_null(outcome$error)
+  }
+  expect_equal(vapply(outcomes, function(o) o$value, character(1)), c("first", "second"))
+})


### PR DESCRIPTION
## Problem

Running 2+ methods in an interactive macOS session (parallel layer via mclapply) killed any plot-exporting method:

```
objc[89068]: +[NSPlaceholderMutableString initialize] may have been in progress in another thread when fork() was called.
...
✖ Failed: funnel_plot (the forked worker running 'funnel_plot' died without reporting an error ...)
```

## Cause

At verbosity >= 3, plot methods preview their plots with a bare `print(plot)`. With no device open, that opens R's default interactive device; on macOS that is quartz, and the Objective-C runtime aborts a forked child that touches it. The child died before its file exports ran, so `mclapply()` returned `NULL` and the failure surfaced with no message. The existing fork-safety layer only guards the file-export devices (`save_plot()`, `open_png_device()`), not the on-screen preview.

Reproduced minimally: `parallel::mclapply(1, function(i) { grDevices::quartz(); plot(1) }, mc.cores = 2)` prints the identical objc message and drops the result.

## Fix

New `preview_plot()` in `inst/artma/visualization/export.R`: prints the plot unless running inside a forked worker (`in_forked_worker()`), where any interactive device is off-limits (quartz aborts on macOS; other platforms would pop a device per child). All five preview sites (`funnel_plot`, `prima_facie_graphs`, `box_plot`, `t_stat_histogram` x2) now go through it. File exports are unchanged.

## Tests

- `preview_plot()` prints normally, skips inside a forked worker, skips `NULL`
- a forked layer whose workers call `preview_plot()` on a real ggplot completes without errors (the exact regression scenario)

`make lint` clean; fork-safety + method test files pass (183 assertions across both runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)