### PR TITLE
fix(endo-kink): use model df, not residual df, in heterogeneity variance divisor

### DIFF
--- a/inst/artma/calc/methods/endo_kink.R
+++ b/inst/artma/calc/methods/endo_kink.R
@@ -59,7 +59,9 @@ select_combined_regression <- function(pet_estimate, pet_std_error, peese_estima
 compute_variance_component <- function(combined_residual_sum, data, peese_model) {
   m <- nrow(data)
   wis_sum <- base::sum(data$wis)
-  df_model <- stats::df.residual(peese_model)
+  # Bom & Rachinger divide Q1 by M - e(df_m) - 1, where e(df_m) is the model
+  # degrees of freedom (number of regressors), not the residual df.
+  df_model <- length(stats::coef(peese_model))
   sigma_sq <- base::pmax(0, m * ((combined_residual_sum / (m - df_model - 1)) - 1) / wis_sum)
   list(
     variance_component = sigma_sq,
@@ -91,7 +93,7 @@ final_endokink_fit <- function(prepared_data, cutoff, verbose) {
   sebs_min <- min(prepared_data$sebs)
   sebs_max <- max(prepared_data$sebs)
   if (cutoff > sebs_min && cutoff < sebs_max) {
-    prepared_data$sebs_a1 <- if (prepared_data$sebs > cutoff) prepared_data$sebs - cutoff else 0
+    prepared_data$sebs_a1 <- base::pmax(prepared_data$sebs - cutoff, 0)
     prepared_data$pubbias <- prepared_data$sebs_a1 / prepared_data$sebs
     model <- stats::lm(bs ~ 0 + constant + pubbias, data = prepared_data)
     result <- summary(model)$coefficients

--- a/tests/testthat/test-calc-endo-kink.R
+++ b/tests/testthat/test-calc-endo-kink.R
@@ -74,18 +74,60 @@ test_that("run_endogenous_kink recovers a homogeneous true effect", {
   expect_true(is.finite(out[2]))
 })
 
-test_that("run_endogenous_kink's no-kink fallback matches a precision-weighted OLS fit", {
-  # Below the +/-1.96*sd band, compute_cutoff() returns 0 and
-  # final_endokink_fit() falls back to an unrestricted regression of bs_sebs
-  # on ones_sebs + pub_bias, which is algebraically the same as a weighted
-  # least-squares fit of effect on se with weights 1/se^2 (i.e. "precision
-  # weighted" when a dataset's precision column is defined as 1/se). A
-  # coincidental match between Endogenous Kink and a precision-weighted OLS
-  # spec in this regime is therefore expected, not a wiring bug.
-  set.seed(5)
-  n <- 40
+test_that("run_endogenous_kink matches the Bom & Rachinger reference on low-heterogeneity data", {
+  # Regression test for issue #366: the heterogeneity variance divisor must be
+  # M - model_df - 1 (model df = 2 regressors), not M - df.residual - 1 = 1.
+  # The inflated variance made the interior-kink condition never fire, so the
+  # estimator silently degenerated to PET. Low-heterogeneity data exposes the
+  # bug; the reference formula below is implemented independently.
+  set.seed(42)
+  n <- 200
   se <- runif(n, 0.05, 0.5)
-  effect <- 0.3 + rnorm(n, 0, se)
+  effect <- 0.5 + rnorm(n, 0, 0.05)
+
+  ref <- data.frame(t = effect / se, prec = 1 / se, ones = 1, se = se)
+  pet <- stats::lm(t ~ 0 + prec + ones, data = ref)
+  peese <- stats::lm(t ~ 0 + prec + se, data = ref)
+  pet_tab <- summary(pet)$coefficients
+  t_stat <- pet_tab["prec", "Estimate"] / pet_tab["prec", "Std. Error"]
+  if (abs(t_stat) > stats::qt(0.975, n - 2)) {
+    combined <- unname(stats::coef(peese)["prec"])
+    q1 <- sum(stats::residuals(peese)^2)
+  } else {
+    combined <- unname(stats::coef(pet)["prec"])
+    q1 <- sum(stats::residuals(pet)^2)
+  }
+  sigma_hat <- sqrt(max(0, n * (q1 / (n - 2 - 1) - 1) / sum(1 / se^2)))
+  a1 <- (combined - 1.96 * sigma_hat) * (combined + 1.96 * sigma_hat) / (2 * 1.96 * combined)
+  # The kink must be interior on this data, otherwise the test loses its power.
+  expect_true(combined > 1.96 * sigma_hat)
+  expect_true(a1 > min(se) && a1 < max(se))
+  ref$pubbias <- pmax(se - a1, 0) / se
+  kinked <- summary(stats::lm(t ~ 0 + prec + pubbias, data = ref))$coefficients
+
+  out <- run_endogenous_kink(data.frame(effect, se), verbose = FALSE)
+
+  expect_equal(unname(out[1]), unname(kinked["prec", "Estimate"]))
+  expect_equal(unname(out[2]), unname(kinked["prec", "Std. Error"]))
+  expect_equal(unname(out[3]), unname(kinked["pubbias", "Estimate"]))
+  expect_equal(unname(out[4]), unname(kinked["pubbias", "Std. Error"]))
+  # An interior kink means the estimate is not the plain PET estimate.
+  expect_false(isTRUE(all.equal(unname(out[1]), unname(stats::coef(pet)["prec"]))))
+})
+
+test_that("run_endogenous_kink's no-kink fallback matches a precision-weighted OLS fit", {
+  # On heavily heterogeneous data the heterogeneity SD swamps the combined
+  # estimate, compute_cutoff() returns 0, and final_endokink_fit() falls back
+  # to an unrestricted regression of bs_sebs on ones_sebs + pub_bias, which is
+  # algebraically the same as a weighted least-squares fit of effect on se
+  # with weights 1/se^2 (i.e. "precision weighted" when a dataset's precision
+  # column is defined as 1/se). A coincidental match between Endogenous Kink
+  # and a precision-weighted OLS spec in this regime is therefore expected,
+  # not a wiring bug.
+  set.seed(7)
+  n <- 150
+  se <- runif(n, 0.05, 0.5)
+  effect <- 0.3 + rnorm(n, 0, 0.6) + rnorm(n, 0, se)
   df <- data.frame(effect, se)
 
   out <- run_endogenous_kink(df, verbose = FALSE)


### PR DESCRIPTION
Closes #366

## What

The endogenous kink heterogeneity variance used `stats::df.residual(peese_model)` (residual df, m - 2) where Bom and Rachinger's reference code uses the model df, `e(df_m)` (number of regressors, 2). The divisor `m - df_model - 1` therefore collapsed to 1, inflating `sigma_sq` roughly m-fold.

## Before

The inflated heterogeneity SD made the interior-kink condition `combined_estimate > 1.96 * variance_sd` essentially never fire, so the estimator silently degenerated to PET. On heavily heterogeneous real meta-analysis data both formulas yield a1 = 0 and identical output, which is why the bug survived replication against published studies; it only shows on low-heterogeneity data.

## After

`compute_variance_component` now uses `length(stats::coef(peese_model))` (2), giving the correct divisor m - 3. On synthetic low-heterogeneity data the interior kink now fires and the estimate matches an independent implementation of the Bom and Rachinger reference formula to machine precision, while differing from plain PET. Also vectorized `sebs_a1 = pmax(sebs - cutoff, 0)` in `final_endokink_fit`: the previous scalar `if` on a vector was unreachable while a1 was always 0, but errors in R >= 4.2 once the interior branch fires.

## Tests

- New regression test: synthetic near-homogeneous data (n = 200, true effect 0.5, no publication bias), reference formula implemented independently in-test; asserts artma matches it exactly and differs from the PET estimate (kink is interior).
- The no-kink fallback test now uses genuinely heterogeneous data so a1 = 0 holds under the correct formula, still asserting the degenerate branch equals precision-weighted OLS. Its previous near-homogeneous data now correctly produces an interior kink, which is exactly the behavior change the divisor fix introduces.
- All expectations computed in-test; no data files. Full endo kink test file passes (28 assertions).

---
_Generated by [Claude Code](https://claude.ai/code/session_0169JCBJWTiBwi3fVQ1JnL1Q)_