### PR TITLE
fix: use inverse-variance WAAP pilot weights and clustered WLS standard errors

### DIFF
--- a/inst/artma/econometric/nonlinear.R
+++ b/inst/artma/econometric/nonlinear.R
@@ -19,6 +19,7 @@ box::use(
   artma / calc / methods / stem[stem, stem_funnel, stem_MSE, STEM_MIN_STUDIES],
   artma / calc / methods / selection_model[metastudies_estimation],
   artma / calc / methods / endo_kink[run_endogenous_kink],
+  artma / econometric / vcov[robust_vcov],
   artma / visualization / options[get_visualization_options],
   artma / visualization / export[export_named_plots]
 )
@@ -156,24 +157,75 @@ nonlinear_method_specs <- function(options) {
   )
 }
 
-prepare_basic_data <- function(df, required_cols) {
-  validate_columns(df, required_cols)
-  cleaned <- df[, required_cols, drop = FALSE]
-  for (col in required_cols) {
-    cleaned <- cleaned[is.finite(cleaned[[col]]), , drop = FALSE]
-  }
-  cleaned
-}
-
+#' Adequately-powered cutoff for the WAAP estimator
+#'
+#' @description
+#' Following Ioannidis et al. (2017), the pilot (unrestricted) mean is the
+#' inverse-variance weighted average of the effects; a study is adequately
+#' powered when its standard error is below `|mean| / 2.8`.
+#'
+#' @param df *\[data.frame\]* With finite `effect` and positive `se` columns.
+#' @return *\[numeric\]* The standard-error cutoff.
+#' @keywords internal
 waap_bound <- function(df) {
-  weights <- 1 / df$se
+  weights <- 1 / df$se^2
   avg <- sum(df$effect * weights) / sum(weights)
   abs(avg) / 2.8
 }
 
