### PR TITLE
fix(effect-summary-stats): correct weighted-mean SE, per-study weights, unrounded CI

### DIFF
--- a/inst/artma/methods/effect_summary_stats.R
+++ b/inst/artma/methods/effect_summary_stats.R
@@ -3,8 +3,9 @@
 #' Compute summary statistics for the main effect grouped by variables that are
 #' flagged in the data configuration. The function supports equality based
 #' splits as well as threshold splits (numeric, mean or median based). It
-#' returns the arithmetic mean, weighted mean (weighted by the inverse squared
-#' study size), confidence intervals, and additional distribution statistics.
+#' returns the arithmetic mean, weighted mean (weighted by the inverse of the
+#' number of estimates per study, so every study contributes equally),
+#' confidence intervals, and additional distribution statistics.
 effect_summary_stats <- function(df) {
   box::use(
     artma / const[CONST],
@@ -69,8 +70,7 @@ effect_summary_stats <- function(df) {
 
     mean_val <- mean(values)
     sd_val <- stats::sd(values)
-    sd_for_ci <- round(sd_val, round_to)
-    se_val <- if (!is.na(sd_for_ci) && length(values) > 1) sd_for_ci / sqrt(length(values)) else NA_real_
+    se_val <- if (!is.na(sd_val) && length(values) > 1) sd_val / sqrt(length(values)) else NA_real_
     ci <- if (!is.na(se_val)) c(mean_val - z_value * se_val, mean_val + z_value * se_val) else c(NA_real_, NA_real_)
 
     list(
@@ -99,10 +99,11 @@ effect_summary_stats <- function(df) {
     }
     norm_weights <- weights / weights_sum
     mean_val <- stats::weighted.mean(values, w = weights)
-    # Weighted variance without Bessel correction keeps behaviour stable
-    variance <- stats::weighted.mean((values - mean_val)^2, w = norm_weights)
-    sd_val <- sqrt(variance)
-    se_val <- if (!is.na(sd_val) && length(values) > 1) sd_val / sqrt(length(values)) else NA_real_
+    # Var(sum(w_i * x_i)) = sum(w_i^2 * Var(x_i)); estimate each Var(x_i) by the
+    # squared deviation, so the SE reflects the effective sample size implied by
+    # unequal weights rather than the raw observation count.
+    variance <- sum(norm_weights^2 * (values - mean_val)^2)
+    se_val <- if (length(values) > 1) sqrt(variance) else NA_real_
     ci <- if (!is.na(se_val)) c(mean_val - z_value * se_val, mean_val + z_value * se_val) else c(NA_real_, NA_real_)
 
     list(mean = mean_val, ci = ci)
@@ -171,7 +172,9 @@ effect_summary_stats <- function(df) {
       return(FALSE)
     }
 
-    weights <- 1 / (subset_data$study_size^2)
+    # study_size is the number of estimates the study reports; weighting each
+    # estimate by its inverse gives every study equal total weight.
+    weights <- 1 / subset_data$study_size
     unweighted <- compute_unweighted_stats(subset_data$effect)
     weighted <- compute_weighted_stats(subset_data$effect, weights)
 

--- a/tests/testthat/test-effect-summary-stats-integration.R
+++ b/tests/testthat/test-effect-summary-stats-integration.R
@@ -144,8 +144,9 @@ test_that("effect_summary_stats computes the All Data row exactly", {
   #   mean   = 0.32   median = 0.30   min = 0.10   max = 0.50
   #   sd     = 0.164 (rounded)        obs = 5
   #   z_0.95 = qnorm(0.975) = 1.959964
-  #   se     = round(sd, 3) / sqrt(5); ci = mean +/- z * se -> [0.176, 0.464]
-  #   weighted mean with w = 1 / study_size^2 -> 0.165
+  #   se     = sd / sqrt(5); ci = mean +/- z * se -> [0.177, 0.463]
+  #   weighted mean with w = 1 / study_size -> 0.234, its CI from
+  #   se_w = sqrt(sum(w_norm^2 * (x - wm)^2)) -> [0.100, 0.369]
   df <- data.frame(
     effect = c(0.10, 0.24, 0.30, 0.46, 0.50),
     study_size = c(10, 20, 30, 40, 50),
@@ -180,9 +181,11 @@ test_that("effect_summary_stats computes the All Data row exactly", {
   expect_equal(all_data$Max, 0.50)
   expect_equal(all_data$SD, 0.164)
   expect_equal(all_data$Obs, 5L)
-  expect_equal(all_data$`CI lower`, 0.176)
-  expect_equal(all_data$`CI upper`, 0.464)
-  expect_equal(all_data$`Weighted Mean`, 0.165)
+  expect_equal(all_data$`CI lower`, 0.177)
+  expect_equal(all_data$`CI upper`, 0.463)
+  expect_equal(all_data$`Weighted Mean`, 0.234)
+  expect_equal(all_data$`WM CI lower`, 0.100)
+  expect_equal(all_data$`WM CI upper`, 0.369)
 })
 
 test_that("effect_summary_stats confidence interval widens with the confidence level", {

--- a/tests/testthat/test-effect-summary-stats.R
+++ b/tests/testthat/test-effect-summary-stats.R
@@ -57,12 +57,15 @@ test_that("effect summary stats computes segmented summaries", {
     "Score >= 2.5",
     "Score < 2.5"
   ))
+  # Weighted mean weights each estimate by 1/study_size (equal weight per
+  # study); its CI uses the weighted-mean SE sqrt(sum(w_i^2 (x_i - xbar_w)^2)),
+  # and the unweighted CI uses the unrounded SD.
   expect_equal(result$Mean, c(0.25, 0.15, 0.35, 0.15))
-  expect_equal(result$`CI lower`, c(0.124, 0.052, 0.252, 0.052))
-  expect_equal(result$`CI upper`, c(0.376, 0.248, 0.448, 0.248))
-  expect_equal(result$`Weighted Mean`, c(0.19, 0.15, 0.35, 0.15))
-  expect_equal(result$`WM CI lower`, c(0.098, 0.081, 0.281, 0.081))
-  expect_equal(result$`WM CI upper`, c(0.282, 0.219, 0.419, 0.219))
+  expect_equal(result$`CI lower`, c(0.123, 0.052, 0.252, 0.052))
+  expect_equal(result$`CI upper`, c(0.377, 0.248, 0.448, 0.248))
+  expect_equal(result$`Weighted Mean`, c(0.217, 0.15, 0.35, 0.15))
+  expect_equal(result$`WM CI lower`, c(0.115, 0.081, 0.281, 0.081))
+  expect_equal(result$`WM CI upper`, c(0.318, 0.219, 0.419, 0.219))
   expect_equal(result$Median, c(0.25, 0.15, 0.35, 0.15))
   expect_equal(result$Min, c(0.1, 0.1, 0.3, 0.1))
   expect_equal(result$Max, c(0.4, 0.2, 0.4, 0.2))


### PR DESCRIPTION
Part of the numeric-correctness audit continuing #369-#374.

## What changed (all behavior changes)

**Weighted-mean CI used the unweighted SE.** `compute_weighted_stats` computed `sd_w / sqrt(n)`, treating all n observations as equally weighted. The SE of a weighted mean with normalized weights is `sqrt(sum(w_i^2 (x_i - xbar_w)^2))`; by Cauchy-Schwarz the effective sample size is at most n, so the old CI was too narrow whenever weights were unequal (about 15% too narrow on the unit-test fixture, arbitrarily overconfident with one dominant study).

**Weighted-mean weights were 1/study_size^2.** `study_size` is the number of estimates a study reports, so squaring over-corrects: a study's total weight became 1/n_i instead of the intended equal weight per study. A 40-estimate study got about 0.24% of total weight instead of its equal share. Now `1/study_size`, the standard equal-weight-per-study convention; docstring updated to match.

**Unweighted CI was computed from the display-rounded SD.** `round(sd, number_of_decimals)` fed the presentation option into the CI math, so changing output decimals changed the statistics, and small-scale effects (SD rounding to 0) collapsed the CI to a point. The CI now uses the unrounded SD; rounding stays display-only.

## Tests

Both pinned fixtures recomputed under the correct formulas (subgroup rows with equal within-group weights are unchanged, as expected; only mixed-weight rows move). The integration test now also pins the WM CI bounds. `devtools::test(filter = 'effect-summary-stats')` passes (89 tests); changed files lint clean.

Findings from a six-area parallel numeric audit; remaining areas follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)