### PR TITLE
fix(fma): correct Mallows criterion, Buckland SE centering, and data scaling

### DIFF
--- a/inst/artma/econometric/fma.R
+++ b/inst/artma/econometric/fma.R
@@ -116,7 +116,6 @@ run_fma <- function(bma_data, bma_model, input_var_list, round_to = NULL, print_
   e <- matrix(0, nrow = n, ncol = M)
   k_vector <- matrix(seq_len(M), ncol = 1)
   var.matrix <- matrix(0, nrow = k, ncol = M)
-  bias.sq <- matrix(0, nrow = k, ncol = M)
   tol <- sqrt(.Machine$double.eps)
 
   for (i in seq_len(M)) {
@@ -138,26 +137,29 @@ run_fma <- function(bma_data, bma_model, input_var_list, round_to = NULL, print_
 
     e_i <- Y - x_tilda %*% beta.star
     e[, i] <- e_i
-    bias.sq[, i] <- (beta[, i] - beta.full)^2
 
     sigma_i <- as.numeric(crossprod(e_i) / (n - i))
     var.matrix.star <- diag(sigma_i, i, i)
     var.matrix.hat <- var.matrix.star %*% (Q %*% diag(lambda_adj^-1, i, i) %*% t(Q))
     var.matrix[1:i, i] <- diag(var.matrix.hat)
-    var.matrix[, i] <- var.matrix[, i] + bias.sq[, i]
   }
 
   e_k <- e[, M, drop = FALSE]
   sigma_hat <- as.numeric(crossprod(e_k) / (n - M))
   G <- crossprod(e)
   G <- (G + t(G)) / 2
-  a <- as.numeric((sigma_hat^2) * k_vector)
+  # Hansen (2007) Mallows criterion: minimize w'Gw + 2*sigma^2*k'w. solve.QP
+  # minimizes (1/2)b'Db - d'b, so with Dmat = G the penalty enters as -sigma^2*k.
+  a <- as.numeric(-sigma_hat * k_vector)
 
   weights <- solve_fma_weights(G, a)
 
   beta_scaled <- beta %*% weights
   final_beta <- as.numeric(beta_scaled / scale_vector)
-  std_scaled <- sqrt(var.matrix) %*% weights
+  # Buckland et al. (1997): spread term is squared deviation from the averaged
+  # estimate, folded into each model's variance before the weighted sqrt sum.
+  bias.sq <- (beta - as.numeric(beta_scaled))^2
+  std_scaled <- sqrt(var.matrix + bias.sq) %*% weights
   final_std <- as.numeric(std_scaled / scale_vector)
 
   t_stats <- final_beta / final_std

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -89,7 +89,9 @@ fma <- function(df, bma_result = NULL) {
       config = config,
       use_vif_optimization = use_vif_optimization,
       max_groups_to_remove = max_groups_to_remove,
-      scale_data = FALSE,
+      # Match the orchestrated path, which reuses the scaled frame from bma():
+      # both paths must report coefficients on the same scale.
+      scale_data = TRUE,
       verbosity = get_verbosity()
     )
 

--- a/tests/testthat/test-fma.R
+++ b/tests/testthat/test-fma.R
@@ -76,3 +76,59 @@ test_that("run_fma returns coefficients and weights", {
   expect_true(abs(sum(result$weights) - 1) < 1e-06)
   expect_true(all(result$weights >= -1e-08))
 })
+
+test_that("Mallows penalty favors small models on pure-noise predictors", {
+  skip_if_not_installed("BMS")
+  skip_if_not_installed("quadprog")
+
+  set.seed(42)
+  n <- 200L
+  df <- data.frame(
+    effect = rnorm(n),
+    noise1 = rnorm(n),
+    noise2 = rnorm(n),
+    noise3 = rnorm(n),
+    noise4 = rnorm(n),
+    noise5 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+
+  var_list <- data.frame(
+    var_name = colnames(df),
+    var_name_verbose = colnames(df),
+    bma = rep(TRUE, ncol(df)),
+    to_log_for_bma = rep(FALSE, ncol(df)),
+    bma_reference_var = rep(FALSE, ncol(df)),
+    stringsAsFactors = FALSE
+  )
+
+  bma_data <- get_bma_data(
+    df,
+    var_list,
+    variable_info = colnames(df),
+    scale_data = FALSE,
+    from_vector = TRUE,
+    include_reference_groups = FALSE
+  )
+
+  params <- list(
+    burn = 100L, iter = 500L, nmodel = 10L,
+    g = "UIP", mprior = "uniform", mcmc = "bd"
+  )
+  bma_model <- run_bma(bma_data, params)
+
+  result <- run_fma(
+    bma_data = bma_data,
+    bma_model = bma_model,
+    input_var_list = var_list,
+    print_results = "none"
+  )
+
+  # None of the predictors carry signal, so the complexity penalty must pull
+  # weight onto the smallest models. The sign-flipped criterion concentrated
+  # nearly all weight on the largest model instead.
+  m <- length(result$weights)
+  small_half <- sum(result$weights[seq_len(ceiling(m / 2))])
+  expect_true(small_half > 0.5)
+  expect_true(result$weights[m] < 0.5)
+})


### PR DESCRIPTION
Part of the numeric-correctness audit continuing #369-#373.

## What changed

**Mallows weight criterion (behavior change, high severity).** `run_fma` passed `+sigma_hat^2 * k` as `dvec` to `quadprog::solve.QP`. Since `sigma_hat` is already the residual variance and `solve.QP` minimizes `(1/2) b'Db - d'b`, the complexity penalty entered with the wrong sign (rewarding larger models) and as sigma^4 instead of sigma^2. Hansen (2007) requires minimizing `w'Gw + 2 sigma^2 k'w`, i.e. `dvec = -sigma^2 k`. Previously weights degenerated toward the largest nested model; now they follow the bias-variance tradeoff. New test pins this: on pure-noise predictors, weight must concentrate on small models.

**Buckland averaged SE (behavior change).** The between-model spread term was centered on the full-model coefficient, `(beta_m - beta_full)^2`. Buckland et al. (1997) center it on the model-averaged estimate: `se = sum_m w_m sqrt(var_m + (beta_m - beta_avg)^2)`. Centering on the full model inflates every model's spread term by the displacement of the average from the full model whenever the two differ.

**Standalone data scaling (behavior change).** `fma()` run standalone prepared data with `scale_data = FALSE`, while the orchestrated path (`depends_on = "bma"`) reuses the z-scored frame from `bma()`. The same options produced coefficients on different scales depending on invocation order, and the MA comparison table joins BMA and FMA columns assuming one scale. The standalone path now scales too.

## Verification

- New behavioral test: with five pure-noise predictors, more than half the weight lands on the smaller half of the nested-model sequence and the full model gets under 0.5 (the old criterion concentrated weight on the largest model).
- `devtools::test(filter = 'fma')` and the FMA-consuming suites (ma-table, bma-result-unwrap, method-execution) pass; changed files lint clean.

Findings from a six-area parallel numeric audit; remaining areas follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)