+#' Keep the columns and rows WAAP/Top10 can use
+#'
+#' @description
+#' Filters to finite `effect` and positive finite `se`, carrying `study_id`
+#' along when the input has it so the fit can cluster by study.
+#'
+#' @param df *\[data.frame\]* Input data.
+#' @return *\[data.frame\]* The cleaned subset.
+#' @keywords internal
+prepare_precision_weighted_data <- function(df) {
+  validate_columns(df, c("effect", "se"))
+  cols <- intersect(c("effect", "se", "study_id"), colnames(df))
+  data <- df[, cols, drop = FALSE]
+  data[is.finite(data$effect) & is.finite(data$se) & data$se > 0, , drop = FALSE]
+}
+
+#' Precision-weighted WLS fit shared by WAAP and Top10
+#'
+#' @description
+#' Runs the WLS regression `t_stat ~ 0 + precision` on the selected
+#' subsample. The coefficient equals the inverse-variance weighted mean of
+#' the effects; the standard error is the regression standard error, which
+#' scales with residual heterogeneity. It is clustered by `study_id` (HC1,
+#' matching the linear tests) when clustering is possible, with a
+#' non-clustered HC1 fallback.
+#'
+#' @param data *\[data.frame\]* With `effect`, `se`, and optionally `study_id`.
+#' @return *\[list\]* With elements `estimate` and `std_error`.
+#' @keywords internal
+precision_weighted_wls <- function(data) {
+  t_stat <- data$effect / data$se
+  precision <- 1 / data$se
+  model <- stats::lm(t_stat ~ 0 + precision)
+  cluster <- data$study_id
+  if (!is.null(cluster) && anyNA(cluster)) {
+    cluster <- NULL
+  }
+  vcov <- robust_vcov(
+    model = model,
+    cluster = cluster,
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = "HC1",
+    final_vcov_fallback = FALSE
+  )
+  list(
+    estimate = stats::coef(model)[["precision"]],
+    std_error = sqrt(vcov["precision", "precision"])
+  )
+}
+
 run_waap <- function(df, total_n) {
-  data <- prepare_basic_data(df, c("effect", "se"))
-  data <- data[data$se > 0, , drop = FALSE]
+  data <- prepare_precision_weighted_data(df)
   if (nrow(data) < 2) {
     cli::cli_abort("Not enough observations to compute the WAAP estimator.")
   }
@@ -186,13 +238,12 @@ run_waap <- function(df, total_n) {
     cli::cli_abort("Not enough adequately powered observations for the WAAP estimator.")
   }
   weights <- 1 / filtered$se^2
-  estimate <- sum(filtered$effect * weights) / sum(weights)
-  std_error <- sqrt(1 / sum(weights))
+  fit <- precision_weighted_wls(filtered)
   list(
     effect = list(
-      estimate = estimate,
-      std_error = std_error,
-      p_value = normal_p_value(estimate, std_error)
+      estimate = fit$estimate,
+      std_error = fit$std_error,
+      p_value = normal_p_value(fit$estimate, fit$std_error)
     ),
     n_model = nrow(filtered),
     effective_n = effective_sample_size(weights)
@@ -200,8 +251,7 @@ run_waap <- function(df, total_n) {
 }
 
 run_top10 <- function(df, total_n) {
-  data <- prepare_basic_data(df, c("effect", "se"))
-  data <- data[data$se > 0, , drop = FALSE]
+  data <- prepare_precision_weighted_data(df)
   if (nrow(data) < 2) {
     cli::cli_abort("Not enough observations to compute the Top10 estimator.")
   }
@@ -212,13 +262,12 @@ run_top10 <- function(df, total_n) {
     cli::cli_abort("Not enough high-precision observations for the Top10 estimator.")
   }
   weights <- 1 / filtered$se^2
-  estimate <- sum(filtered$effect * weights) / sum(weights)
-  std_error <- sqrt(1 / sum(weights))
+  fit <- precision_weighted_wls(filtered)
   list(
     effect = list(
-      estimate = estimate,
-      std_error = std_error,
-      p_value = normal_p_value(estimate, std_error)
+      estimate = fit$estimate,
+      std_error = fit$std_error,
+      p_value = normal_p_value(fit$estimate, fit$std_error)
     ),
     n_model = nrow(filtered),
     effective_n = effective_sample_size(weights)
@@ -582,7 +631,10 @@ run_nonlinear_methods <- function(df, options) {
 }
 
 box::export(
-  run_nonlinear_methods
+  run_nonlinear_methods,
+  run_waap,
+  run_top10,
+  waap_bound
 )
 
 # nocov end -------------------------------------------------------------------

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -149,7 +149,9 @@ test_that("WAAP and STEM formatted cells are pinned across the formatting refact
   expect_identical(waap_pb$estimate_formatted, "NA")
   expect_identical(waap_pb$std_error_formatted, "")
   expect_identical(waap_eff$estimate_formatted, "0.13***")
-  expect_identical(waap_eff$std_error_formatted, "(0.01)")
+  # The WAAP standard error is the study-clustered WLS regression SE; the
+  # fixture effects are nearly homogeneous, so it rounds below 0.01 here.
+  expect_identical(waap_eff$std_error_formatted, "(0.00)")
 
   stem_rows <- res$coefficients[res$coefficients$model == "stem", ]
   stem_pb <- stem_rows[stem_rows$term == "publication_bias", ]

--- a/tests/testthat/test-nonlinear-waap-top10.R
+++ b/tests/testthat/test-nonlinear-waap-top10.R
@@ -1,0 +1,112 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_gt,
+    expect_identical,
+    test_that
+  ]
+)
+
+box::use(
+  artma / econometric / nonlinear[run_top10, run_waap, waap_bound]
+)
+
+# Synthetic meta-analysis sample: several studies, heterogeneous effects, and
+# a positive effect-se correlation so that 1/se and 1/se^2 pilot weights give
+# different unrestricted means (and hence different WAAP bounds).
+make_waap_data <- function() {
+  set.seed(1234)
+  n_studies <- 12L
+  per_study <- 12L
+  n <- n_studies * per_study
+  study_id <- rep(paste0("S", seq_len(n_studies)), each = per_study)
+  se <- stats::runif(n, 0.02, 0.5)
+  study_shift <- rep(stats::rnorm(n_studies, 0, 0.05), each = per_study)
+  effect <- 0.3 + 0.8 * se + study_shift + stats::rnorm(n, 0, 0.08)
+  data.frame(
+    study_id = study_id,
+    effect = effect,
+    se = se,
+    stringsAsFactors = FALSE
+  )
+}
+
+# Reference pilot mean: intercept of a WLS regression on a constant with
+# aweight-style inverse-variance weights (Ioannidis et al. 2017).
+reference_waap_bound <- function(df) {
+  pilot <- stats::lm(effect ~ 1, data = df, weights = 1 / df$se^2)
+  abs(stats::coef(pilot)[[1]]) / 2.8
+}
+
+# Reference WAAP/Top10 fit: WLS regression t ~ 0 + precision on the selected
+# subsample, with its standard error clustered by study (HC1).
+reference_wls_fit <- function(subsample) {
+  t_stat <- subsample$effect / subsample$se
+  precision <- 1 / subsample$se
+  fit <- stats::lm(t_stat ~ 0 + precision)
+  vcov <- sandwich::vcovCL(fit, cluster = subsample$study_id, type = "HC1")
+  list(
+    estimate = stats::coef(fit)[["precision"]],
+    std_error = sqrt(vcov["precision", "precision"])
+  )
+}
+
+test_that("waap_bound weights the pilot mean by inverse variance", {
+  df <- make_waap_data()
+
+  expect_equal(waap_bound(df), reference_waap_bound(df), tolerance = 1e-12)
+})
+
+test_that("WAAP selects the subsample implied by the inverse-variance pilot mean", {
+  df <- make_waap_data()
+
+  bound <- reference_waap_bound(df)
+  expected_subsample <- df[df$se < bound, , drop = FALSE]
+
+  # The old 1/se pilot weights select a different subsample, so this fixture
+  # genuinely discriminates between the two weighting schemes.
+  old_pilot_mean <- sum(df$effect / df$se) / sum(1 / df$se)
+  old_subsample <- df[df$se < abs(old_pilot_mean) / 2.8, , drop = FALSE]
+  expect_false(nrow(old_subsample) == nrow(expected_subsample))
+
+  res <- run_waap(df, nrow(df))
+  reference <- reference_wls_fit(expected_subsample)
+
+  expect_identical(res$n_model, nrow(expected_subsample))
+  expect_equal(res$effect$estimate, reference$estimate, tolerance = 1e-12)
+})
+
+test_that("WAAP reports the study-clustered WLS regression standard error", {
+  df <- make_waap_data()
+
+  expected_subsample <- df[df$se < reference_waap_bound(df), , drop = FALSE]
+  reference <- reference_wls_fit(expected_subsample)
+
+  res <- run_waap(df, nrow(df))
+
+  expect_equal(res$effect$estimate, reference$estimate, tolerance = 1e-12)
+  expect_equal(res$effect$std_error, reference$std_error, tolerance = 1e-12)
+
+  # The homogeneous fixed-effect formula understates the uncertainty here.
+  fixed_effect_se <- sqrt(1 / sum(1 / expected_subsample$se^2))
+  expect_gt(res$effect$std_error, fixed_effect_se)
+})
+
+test_that("Top10 reports the study-clustered WLS regression standard error", {
+  df <- make_waap_data()
+
+  precision <- 1 / df$se
+  threshold <- stats::quantile(precision, probs = 0.9, names = FALSE)
+  expected_subsample <- df[precision > threshold, , drop = FALSE]
+  reference <- reference_wls_fit(expected_subsample)
+
+  res <- run_top10(df, nrow(df))
+
+  expect_identical(res$n_model, nrow(expected_subsample))
+  expect_equal(res$effect$estimate, reference$estimate, tolerance = 1e-12)
+  expect_equal(res$effect$std_error, reference$std_error, tolerance = 1e-12)
+
+  fixed_effect_se <- sqrt(1 / sum(1 / expected_subsample$se^2))
+  expect_gt(res$effect$std_error, fixed_effect_se)
+})

--- a/tests/testthat/test-summary-table-characterization.R
+++ b/tests/testthat/test-summary-table-characterization.R
@@ -141,7 +141,9 @@ test_that("nonlinear_tests summary table is pinned on fixture data", {
         "Publication Bias", "(Std. Error)", "Effect Beyond Bias",
         "(Std. Error)", "Total observations", "Model observations"
       ),
-      WAAP = c("NA", "", "0.13***", "(0.01)", "90", "15"),
+      # The WAAP standard error is the study-clustered WLS regression SE; the
+      # fixture effects are nearly homogeneous, so it rounds below 0.01 here.
+      WAAP = c("NA", "", "0.13***", "(0.00)", "90", "15"),
       Stem = c("NA", "", "0.15***", "(0.02)", "90", "14"),
       Hierarch = c("0.56***", "(0.16)", "0.08", "(0.15)", "90", "90"),
       `Endogenous Kink` = c("0.57***", "(0.03)", "0.10***", "(0.00)", "90", "90")


### PR DESCRIPTION
Closes #362
Closes #363

## What changed

Both fixes live in `inst/artma/econometric/nonlinear.R`.

**WAAP pilot weights (#362).** `waap_bound()` computed the pilot (unrestricted) mean with weights `1/se`. Ioannidis et al. (2017) and the reference implementations weight by inverse variance. Before: the adequately-powered cutoff `|mean|/2.8` was derived from the wrong pilot mean, so WAAP selected the wrong subsample (for example 349 observations instead of 169 on one validation dataset). After: the pilot mean uses `1/se^2`, so the cutoff and the selected subsample match the reference implementations.

**WAAP/Top10 standard errors (#363).** `run_waap()` and `run_top10()` reported `sqrt(1/sum(weights))`, the homogeneous fixed-effect formula, which understated the uncertainty by 12x to 80x on validation datasets. After: both methods run the WLS regression `t_stat ~ 0 + precision` on the selected subsample and report its regression standard error, clustered by `study_id` via the shared `robust_vcov` helper (HC1, consistent with the linear tests), with a non-clustered HC1 fallback. The point estimate is unchanged, since the WLS coefficient equals the inverse-variance weighted mean.

## Tests

- New `tests/testthat/test-nonlinear-waap-top10.R` generates small synthetic multi-study data in-test and checks artma against independent reference implementations computed in the test itself: a plain `lm()` with inverse-variance weights for the pilot bound, and `lm(t ~ 0 + precision)` plus `sandwich::vcovCL` for the clustered standard error. One test proves the 1/se and 1/se^2 pilot weights select different subsamples on this data and that artma selects the inverse-variance one. No data files, no hardcoded numbers from papers.
- Two pinned characterization expectations changed, both the same cell: the WAAP formatted standard error on the demo fixture goes from `(0.01)` to `(0.00)`. The fixture's effects are nearly homogeneous, so the regression standard error, which scales with residual heterogeneity, rounds below 0.01 there. The WAAP estimate cell (`0.13***`) and the model observation count (15) are unchanged, confirming the fixture's subsample was unaffected and only the standard error formula changed.

Full test suite: 2513 passing, 0 failures. Lint and styler clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWUa4mqLMcyFfaBvPjzFvE)_