### PR TITLE
fix(nonlinear): allow general selection cutoffs, cluster SEs by study, report pub probabilities

### DIFF
--- a/inst/artma/calc/methods/selection_model.R
+++ b/inst/artma/calc/methods/selection_model.R
@@ -154,12 +154,19 @@ variation_variance_loglikelihood <- function(lambdabar, tauhat, betap, cutoffs, 
 #' @param cutoffs [numeric] Cut-off thresholds.
 #' @param symmetric [logical] Should symmetry be enforced?
 #' @param model [character] Either "normal" or "t".
+#' @param cluster_id [vector] Optional cluster identifiers (e.g. study ids),
+#'   one per observation. When at least two distinct clusters are present the
+#'   robust standard errors aggregate score contributions by cluster; with a
+#'   single cluster, incomplete identifiers, or a failed clustered
+#'   computation, the estimation falls back to unclustered standard errors
+#'   with a message.
 #' @return A list with parameter estimates and robust standard errors, plus
-#'   `convergence` (the optimiser's exit code, 0 for success) and
+#'   `convergence` (the optimiser's exit code, 0 for success),
 #'   `boundary_hit` (TRUE when a variance or publication-probability
 #'   parameter landed on its lower constraint of 0, a corner solution rather
-#'   than a genuine optimum).
-metastudies_estimation <- function(X, sigma, cutoffs, symmetric, model = "normal") {
+#'   than a genuine optimum), and `clustered` (TRUE when the reported
+#'   standard errors are clustered by `cluster_id`).
+metastudies_estimation <- function(X, sigma, cutoffs, symmetric, model = "normal", cluster_id = NULL) {
   max_eval <- 1e5
   max_iter <- 1e5
   tol <- 1e-8
@@ -181,10 +188,33 @@ metastudies_estimation <- function(X, sigma, cutoffs, symmetric, model = "normal
   upper <- rep(Inf, length(start))
   optimum <- stats::nlminb(start = start, objective = objective, lower = lower, upper = upper, control = list(eval.max = max_eval, iter.max = max_iter, abs.tol = tol))
   params <- optimum$par
+  cluster_index <- seq_len(n)
+  clustered <- FALSE
+  if (!is.null(cluster_id)) {
+    if (length(cluster_id) != n || anyNA(cluster_id)) {
+      cli::cli_inform("Cluster identifiers are missing or incomplete; reporting unclustered standard errors.")
+    } else if (length(unique(cluster_id)) < 2L) {
+      cli::cli_inform("Only one cluster is present; reporting unclustered standard errors.")
+    } else {
+      cluster_index <- as.integer(factor(cluster_id))
+      clustered <- TRUE
+    }
+  }
   covariance <- tryCatch(
-    robust_variance(stepsize, n, params, llh, seq_len(n)),
-    error = function(e) matrix(NA_real_, length(params), length(params))
+    robust_variance(stepsize, n, params, llh, cluster_index),
+    error = function(e) NULL
   )
+  if (is.null(covariance) && clustered) {
+    cli::cli_inform("Clustered variance estimation failed; falling back to unclustered standard errors.")
+    clustered <- FALSE
+    covariance <- tryCatch(
+      robust_variance(stepsize, n, params, llh, seq_len(n)),
+      error = function(e) NULL
+    )
+  }
+  if (is.null(covariance)) {
+    covariance <- matrix(NA_real_, length(params), length(params))
+  }
   standard_errors <- suppressWarnings(base::sqrt(base::diag(covariance)))
   boundary_tolerance <- 1e-4
   boundary_hit <- any(abs(params[-1]) < boundary_tolerance)
@@ -193,7 +223,8 @@ metastudies_estimation <- function(X, sigma, cutoffs, symmetric, model = "normal
     SE = standard_errors,
     convergence = optimum$convergence,
     message = optimum$message,
-    boundary_hit = boundary_hit
+    boundary_hit = boundary_hit,
+    clustered = clustered
   )
 }
 
@@ -255,5 +286,6 @@ box::export(
   VariationVarianceLogLikelihood,
   estimatestable,
   metastudies_estimation,
-  compute_score_matrix
+  compute_score_matrix,
+  compute_information_matrix
 )

--- a/inst/artma/econometric/nonlinear.R
+++ b/inst/artma/econometric/nonlinear.R
@@ -391,9 +391,31 @@ run_hierarchical <- function(df, total_n, options) {
   )
 }
 
+#' Label the t-statistic intervals of the selection model's publication
+#' probabilities
+#'
+#' @param cutoffs *\[numeric\]* Cut-off thresholds, strictly increasing.
+#' @param symmetric *\[logical\]* Whether the model applies cutoffs to `|t|`.
+#' @return *\[character\]* One label per estimated publication-probability
+#'   parameter; the interval above the last cutoff is the reference category
+#'   with its probability normalised to 1.
+#' @keywords internal
+selection_interval_labels <- function(cutoffs, symmetric) {
+  bounds <- c(if (symmetric) "0" else "-Inf", as.character(cutoffs))
+  vapply(seq_along(cutoffs), function(i) {
+    left <- if (i == 1 && symmetric) "[" else "("
+    paste0(left, bounds[i], ", ", bounds[i + 1], "]")
+  }, character(1))
+}
+
 run_selection <- function(df, total_n, options) {
   validate_columns(df, c("effect", "se"))
-  data <- df[, c("effect", "se"), drop = FALSE]
+  columns <- c("effect", "se")
+  has_study_id <- "study_id" %in% colnames(df)
+  if (has_study_id) {
+    columns <- c(columns, "study_id")
+  }
+  data <- df[, columns, drop = FALSE]
   data <- data[is.finite(data$effect) & is.finite(data$se) & data$se > 0, , drop = FALSE]
   if (nrow(data) < 2) {
     cli::cli_abort("Not enough observations to run the selection model.")
@@ -406,26 +428,47 @@ run_selection <- function(df, total_n, options) {
     sigma = data$se,
     cutoffs = cutoffs,
     symmetric = symmetric,
-    model = model
+    model = model,
+    cluster_id = if (has_study_id) data$study_id else NULL
   )
-  if (length(estimates$Psihat) < 2 || length(estimates$SE) < 2) {
-    cli::cli_abort("Selection model did not return effect and publication bias parameters.")
+  n_shape_params <- if (model == "t") 3L else 2L
+  n_params <- n_shape_params + length(cutoffs)
+  if (length(estimates$Psihat) != n_params || length(estimates$SE) != n_params) {
+    cli::cli_abort("Selection model did not return the expected parameter vector.")
   }
   effect_est <- estimates$Psihat[1]
   effect_se <- estimates$SE[1]
-  pub_bias_est <- estimates$Psihat[2]
-  pub_bias_se <- estimates$SE[2]
+  tau_est <- estimates$Psihat[2]
+  tau_se <- estimates$SE[2]
+  extra_terms <- list(list(
+    term = "effect_heterogeneity",
+    term_label = "Effect Heterogeneity (tau)",
+    estimate = tau_est,
+    std_error = tau_se,
+    p_value = normal_p_value(tau_est, tau_se)
+  ))
+  interval_labels <- selection_interval_labels(cutoffs, symmetric)
+  pub_prob_index <- seq.int(n_shape_params + 1L, n_params)
+  for (i in seq_along(pub_prob_index)) {
+    pub_prob_est <- estimates$Psihat[pub_prob_index[i]]
+    pub_prob_se <- estimates$SE[pub_prob_index[i]]
+    extra_terms[[i + 1L]] <- list(
+      term = paste0("pub_prob_", i),
+      term_label = paste0("Rel. Pub. Probability ", interval_labels[i]),
+      estimate = pub_prob_est,
+      std_error = pub_prob_se,
+      # Publication probabilities are relative to the reference interval above
+      # the last cutoff, so the no-selection null is 1, not 0.
+      p_value = normal_p_value(pub_prob_est - 1, pub_prob_se)
+    )
+  }
   list(
     effect = list(
       estimate = effect_est,
       std_error = effect_se,
       p_value = normal_p_value(effect_est, effect_se)
     ),
-    publication_bias = list(
-      estimate = pub_bias_est,
-      std_error = pub_bias_se,
-      p_value = normal_p_value(pub_bias_est, pub_bias_se)
-    ),
+    extra_terms = extra_terms,
     n_model = nrow(data),
     convergence = estimates$convergence,
     boundary_hit = estimates$boundary_hit
@@ -466,11 +509,15 @@ build_summary_table <- function(coefficients, digits) {
   if (!nrow(coefficients)) {
     return(data.frame())
   }
+  is_extra <- !coefficients$term %in% c("publication_bias", "effect")
+  extra_labels <- unique(coefficients$term_label[is_extra])
+  extra_row_labels <- as.vector(rbind(extra_labels, rep("(Std. Error)", length(extra_labels))))
   row_labels <- c(
     "Publication Bias",
     "(Std. Error)",
     "Effect Beyond Bias",
     "(Std. Error)",
+    extra_row_labels,
     "Total observations",
     "Model observations"
   )
@@ -479,6 +526,15 @@ build_summary_table <- function(coefficients, digits) {
     model_rows <- coefficients[coefficients$model == model, , drop = FALSE]
     pb_row <- model_rows[model_rows$term == "publication_bias", , drop = FALSE]
     eff_row <- model_rows[model_rows$term == "effect", , drop = FALSE]
+    extra_cells <- character(0)
+    for (extra_label in extra_labels) {
+      extra_row <- model_rows[model_rows$term_label == extra_label & !model_rows$term %in% c("publication_bias", "effect"), , drop = FALSE]
+      extra_cells <- c(
+        extra_cells,
+        if (nrow(extra_row)) extra_row$estimate_formatted else "",
+        if (nrow(extra_row)) extra_row$std_error_formatted else ""
+      )
+    }
     total_obs <- unique(model_rows$n_obs_total)
     total_obs <- total_obs[is.finite(total_obs)]
     model_obs <- unique(model_rows$n_obs_model)
@@ -488,6 +544,7 @@ build_summary_table <- function(coefficients, digits) {
       if (nrow(pb_row)) pb_row$std_error_formatted else "",
       if (nrow(eff_row)) eff_row$estimate_formatted else "",
       if (nrow(eff_row)) eff_row$std_error_formatted else "",
+      extra_cells,
       if (length(total_obs)) format_number(total_obs[1], 0) else "",
       if (length(model_obs)) format_number(model_obs[1], 0) else ""
     )
@@ -510,6 +567,12 @@ run_nonlinear_methods <- function(df, options) {
         if (is.null(degenerate_reason)) {
           degenerate_reason <- degenerate_effect_reason(method_result$publication_bias, "Publication-bias estimate")
         }
+        if (is.null(degenerate_reason)) {
+          for (extra in method_result$extra_terms %||% list()) {
+            degenerate_reason <- degenerate_effect_reason(extra, paste(extra$term_label, "estimate"))
+            if (!is.null(degenerate_reason)) break
+          }
+        }
         if (is.null(degenerate_reason) && !is.null(spec$degenerate_check)) {
           degenerate_reason <- spec$degenerate_check(method_result)
         }
@@ -527,6 +590,7 @@ run_nonlinear_methods <- function(df, options) {
           model = spec$name,
           model_label = spec$label,
           term = "publication_bias",
+          term_label = "Publication Bias",
           estimate = pb$estimate,
           std_error = pb$std_error,
           p_value = pb$p_value,
@@ -538,6 +602,7 @@ run_nonlinear_methods <- function(df, options) {
           model = spec$name,
           model_label = spec$label,
           term = "effect",
+          term_label = "Effect Beyond Bias",
           estimate = effect$estimate,
           std_error = effect$std_error,
           p_value = effect$p_value,
@@ -545,6 +610,20 @@ run_nonlinear_methods <- function(df, options) {
           n_obs_model = n_model,
           stringsAsFactors = FALSE
         )
+        for (extra in method_result$extra_terms %||% list()) {
+          coefficients[[length(coefficients) + 1]] <- data.frame(
+            model = spec$name,
+            model_label = spec$label,
+            term = extra$term,
+            term_label = extra$term_label,
+            estimate = extra$estimate,
+            std_error = extra$std_error,
+            p_value = extra$p_value,
+            n_obs_total = total_n,
+            n_obs_model = n_model,
+            stringsAsFactors = FALSE
+          )
+        }
         results[[length(results) + 1]] <- do.call(rbind, coefficients)
       },
       error = function(e) {
@@ -557,6 +636,7 @@ run_nonlinear_methods <- function(df, options) {
       model = character(),
       model_label = character(),
       term = character(),
+      term_label = character(),
       estimate = numeric(),
       std_error = numeric(),
       p_value = numeric(),

--- a/inst/artma/methods/nonlinear_tests.R
+++ b/inst/artma/methods/nonlinear_tests.R
@@ -50,8 +50,13 @@ nonlinear_tests <- function(df) {
     ))
   )
 
-  assert(length(resolved_options$selection_cutoffs) > 0, "Selection model requires at least one cutoff value.")
-  assert(all(resolved_options$selection_cutoffs > 0), "Selection cutoffs must be positive.")
+  selection_cutoffs <- resolved_options$selection_cutoffs
+  assert(length(selection_cutoffs) > 0, "Selection model requires at least one cutoff value.")
+  assert(all(is.finite(selection_cutoffs)), "Selection cutoffs must be finite numbers.")
+  assert(
+    !is.unsorted(selection_cutoffs, strictly = TRUE),
+    "Selection cutoffs must be strictly increasing, without duplicates."
+  )
 
   results <- run_nonlinear_methods(df, resolved_options)
 

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -175,8 +175,12 @@ methods:
       type: "numeric"
       default: [1.96]
       help: |
-        Cut-off values supplied to the selection model. Provide one or more
-        positive values corresponding to the publication probability thresholds.
+        Cut-off values supplied to the selection model, expressed as
+        t-statistic thresholds delimiting the publication probability
+        intervals. Provide one or more strictly increasing values without
+        duplicates; zero and negative values are allowed, e.g.
+        [-1.96, 0, 1.96] for literatures with negative effects or [0] for
+        selection on the sign of the estimate.
 
     selection_symmetric:
       type: "logical"

--- a/tests/testthat/test-calc-selection-model.R
+++ b/tests/testthat/test-calc-selection-model.R
@@ -1,7 +1,9 @@
 box::use(
   testthat[
     expect_equal,
+    expect_false,
     expect_length,
+    expect_message,
     expect_true,
     test_that
   ],
@@ -9,10 +11,27 @@ box::use(
     compute_tpowers,
     variation_variance_loglikelihood,
     clustered_covariance_estimate,
+    compute_information_matrix,
+    compute_score_matrix,
     estimates_table,
     metastudies_estimation
   ]
 )
+
+# Synthetic meta-analytic sample with genuine study-level heterogeneity, so
+# study clustering changes the standard errors and the selection model's
+# publication-probability parameters sit in the interior of their cells.
+make_clustered_selection_data <- function() {
+  set.seed(2024)
+  n_studies <- 15L
+  per_study <- 6L
+  n <- n_studies * per_study
+  study <- rep(seq_len(n_studies), each = per_study)
+  study_effect <- rnorm(n_studies, mean = 0.1, sd = 0.3)
+  se <- runif(n, 0.05, 0.35)
+  effect <- study_effect[study] + rnorm(n, 0, se)
+  list(effect = effect, se = se, study = study, n = n)
+}
 
 # compute_tpowers -----------------------------------------------------------
 
@@ -99,4 +118,84 @@ test_that("metastudies_estimation recovers a homogeneous true effect", {
   expect_equal(fit$Psihat[1], 0.3, tolerance = 0.1)
   expect_length(fit$SE, length(fit$Psihat))
   expect_true(all(fit$Psihat[-1] >= 0))
+})
+
+test_that("metastudies_estimation supports zero and negative cutoffs", {
+  d <- make_clustered_selection_data()
+
+  fit <- metastudies_estimation(
+    d$effect, d$se,
+    cutoffs = c(-1.96, 0, 1.96), symmetric = FALSE, model = "normal",
+    cluster_id = d$study
+  )
+
+  # mu, tau, and one publication probability per interval below a cutoff.
+  expect_length(fit$Psihat, 5L)
+  expect_equal(fit$convergence, 0)
+  expect_false(fit$boundary_hit)
+})
+
+test_that("metastudies_estimation clusters standard errors by study", {
+  d <- make_clustered_selection_data()
+
+  fit_clustered <- metastudies_estimation(
+    d$effect, d$se,
+    cutoffs = 1.96, symmetric = FALSE, model = "normal",
+    cluster_id = d$study
+  )
+  fit_unclustered <- metastudies_estimation(
+    d$effect, d$se,
+    cutoffs = 1.96, symmetric = FALSE, model = "normal"
+  )
+
+  # Clustering only changes the variance estimate, not the point estimates.
+  expect_equal(fit_clustered$Psihat, fit_unclustered$Psihat)
+  expect_true(fit_clustered$clustered)
+  expect_false(fit_unclustered$clustered)
+  expect_false(isTRUE(all.equal(fit_clustered$SE, fit_unclustered$SE)))
+})
+
+test_that("clustered standard errors match an independently computed cluster sandwich", {
+  d <- make_clustered_selection_data()
+
+  fit <- metastudies_estimation(
+    d$effect, d$se,
+    cutoffs = 1.96, symmetric = FALSE, model = "normal",
+    cluster_id = d$study
+  )
+
+  tpowers <- compute_tpowers(d$effect / d$se, cutoffs = 1.96, symmetric = FALSE)
+  llh <- function(psi) {
+    variation_variance_loglikelihood(
+      psi[1], psi[2], c(psi[3], 1), 1.96, FALSE, d$effect, d$se, tpowers
+    )
+  }
+  scores <- compute_score_matrix(fit$Psihat, 1e-6, llh)
+  centered <- sweep(scores, 2, colMeans(scores))
+  meat <- crossprod(rowsum(centered, d$study)) / (d$n - 1)
+  bread <- solve(compute_information_matrix(fit$Psihat, 1e-6, llh))
+  expected_se <- sqrt(diag(bread %*% meat %*% bread * d$n))
+
+  expect_equal(unname(fit$SE), unname(expected_se), tolerance = 1e-8)
+})
+
+test_that("metastudies_estimation falls back to unclustered errors with a single cluster", {
+  d <- make_clustered_selection_data()
+
+  fit_single <- NULL
+  expect_message(
+    fit_single <- metastudies_estimation(
+      d$effect, d$se,
+      cutoffs = 1.96, symmetric = FALSE, model = "normal",
+      cluster_id = rep(1L, d$n)
+    ),
+    "unclustered"
+  )
+  fit_unclustered <- metastudies_estimation(
+    d$effect, d$se,
+    cutoffs = 1.96, symmetric = FALSE, model = "normal"
+  )
+
+  expect_false(fit_single$clustered)
+  expect_equal(fit_single$SE, fit_unclustered$SE)
 })

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_error,
     expect_false,
     expect_gt,
     expect_identical,
@@ -74,8 +75,9 @@ test_that("nonlinear tests return tidy coefficients and summary", {
   expect_named(
     res$meta$coefficients,
     c(
-      "model", "model_label", "term", "estimate", "std_error", "p_value",
-      "n_obs_total", "n_obs_model", "estimate_formatted", "std_error_formatted"
+      "model", "model_label", "term", "term_label", "estimate", "std_error",
+      "p_value", "n_obs_total", "n_obs_model", "estimate_formatted",
+      "std_error_formatted"
     )
   )
   expect_setequal(unique(res$meta$coefficients$term), c("publication_bias", "effect"))
@@ -110,6 +112,103 @@ test_that("nonlinear tests writes STEM diagnostic plot files when export is enab
   expect_setequal(list.files(dir), c("stem_funnel.png", "stem_mse.png"))
   expect_s3_class(res$plots$stem_funnel, "recordedplot")
   expect_s3_class(res$plots$stem_mse, "recordedplot")
+})
+
+# Model-generated data with genuine study-level heterogeneity and effects of
+# mixed sign and significance, so every publication-probability interval of
+# the standard cutoff specs is populated and the selection model converges to
+# an interior solution.
+make_mixed_significance_data <- function() {
+  set.seed(2024)
+  n_studies <- 15L
+  per_study <- 6L
+  n <- n_studies * per_study
+  study_ids <- rep(paste0("S", seq_len(n_studies)), each = per_study)
+  study_effect <- rnorm(n_studies, mean = 0.1, sd = 0.3)
+  se_vals <- runif(n, 0.05, 0.35)
+  effect_vals <- rep(study_effect, each = per_study) + rnorm(n, 0, se_vals)
+  data.frame(
+    study_id = study_ids,
+    effect = effect_vals,
+    se = se_vals,
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("selection model runs with negative and zero cutoffs and restructured labels", {
+  df <- make_mixed_significance_data()
+
+  local_options(
+    "artma.methods.nonlinear_tests.selection_cutoffs" = c(-1.96, 0, 1.96),
+    "artma.methods.nonlinear_tests.selection_symmetric" = FALSE,
+    "artma.methods.nonlinear_tests.selection_model" = "normal",
+    "artma.methods.nonlinear_tests.hierarchical_iterations" = 20L,
+    "artma.visualization.export_graphics" = FALSE,
+    "artma.verbose" = 0L
+  )
+
+  res <- suppressWarnings(suppressMessages(nonlinear_tests(df)))
+
+  expect_false("selection" %in% names(res$meta$skipped))
+  selection <- res$meta$coefficients[res$meta$coefficients$model == "selection", , drop = FALSE]
+  expect_setequal(
+    selection$term,
+    c(
+      "publication_bias", "effect", "effect_heterogeneity",
+      "pub_prob_1", "pub_prob_2", "pub_prob_3"
+    )
+  )
+  expect_setequal(
+    selection$term_label[grepl("^pub_prob_", selection$term)],
+    c(
+      "Rel. Pub. Probability (-Inf, -1.96]",
+      "Rel. Pub. Probability (-1.96, 0]",
+      "Rel. Pub. Probability (0, 1.96]"
+    )
+  )
+
+  # tau is reported as heterogeneity, not as publication bias: the selection
+  # model carries no publication-bias estimate at all.
+  expect_true(is.na(selection$estimate[selection$term == "publication_bias"]))
+  tau_row <- selection[selection$term == "effect_heterogeneity", , drop = FALSE]
+  expect_identical(tau_row$term_label, "Effect Heterogeneity (tau)")
+  expect_true(is.finite(tau_row$estimate) && is.finite(tau_row$std_error))
+
+  summary <- res$tables$summary
+  expect_true("Effect Heterogeneity (tau)" %in% summary$Metric)
+  expect_true(any(grepl("Rel. Pub. Probability", summary$Metric, fixed = TRUE)))
+  expect_identical(summary$Selection[summary$Metric == "Publication Bias"], "NA")
+})
+
+test_that("selection model runs with a single zero cutoff (sign selection)", {
+  df <- make_mixed_significance_data()
+
+  local_options(
+    "artma.methods.nonlinear_tests.selection_cutoffs" = c(0),
+    "artma.methods.nonlinear_tests.selection_symmetric" = FALSE,
+    "artma.methods.nonlinear_tests.selection_model" = "normal",
+    "artma.methods.nonlinear_tests.hierarchical_iterations" = 20L,
+    "artma.visualization.export_graphics" = FALSE,
+    "artma.verbose" = 0L
+  )
+
+  res <- suppressWarnings(suppressMessages(nonlinear_tests(df)))
+
+  expect_false("selection" %in% names(res$meta$skipped))
+  selection <- res$meta$coefficients[res$meta$coefficients$model == "selection", , drop = FALSE]
+  expect_true("pub_prob_1" %in% selection$term)
+  expect_true("Rel. Pub. Probability (-Inf, 0]" %in% selection$term_label)
+})
+
+test_that("selection cutoffs must be strictly increasing without duplicates", {
+  df <- make_mixed_significance_data()
+
+  local_options(
+    "artma.methods.nonlinear_tests.selection_cutoffs" = c(1.96, 1.96),
+    "artma.verbose" = 0L
+  )
+
+  expect_error(suppressWarnings(nonlinear_tests(df)), "strictly increasing")
 })
 
 make_degenerate_options <- function() {


### PR DESCRIPTION
Closes #367

Three related fixes to the Andrews-Kasy selection model as surfaced through `nonlinear_tests`:

1. **Cutoff gate relaxed.** The option gate in `nonlinear_tests` no longer requires all `selection_cutoffs` to be positive. Cutoffs must now be finite, non-empty, and strictly increasing without duplicates, so standard specs such as `[-1.96, 0, 1.96]` (negative-effect literatures) and `[0]` (sign selection) pass through to `metastudies_estimation()`, which already handled them. The option's template documentation is updated accordingly.

2. **Study-clustered standard errors.** `metastudies_estimation()` gains a `cluster_id` argument; `run_selection()` threads `study_id` through it. The cluster-robust ML sandwich aggregates score contributions by study before forming the meat (via the existing `clustered_covariance_estimate()`, which previously received `seq_len(n)`, i.e. one cluster per observation). With a single study, incomplete identifiers, or a failed clustered computation, the fit falls back to unclustered SEs with a message. Point estimates are unchanged; only the variance estimate moves.

3. **Summary labels restructured.** The selection column no longer prints Psihat[2] (tau, the effect-dispersion scale) as "Publication Bias". The effect row stays as is; tau is now reported as "Effect Heterogeneity (tau)"; and the relative publication probabilities (betap, one per cutoff interval, normalized to the interval above the last cutoff) are reported with their SEs as "Rel. Pub. Probability (interval)" rows. The coefficients frame keeps the term/estimate/std_error shape plus significance marks, with a new `term_label` column; other methods' rows and the pinned characterization tables are unchanged.

**Flagged for review:**

- **Label restructuring (point 3):** the selection model's "Publication Bias" summary cell is now intentionally empty ("NA", matching WAAP/Stem, which also have no publication-bias term), and the new rows appear only when the selection model produces estimates. Significance marks on the publication-probability rows test the no-selection null of 1 rather than 0, since the probabilities are relative to the reference interval; happy to change if you prefer marks against 0 or no marks there.
- **Clustering approach (point 2):** clustering follows the `linear_tests` convention of always clustering by `study_id` with no new option, with the unclustered path kept as an automatic fallback. No new option groups were added; the existing `selection_cutoffs`, `selection_model`, and `selection_symmetric` names are untouched.

Regression tests use in-test synthetic data (15 studies, study-level heterogeneity, mixed signs and significance): end-to-end runs through the method options path for cutoffs `[-1.96, 0, 1.96]` and `[0]`, clustered vs unclustered SEs differing and the clustered values matching an independently computed cluster sandwich (score aggregation via `rowsum`), the single-cluster fallback, the strictly-increasing gate, and the restructured summary rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMZkemKgqU7mT6cgTHmF1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMZkemKgqU7mT6cgTHmF1m)_