### PR TITLE
feat(p-hacking): make Elliott supports configurable and surface Cox-Shi skip reasons

### DIFF
--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -32,6 +32,22 @@ skip_reason <- function(value) {
   attr(value, "reason")
 }
 
+DEFAULT_ELLIOTT_SUPPORTS <- c(0.05, 0.1)
+
+#' @title Result-list key suffix for an Elliott support upper bound
+#' @param p_max *[numeric]* Support upper bound, e.g. `0.05`.
+#' @return *[character]* Suffix such as `"005"` (0.05) or `"01"` (0.1).
+support_key <- function(p_max) {
+  gsub(".", "", format(p_max), fixed = TRUE)
+}
+
+#' @title Display label for an Elliott support upper bound
+#' @param p_max *[numeric]* Support upper bound, e.g. `0.1`.
+#' @return *[character]* Label such as `"0.10"`, always with two decimals.
+support_label <- function(p_max) {
+  format(p_max, nsmall = 2)
+}
+
 # Caliper tests (Gerber & Malhotra, 2008) ---------------------------------
 
 CALIPER_TAILS <- c("auto", "positive", "negative", "absolute")
@@ -547,8 +563,8 @@ run_discontinuity <- function(pvalues, cutoff = 0.05, bandwidth = NULL) {
 #' @title Run Cox-Shi test wrapper
 #' @description
 #' `n_bins` fixes the bin *count*, not the bin *width*, so the same value
-#' applied to the [0, 0.05] and [0, 0.10] windows makes the wider window twice
-#' as coarse. A spike in the p-curve narrower than one bin can be averaged away
+#' applied to nested windows (e.g. [0, 0.05] and [0, 0.10]) makes the wider
+#' window coarser. A spike in the p-curve narrower than one bin can be averaged away
 #' on the wider window while remaining visible on the narrower one, and the two
 #' windows are then not comparable, nor need their p-values be ordered. Compare
 #' windows at a matched bin width (double `n_bins` when doubling `p_max`)
@@ -611,12 +627,18 @@ run_p_hacking_tests <- function(df, options) {
   t_stats <- resolve_t_stats(df)
   pvalues <- 2 * stats::pnorm(-abs(t_stats))
 
+  supports <- options$elliott_supports %||% DEFAULT_ELLIOTT_SUPPORTS
+  validate(is.numeric(supports))
+  assert(length(supports) > 0, "elliott_supports must not be empty")
+  assert(all(supports > 0 & supports <= 1), "elliott_supports must lie in (0, 1]")
+  assert(!is.unsorted(supports, strictly = TRUE), "elliott_supports must be strictly increasing")
+
   output <- list()
   skipped <- list()
-  record_skip <- function(key, value) {
+  record_skip <- function(key, label, value) {
     reason <- skip_reason(value)
     if (!is.null(reason)) {
-      skipped[[key]] <<- reason
+      skipped[[key]] <<- list(label = label, reason = reason)
     }
     invisible(NULL)
   }
@@ -664,44 +686,34 @@ run_p_hacking_tests <- function(df, options) {
     )
 
     # Binomial tests
-    elliott_tests$binomial_005 <- list(
-      test = "Binomial [0, 0.05]",
-      p_value = run_binomial(pvalues, 0, 0.05, type = "c")
-    )
-
-    elliott_tests$binomial_01 <- list(
-      test = "Binomial [0, 0.10]",
-      p_value = run_binomial(pvalues, 0, 0.1, type = "c")
-    )
+    for (p_max in supports) {
+      elliott_tests[[paste0("binomial_", support_key(p_max))]] <- list(
+        test = paste0("Binomial [0, ", support_label(p_max), "]"),
+        p_value = run_binomial(pvalues, 0, p_max, type = "c")
+      )
+    }
 
     # LCM tests (always reported, even when the CDF simulation failed, so the
     # skip reason surfaces instead of the rows silently disappearing)
-    if (length(cdfs) > 0) {
-      elliott_tests$lcm_005 <- list(
-        test = "LCM [0, 0.05]",
-        p_value = run_lcm(pvalues, 0, 0.05, cdfs)
-      )
-
-      elliott_tests$lcm_01 <- list(
-        test = "LCM [0, 0.10]",
-        p_value = run_lcm(pvalues, 0, 0.1, cdfs)
-      )
+    lcm_skip <- if (length(cdfs) == 0) {
+      skipped_result(cdfs_reason %||% "CDF simulation returned no draws")
     } else {
-      lcm_skip <- skipped_result(cdfs_reason %||% "CDF simulation returned no draws")
-      elliott_tests$lcm_005 <- list(test = "LCM [0, 0.05]", p_value = lcm_skip)
-      elliott_tests$lcm_01 <- list(test = "LCM [0, 0.10]", p_value = lcm_skip)
+      NULL
+    }
+    for (p_max in supports) {
+      elliott_tests[[paste0("lcm_", support_key(p_max))]] <- list(
+        test = paste0("LCM [0, ", support_label(p_max), "]"),
+        p_value = lcm_skip %||% run_lcm(pvalues, 0, p_max, cdfs)
+      )
     }
 
     # Fisher tests
-    elliott_tests$fisher_005 <- list(
-      test = "Fisher [0, 0.05]",
-      p_value = run_fisher(pvalues, 0, 0.05)
-    )
-
-    elliott_tests$fisher_01 <- list(
-      test = "Fisher [0, 0.10]",
-      p_value = run_fisher(pvalues, 0, 0.1)
-    )
+    for (p_max in supports) {
+      elliott_tests[[paste0("fisher_", support_key(p_max))]] <- list(
+        test = paste0("Fisher [0, ", support_label(p_max), "]"),
+        p_value = run_fisher(pvalues, 0, p_max)
+      )
+    }
 
     # Discontinuity test
     if (options$include_discontinuity) {
@@ -713,29 +725,21 @@ run_p_hacking_tests <- function(df, options) {
 
     # Cox-Shi tests
     if (options$include_cox_shi) {
-      elliott_tests$cox_shi_005 <- list(
-        test = "Cox-Shi [0, 0.05]",
-        p_value = run_cox_shi(
-          pvalues, study_id, 0, 0.05,
-          n_bins = options$cox_shi_bins,
-          monotonicity_order = options$cox_shi_order,
-          use_bounds = options$cox_shi_bounds
+      for (p_max in supports) {
+        elliott_tests[[paste0("cox_shi_", support_key(p_max))]] <- list(
+          test = paste0("Cox-Shi [0, ", support_label(p_max), "]"),
+          p_value = run_cox_shi(
+            pvalues, study_id, 0, p_max,
+            n_bins = options$cox_shi_bins,
+            monotonicity_order = options$cox_shi_order,
+            use_bounds = options$cox_shi_bounds
+          )
         )
-      )
-
-      elliott_tests$cox_shi_01 <- list(
-        test = "Cox-Shi [0, 0.10]",
-        p_value = run_cox_shi(
-          pvalues, study_id, 0, 0.1,
-          n_bins = options$cox_shi_bins,
-          monotonicity_order = options$cox_shi_order,
-          use_bounds = options$cox_shi_bounds
-        )
-      )
+      }
     }
 
     for (key in names(elliott_tests)) {
-      record_skip(key, elliott_tests[[key]]$p_value)
+      record_skip(key, elliott_tests[[key]]$test, elliott_tests[[key]]$p_value)
     }
 
     output$elliott <- build_elliott_summary(elliott_tests, pvalues, options)
@@ -772,13 +776,20 @@ build_elliott_summary <- function(elliott_tests, pvalues, options) {
     check.names = FALSE
   )
 
-  # Add observation count rows
-  n_01_range <- sum(pvalues >= 0 & pvalues <= 0.1, na.rm = TRUE)
-  n_005_range <- sum(pvalues >= 0 & pvalues <= 0.05, na.rm = TRUE)
+  # Add observation count rows, widest support first
+  supports <- sort(options$elliott_supports %||% DEFAULT_ELLIOTT_SUPPORTS, decreasing = TRUE)
 
   obs_rows <- data.frame(
-    Test = c("Observations in [0, 0.1]", "Observations in [0, 0.05]"),
-    `P-value` = c(as.character(n_01_range), as.character(n_005_range)),
+    Test = vapply(
+      supports,
+      function(p_max) paste0("Observations in [0, ", format(p_max), "]"),
+      character(1)
+    ),
+    `P-value` = vapply(
+      supports,
+      function(p_max) as.character(sum(pvalues >= 0 & pvalues <= p_max, na.rm = TRUE)),
+      character(1)
+    ),
     stringsAsFactors = FALSE,
     check.names = FALSE
   )

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -43,6 +43,14 @@ p_hacking_tests <- function(df) {
     ),
     caliper_cluster = opt_spec(default = TRUE, type = "logical"),
     include_elliott = opt_spec(default = TRUE, type = "logical"),
+    elliott_supports = opt_spec(
+      default = c(0.05, 0.1), type = "numeric",
+      constraint = function(x) {
+        length(x) > 0 && all(is.finite(x) & x > 0 & x <= 1) &&
+          !is.unsorted(x, strictly = TRUE)
+      },
+      constraint_msg = "elliott_supports must be strictly increasing p-value bounds in (0, 1]"
+    ),
     lcm_iterations = opt_spec(
       default = 10000L, type = "numeric", cast = as.integer,
       constraint = function(x) x > 0, constraint_msg = "lcm_iterations must be positive"
@@ -104,6 +112,7 @@ p_hacking_tests <- function(df) {
     caliper_tail = resolved$caliper_tail,
     caliper_cluster = resolved$caliper_cluster,
     include_elliott = resolved$include_elliott,
+    elliott_supports = resolved$elliott_supports,
     lcm_iterations = resolved$lcm_iterations,
     lcm_grid_points = resolved$lcm_grid_points,
     simulate_cdfs_chunk_size = resolved$simulate_cdfs_chunk_size,
@@ -162,6 +171,12 @@ p_hacking_tests <- function(df) {
         print(results$elliott, row.names = FALSE) # nolint: undesirable_function_linter.
       )
       cli::cli_verbatim(elliott_lines)
+
+      # Footnote the NA cells: each skipped test carries a reason (e.g. a
+      # singular Cox-Shi bin covariance) that would otherwise be lost.
+      for (item in results$skipped) {
+        cli::cli_alert_warning("Skipped {item$label}: {item$reason}")
+      }
       cli::cli_text("")
     }
 
@@ -171,12 +186,6 @@ p_hacking_tests <- function(df) {
       cli::cli_text("Significance marks: * p <= 0.1, ** p <= 0.05, *** p <= 0.01")
     } else {
       cli::cli_alert_warning("No p-hacking tests were successfully completed.")
-    }
-
-    if (!is.null(results$skipped) && verbosity >= 2) {
-      for (key in names(results$skipped)) {
-        cli::cli_alert_warning("Skipped {key}: {results$skipped[[key]]}")
-      }
     }
   }
 

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -687,6 +687,17 @@ methods:
       help: |
         If `TRUE`, include Elliott et al. (2022) p-hacking detection tests.
 
+    elliott_supports:
+      type: "numeric"
+      default: [0.05, 0.1]
+      help: |
+        Upper bounds of the p-value supports [0, p_max] on which the Elliott
+        et al. (2022) battery (Binomial, LCM, Fisher, Cox-Shi) runs. Each
+        bound must lie in (0, 1] and the vector must be strictly increasing.
+        Published applications often extend the default with 0.15 or 0.2;
+        the support choice can flip the substantive conclusion, so report
+        which support a rejection comes from.
+
     simulate_cdfs:
       chunk_size:
         type: "integer"
@@ -751,13 +762,14 @@ methods:
         Number of bins for discretization in Cox-Shi tests.
         More bins provide finer resolution but require more observations; empty
         bins make the covariance matrix singular and the test is then skipped.
-        The same bin count is used for both the [0, 0.05] and [0, 0.10] windows
-        (matching the canonical Elliott et al. code), so the wider window runs
-        at half the bin width of the narrower one. A spike in the p-curve that
-        is narrower than a bin can therefore be averaged away on [0, 0.10]
-        while still showing up on [0, 0.05], and the two windows may disagree
-        sharply. When they do, rerun with the bin count doubled to compare the
-        windows at a matched bin width before reading anything into the gap.
+        The same bin count is used for every support in `elliott_supports`
+        (matching the canonical Elliott et al. code, which fixes the count
+        regardless of the interval), so wider windows run at coarser bin
+        widths. A spike in the p-curve that is narrower than a bin can
+        therefore be averaged away on a wide window while still showing up on
+        a narrow one, and nested windows may disagree sharply. When they do,
+        rerun with the bin count scaled to the window width before reading
+        anything into the gap.
 
     cox_shi_order:
       type: "integer"

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -434,28 +434,33 @@ test_that("run_p_hacking_tests runs the Elliott suite when requested", {
 
 # Elliott supports ------------------------------------------------------------
 
-# Deterministic p-curve on [0, 0.15]: strictly declining bin counts over
-# [0, 0.10] (so the default Cox-Shi windows read as monotone) plus a bump in
-# (0.12, 0.13] that only a wider support can see. Points are spread evenly
-# inside each 0.01-wide bin so no window binning leaves a bin empty.
-bumped_pcurve_df <- function() {
-  counts <- c(40, 34, 28, 24, 20, 16, 12, 10, 8, 6, 5, 5, 30, 5, 5)
-  edges <- seq(0, 0.15, by = 0.01)
-  pvalues <- unlist(lapply(seq_along(counts), function(j) {
-    seq(edges[j], edges[j + 1], length.out = counts[j] + 2)[2:(counts[j] + 1)]
-  }))
-  t_stats <- stats::qnorm(1 - pvalues / 2)
+# A realistic clustered p-curve (the cox_shi_panel(202) construction, which
+# respects the Elliott theoretical bounds so the default windows stay quiet),
+# plus a heap of p-values at 0.125. The heap is invisible to the default
+# supports but breaks monotonicity on a [0, 0.15] window, so widening the
+# support flips the Cox-Shi conclusion.
+heap_bump_df <- function() {
+  set.seed(202, kind = "Mersenne-Twister", normal.kind = "Inversion")
+  panel_t <- abs(stats::rnorm(800, mean = 1.5, sd = 1))
+  heap_t <- rep(stats::qnorm(1 - 0.125 / 2), 150)
+  t_stats <- c(panel_t, heap_t)
+  study_id <- c(
+    1 + ((seq_along(panel_t) - 1) %/% 20),
+    41 + ((seq_along(heap_t) - 1) %/% 20)
+  )
   data.frame(
     effect = t_stats,
     se = rep(1, length(t_stats)),
-    t_stat = t_stats,
-    study_id = seq_along(t_stats)
+    study_id = study_id
   )
 }
 
+# Strip significance marks from a formatted p-value cell.
+formatted_p_to_num <- function(x) as.numeric(sub("\\*+$", "", x))
+
 test_that("run_p_hacking_tests honours custom Elliott supports", {
   local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
-  df <- bumped_pcurve_df()
+  df <- heap_bump_df()
 
   result <- run_p_hacking_tests(
     df,
@@ -472,14 +477,15 @@ test_that("run_p_hacking_tests honours custom Elliott supports", {
   # The default [0, 0.10] rows are replaced, not appended.
   expect_false(any(grepl("[0, 0.10]", result$elliott$Test, fixed = TRUE)))
   expect_false(any(grepl("Observations in [0, 0.1]", result$elliott$Test, fixed = TRUE)))
-  # The wider window sees 60 more p-values than [0, 0.10] would.
+  # The observation count matches the requested support window.
+  expected_n <- sum(2 * stats::pnorm(-abs(df$effect / df$se)) <= 0.15)
   obs_row <- result$elliott[result$elliott$Test == "Observations in [0, 0.15]", ]
-  expect_equal(obs_row$`P-value`, as.character(nrow(df)))
+  expect_equal(obs_row$`P-value`, as.character(expected_n))
 })
 
 test_that("a custom support changes the Cox-Shi result relative to the default supports", {
   local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
-  df <- bumped_pcurve_df()
+  df <- heap_bump_df()
 
   run_with_supports <- function(supports) {
     run_p_hacking_tests(
@@ -501,9 +507,13 @@ test_that("a custom support changes the Cox-Shi result relative to the default s
   custom_row <- custom_run$elliott[custom_run$elliott$Test == "Cox-Shi [0, 0.15]", ]
   expect_equal(nrow(default_row), 1L)
   expect_equal(nrow(custom_row), 1L)
-  # Both windows produce a numeric p-value, and widening the support changes it.
+  # Both windows produce a numeric p-value.
   expect_false(grepl("NA", default_row$`P-value`))
   expect_false(grepl("NA", custom_row$`P-value`))
+  # The heap at p = 0.125 is invisible on [0, 0.10] but rejects on [0, 0.15],
+  # so the support choice flips the substantive conclusion.
+  expect_true(formatted_p_to_num(default_row$`P-value`) > 0.05)
+  expect_true(formatted_p_to_num(custom_row$`P-value`) < 0.05)
   expect_false(identical(default_row$`P-value`, custom_row$`P-value`))
 })
 

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -346,6 +346,7 @@ base_p_hacking_options <- function(...) {
     caliper_widths = c(0.05, 0.1),
     caliper_display_ratios = TRUE,
     include_elliott = FALSE,
+    elliott_supports = c(0.05, 0.1),
     lcm_iterations = 50L,
     lcm_grid_points = 50L,
     simulate_cdfs_chunk_size = 512L,
@@ -431,6 +432,95 @@ test_that("run_p_hacking_tests runs the Elliott suite when requested", {
   expect_false("Observations <= 0.1" %in% result$elliott$Test)
 })
 
+# Elliott supports ------------------------------------------------------------
+
+# Deterministic p-curve on [0, 0.15]: strictly declining bin counts over
+# [0, 0.10] (so the default Cox-Shi windows read as monotone) plus a bump in
+# (0.12, 0.13] that only a wider support can see. Points are spread evenly
+# inside each 0.01-wide bin so no window binning leaves a bin empty.
+bumped_pcurve_df <- function() {
+  counts <- c(40, 34, 28, 24, 20, 16, 12, 10, 8, 6, 5, 5, 30, 5, 5)
+  edges <- seq(0, 0.15, by = 0.01)
+  pvalues <- unlist(lapply(seq_along(counts), function(j) {
+    seq(edges[j], edges[j + 1], length.out = counts[j] + 2)[2:(counts[j] + 1)]
+  }))
+  t_stats <- stats::qnorm(1 - pvalues / 2)
+  data.frame(
+    effect = t_stats,
+    se = rep(1, length(t_stats)),
+    t_stat = t_stats,
+    study_id = seq_along(t_stats)
+  )
+}
+
+test_that("run_p_hacking_tests honours custom Elliott supports", {
+  local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
+  df <- bumped_pcurve_df()
+
+  result <- run_p_hacking_tests(
+    df,
+    base_p_hacking_options(
+      include_caliper = FALSE,
+      include_elliott = TRUE,
+      elliott_supports = c(0.05, 0.15)
+    )
+  )
+
+  expect_true("Binomial [0, 0.15]" %in% result$elliott$Test)
+  expect_true("Fisher [0, 0.15]" %in% result$elliott$Test)
+  expect_true("Observations in [0, 0.15]" %in% result$elliott$Test)
+  # The default [0, 0.10] rows are replaced, not appended.
+  expect_false(any(grepl("[0, 0.10]", result$elliott$Test, fixed = TRUE)))
+  expect_false(any(grepl("Observations in [0, 0.1]", result$elliott$Test, fixed = TRUE)))
+  # The wider window sees 60 more p-values than [0, 0.10] would.
+  obs_row <- result$elliott[result$elliott$Test == "Observations in [0, 0.15]", ]
+  expect_equal(obs_row$`P-value`, as.character(nrow(df)))
+})
+
+test_that("a custom support changes the Cox-Shi result relative to the default supports", {
+  local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
+  df <- bumped_pcurve_df()
+
+  run_with_supports <- function(supports) {
+    run_p_hacking_tests(
+      df,
+      base_p_hacking_options(
+        include_caliper = FALSE,
+        include_elliott = TRUE,
+        include_cox_shi = TRUE,
+        cox_shi_bins = 10L,
+        elliott_supports = supports
+      )
+    )
+  }
+
+  default_run <- run_with_supports(c(0.05, 0.1))
+  custom_run <- run_with_supports(c(0.05, 0.15))
+
+  default_row <- default_run$elliott[default_run$elliott$Test == "Cox-Shi [0, 0.10]", ]
+  custom_row <- custom_run$elliott[custom_run$elliott$Test == "Cox-Shi [0, 0.15]", ]
+  expect_equal(nrow(default_row), 1L)
+  expect_equal(nrow(custom_row), 1L)
+  # Both windows produce a numeric p-value, and widening the support changes it.
+  expect_false(grepl("NA", default_row$`P-value`))
+  expect_false(grepl("NA", custom_row$`P-value`))
+  expect_false(identical(default_row$`P-value`, custom_row$`P-value`))
+})
+
+test_that("run_p_hacking_tests rejects invalid Elliott supports", {
+  local_options(artma.verbose = 1, artma.cache.use_cache = FALSE)
+  df <- make_p_hacking_df()
+
+  bad_options <- function(supports) {
+    base_p_hacking_options(include_caliper = FALSE, include_elliott = TRUE, elliott_supports = supports)
+  }
+
+  expect_error(run_p_hacking_tests(df, bad_options(numeric(0))), "must not be empty")
+  expect_error(run_p_hacking_tests(df, bad_options(c(0, 0.1))), "\\(0, 1\\]")
+  expect_error(run_p_hacking_tests(df, bad_options(c(0.05, 1.5))), "\\(0, 1\\]")
+  expect_error(run_p_hacking_tests(df, bad_options(c(0.1, 0.05))), "strictly increasing")
+})
+
 # Skip reasons ---------------------------------------------------------------
 
 test_that("run_p_hacking_tests records a skip reason when the CDF simulation yields no draws", {
@@ -446,8 +536,9 @@ test_that("run_p_hacking_tests records a skip reason when the CDF simulation yie
     )
   )
 
-  expect_true(!is.null(result$skipped$lcm_005))
-  expect_true(!is.null(result$skipped$lcm_01))
+  expect_true(!is.null(result$skipped$lcm_005$reason))
+  expect_true(!is.null(result$skipped$lcm_01$reason))
+  expect_equal(result$skipped$lcm_005$label, "LCM [0, 0.05]")
   # The row is still reported (not silently absent), just as NA.
   lcm_rows <- result$elliott[grepl("^LCM", result$elliott$Test), ]
   expect_equal(nrow(lcm_rows), 2L)
@@ -469,7 +560,8 @@ test_that("run_p_hacking_tests records a skip reason for a singular Cox-Shi cova
     )
   )
 
-  expect_match(result$skipped$cox_shi_005, "singular")
+  expect_match(result$skipped$cox_shi_005$reason, "singular")
+  expect_equal(result$skipped$cox_shi_005$label, "Cox-Shi [0, 0.05]")
 })
 
 test_that("run_lcm skips with a reason instead of failing silently", {

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -76,28 +76,34 @@ elliott_base_options <- function() {
   )
 }
 
-# Deterministic p-curve: strictly declining over [0, 0.10], plus a bump in
-# (0.12, 0.13] that only a wider support window can see. Points are spread
-# evenly inside each 0.01-wide bin so no Cox-Shi binning leaves a bin empty.
-make_bumped_pcurve_df <- function() {
-  counts <- c(40, 34, 28, 24, 20, 16, 12, 10, 8, 6, 5, 5, 30, 5, 5)
-  edges <- seq(0, 0.15, by = 0.01)
-  pvalues <- unlist(lapply(seq_along(counts), function(j) {
-    seq(edges[j], edges[j + 1], length.out = counts[j] + 2)[2:(counts[j] + 1)]
-  }))
-  t_stats <- stats::qnorm(1 - pvalues / 2)
+# A realistic clustered p-curve (it respects the Elliott theoretical bounds,
+# so the default Cox-Shi windows stay quiet), plus a heap of p-values at
+# 0.125. The heap is invisible to the default supports but breaks monotonicity
+# on a [0, 0.15] window, so widening the support flips the conclusion.
+make_heap_bump_df <- function() {
+  set.seed(202, kind = "Mersenne-Twister", normal.kind = "Inversion")
+  panel_t <- abs(stats::rnorm(800, mean = 1.5, sd = 1))
+  heap_t <- rep(stats::qnorm(1 - 0.125 / 2), 150)
+  t_stats <- c(panel_t, heap_t)
+  study_id <- c(
+    1 + ((seq_along(panel_t) - 1) %/% 20),
+    41 + ((seq_along(heap_t) - 1) %/% 20)
+  )
   data.frame(
     effect = t_stats,
     se = rep(1, length(t_stats)),
     t_stat = t_stats,
-    study_id = seq_along(t_stats)
+    study_id = study_id
   )
 }
+
+# Strip significance marks from a formatted p-value cell.
+formatted_p_to_num <- function(x) as.numeric(sub("\\*+$", "", x))
 
 test_that("a custom elliott_supports option flows through to the Cox-Shi call", {
   skip_if_not_installed("NlcOptim")
   skip_if_not_installed("quadprog")
-  df <- make_bumped_pcurve_df()
+  df <- make_heap_bump_df()
 
   run_with_supports <- function(supports) {
     opts <- elliott_base_options()
@@ -117,9 +123,12 @@ test_that("a custom elliott_supports option flows through to the Cox-Shi call", 
   custom_p <- custom_result$tables$elliott[
     custom_result$tables$elliott$Test == "Cox-Shi [0, 0.15]", "P-value"
   ]
-  # Both windows yield a numeric p-value and the support choice changes it.
+  # Both windows yield a numeric p-value and the support choice changes it:
+  # the heap at p = 0.125 rejects only on the wider window.
   expect_false(grepl("NA", default_p))
   expect_false(grepl("NA", custom_p))
+  expect_true(formatted_p_to_num(default_p) > 0.05)
+  expect_true(formatted_p_to_num(custom_p) < 0.05)
   expect_false(identical(default_p, custom_p))
 })
 

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -2,12 +2,14 @@ box::use(
   testthat[
     expect_equal,
     expect_error,
+    expect_false,
+    expect_match,
     expect_no_error,
     expect_true,
     skip_if_not_installed,
     test_that
   ],
-  withr[local_options],
+  withr[local_options, with_options],
   artma / data / mock[create_mock_df],
   artma / methods / p_hacking_tests[p_hacking_tests],
   artma / methods / exogeneity_tests[exogeneity_tests]
@@ -59,6 +61,97 @@ test_that("p_hacking_tests prints a significance legend matching significance_ma
   output <- utils::capture.output(p_hacking_tests(make_p_hacking_df()), type = "message")
 
   expect_true(any(grepl("Significance marks: \\* p <= 0.1, \\*\\* p <= 0.05, \\*\\*\\* p <= 0.01", output)))
+})
+
+# Elliott supports and Cox-Shi skip reasons ----------------------------------
+
+elliott_base_options <- function() {
+  list(
+    artma.verbose = 1,
+    artma.cache.use_cache = FALSE,
+    artma.methods.p_hacking_tests.include_caliper = FALSE,
+    artma.methods.p_hacking_tests.include_discontinuity = FALSE,
+    artma.methods.p_hacking_tests.lcm_iterations = 50,
+    artma.methods.p_hacking_tests.lcm_grid_points = 50
+  )
+}
+
+# Deterministic p-curve: strictly declining over [0, 0.10], plus a bump in
+# (0.12, 0.13] that only a wider support window can see. Points are spread
+# evenly inside each 0.01-wide bin so no Cox-Shi binning leaves a bin empty.
+make_bumped_pcurve_df <- function() {
+  counts <- c(40, 34, 28, 24, 20, 16, 12, 10, 8, 6, 5, 5, 30, 5, 5)
+  edges <- seq(0, 0.15, by = 0.01)
+  pvalues <- unlist(lapply(seq_along(counts), function(j) {
+    seq(edges[j], edges[j + 1], length.out = counts[j] + 2)[2:(counts[j] + 1)]
+  }))
+  t_stats <- stats::qnorm(1 - pvalues / 2)
+  data.frame(
+    effect = t_stats,
+    se = rep(1, length(t_stats)),
+    t_stat = t_stats,
+    study_id = seq_along(t_stats)
+  )
+}
+
+test_that("a custom elliott_supports option flows through to the Cox-Shi call", {
+  skip_if_not_installed("NlcOptim")
+  skip_if_not_installed("quadprog")
+  df <- make_bumped_pcurve_df()
+
+  run_with_supports <- function(supports) {
+    opts <- elliott_base_options()
+    opts$artma.methods.p_hacking_tests.elliott_supports <- supports
+    with_options(opts, p_hacking_tests(df))
+  }
+
+  default_result <- run_with_supports(c(0.05, 0.1))
+  custom_result <- run_with_supports(c(0.05, 0.15))
+
+  expect_true("Cox-Shi [0, 0.15]" %in% custom_result$tables$elliott$Test)
+  expect_false(any(grepl("[0, 0.10]", custom_result$tables$elliott$Test, fixed = TRUE)))
+
+  default_p <- default_result$tables$elliott[
+    default_result$tables$elliott$Test == "Cox-Shi [0, 0.10]", "P-value"
+  ]
+  custom_p <- custom_result$tables$elliott[
+    custom_result$tables$elliott$Test == "Cox-Shi [0, 0.15]", "P-value"
+  ]
+  # Both windows yield a numeric p-value and the support choice changes it.
+  expect_false(grepl("NA", default_p))
+  expect_false(grepl("NA", custom_p))
+  expect_false(identical(default_p, custom_p))
+})
+
+test_that("p_hacking_tests surfaces the Cox-Shi skip reason in output and meta", {
+  # P-values heaped on two points leave most Cox-Shi bins empty, making the
+  # bin covariance singular, so the test must skip with a visible reason.
+  pvalues <- rep(c(0.001, 0.045), each = 100)
+  t_stats <- stats::qnorm(1 - pvalues / 2)
+  df <- data.frame(
+    effect = t_stats,
+    se = rep(1, length(t_stats)),
+    t_stat = t_stats,
+    study_id = rep(seq_len(20), each = 10)
+  )
+
+  messages <- with_options(
+    elliott_base_options(),
+    utils::capture.output(result <- p_hacking_tests(df), type = "message")
+  )
+
+  # The summary table keeps NA in the p-value column.
+  cox_rows <- result$tables$elliott[grepl("^Cox-Shi", result$tables$elliott$Test), ]
+  expect_equal(nrow(cox_rows), 2L)
+  expect_true(all(grepl("NA", cox_rows$`P-value`)))
+
+  # The reason lands in meta for programmatic consumers.
+  expect_match(result$meta$skipped$cox_shi_005$reason, "singular")
+  expect_equal(result$meta$skipped$cox_shi_005$label, "Cox-Shi [0, 0.05]")
+
+  # And it is printed after the summary table instead of a bare NA.
+  expect_true(any(grepl("singular", messages)))
+  expect_true(any(grepl("Cox-Shi \\[0, 0.05\\]", messages)))
 })
 
 # exogeneity_tests wrapper --------------------------------------------------


### PR DESCRIPTION
Closes #368

## Summary

Two usability gaps in the p-hacking tests:

- **Configurable Elliott supports.** The Elliott et al. (2022) battery (Binomial, LCM, Fisher, Cox-Shi) previously ran only on the hardcoded p-value supports [0, 0.05] and [0, 0.10]. A new `elliott_supports` option under `artma.methods.p_hacking_tests` holds the support upper bounds, defaulting to `c(0.05, 0.1)` to preserve current behavior, so published supports such as [0, 0.15] or [0, 0.2] are now reachable through the options system. Each bound is validated to lie in (0, 1] and the vector must be strictly increasing. The bin count was already configurable (`cox_shi_bins`) and is applied to every support, matching the canonical Elliott code.
- **Cox-Shi skip reasons surfaced.** When `cox_shi_test` returns NA with an informative `attr("reason")` (for example a singular bin covariance from heaped p-values), the summary table keeps NA in the p-value column, the reasons are printed as cli warnings directly after the Elliott summary table, and they are stored in the method result's `meta$skipped` as `list(label =, reason =)` entries, following the convention used by `linear_tests`.

## Tests

- A custom support (0.15) flows through the method options into the Cox-Shi call and changes the result relative to the default supports, on a deterministic synthetic p-curve with a bump only the wider window can see.
- Skip path: heaped p-values leave Cox-Shi bins empty, the table shows NA, the reason lands in meta, and the printed output mentions it.
- Invalid supports (empty, zero, above 1, not strictly increasing) are rejected at both the method and econometric layers.

Note: the test suite could not be executed in this sandbox because the network policy blocks CRAN, so the box/testthat dependency stack could not be installed. Changed R files were parse-checked and the options template was validated as YAML; CI should be treated as the authoritative run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNXYYLPMLvxvZzrkobn2pf)_