### PR TITLE
fix(vcov): warn on silent clustering downgrades; sign-correct zero-SE t-stats

### DIFF
--- a/inst/artma/calc/meta.R
+++ b/inst/artma/calc/meta.R
@@ -18,7 +18,9 @@ t_stat <- function(effect, se) {
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning("Introducing infinite t-values for {length(zero_se_rows)} rows with zero standard errors")
     }
-    t_values[zero_se_rows] <- Inf
+    # Keep the sign of the effect; 0/0 carries no direction and becomes NA.
+    t_values[zero_se_rows] <- sign(effect[zero_se_rows]) * Inf
+    t_values[zero_se_rows][effect[zero_se_rows] == 0] <- NA_real_
   }
 
   t_values

--- a/inst/artma/econometric/vcov.R
+++ b/inst/artma/econometric/vcov.R
@@ -7,6 +7,7 @@
 NULL
 
 box::use(
+  artma / libs / core / utils[get_verbosity],
   artma / libs / core / validation[validate]
 )
 
@@ -88,6 +89,20 @@ robust_vcov <- function(model,
     TRUE
   }
 
+  # Downgrading from clustered to non-clustered inference changes reported
+  # SEs materially (usually shrinking them); never do it silently.
+  warn_downgrade <- function(reason) {
+    if (get_verbosity() >= 2) {
+      cli::cli_alert_warning(
+        "Clustered vcov unavailable ({reason}); standard errors are NOT clustered."
+      )
+    }
+  }
+
+  if (!is.null(cluster) && !use_cluster) {
+    warn_downgrade("cluster length does not match the model's observations")
+  }
+
   # A robust (sandwich/plm) vcov step, optionally clustered, wrapped in
   # suppressWarnings() when requested.
   robust_step <- function(type, clustered) {
@@ -130,10 +145,16 @@ robust_vcov <- function(model,
     }
     result <- tryCatch(run_robust(steps[[i]]), error = function(e) NULL)
     if (!is.null(result)) {
+      if (i > 1L && use_cluster) {
+        warn_downgrade("the clustered estimator failed")
+      }
       return(result)
     }
   }
 
+  if (use_cluster || length(steps) > 1L) {
+    warn_downgrade("all robust estimators failed; using stats::vcov()")
+  }
   final_step()
 }
 

--- a/tests/testthat/test-calc-meta.R
+++ b/tests/testthat/test-calc-meta.R
@@ -1,8 +1,9 @@
 box::use(
-  testthat[expect_identical, expect_true, test_that]
+  testthat[expect_identical, expect_true, test_that],
+  withr[local_options]
 )
 
-box::use(artma / calc / meta[normal_p_value])
+box::use(artma / calc / meta[normal_p_value, t_stat])
 
 test_that("normal_p_value computes the two-sided normal p-value", {
   expect_identical(normal_p_value(1.96, 1), 2 * stats::pnorm(1.96, lower.tail = FALSE))
@@ -14,4 +15,15 @@ test_that("normal_p_value returns NA for non-finite or non-positive inputs", {
   expect_true(is.na(normal_p_value(Inf, 1)))
   expect_true(is.na(normal_p_value(1, 0)))
   expect_true(is.na(normal_p_value(1, -1)))
+})
+
+test_that("t_stat keeps the effect sign for zero standard errors", {
+  local_options("artma.verbose" = 1)
+
+  result <- t_stat(effect = c(0.5, -0.5, 0, 0.2), se = c(0, 0, 0, 0.1))
+
+  expect_identical(result[1], Inf)
+  expect_identical(result[2], -Inf)
+  expect_true(is.na(result[3]))
+  expect_identical(result[4], 2)
 })

--- a/tests/testthat/test-econometric-vcov.R
+++ b/tests/testthat/test-econometric-vcov.R
@@ -2,10 +2,13 @@ box::use(
   testthat[
     expect_equal,
     expect_error,
+    expect_message,
+    expect_no_message,
     expect_true,
     skip_if_not_installed,
     test_that
   ],
+  withr[local_options],
   artma / econometric / vcov[robust_vcov]
 )
 
@@ -72,6 +75,60 @@ test_that("get_robust_vcov ladder falls back to non-clustered HC1 on cluster err
 
   oracle <- suppressWarnings(sandwich::vcovHC(model, type = "HC1"))
   expect_equal(result, oracle)
+})
+
+test_that("robust_vcov warns when clustering is silently lost", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  # Clustered step fails on a wrong-length cluster: the fallback must announce
+  # that the returned SEs are not clustered.
+  expect_message(
+    robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC1",
+      fallback_types = c("HC1", "HC0"),
+      suppress_warnings = TRUE
+    ),
+    regexp = "NOT clustered"
+  )
+
+  # The match_cluster_length guard is the same downgrade and must also warn.
+  expect_message(
+    robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC0",
+      match_cluster_length = TRUE
+    ),
+    regexp = "NOT clustered"
+  )
+
+  # A working clustered step stays quiet.
+  expect_no_message(
+    robust_vcov(
+      model = model,
+      cluster = df$study_id,
+      engine = "sandwich",
+      clustered_type = "HC1"
+    )
+  )
+
+  # Verbosity 1 keeps the run errors-only.
+  local_options("artma.verbose" = 1)
+  expect_no_message(
+    robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC1",
+      fallback_types = c("HC1", "HC0")
+    )
+  )
 })
 
 test_that("robust_vcov errors when a required cluster is NULL", {


### PR DESCRIPTION
Part of the numeric-correctness audit continuing #369-#375.

## What changed

**`robust_vcov` no longer downgrades silently.** The ladder swallowed any error in the clustered step and fell through to a non-clustered HC vcov (or `stats::vcov()`) with no signal at any verbosity. In meta-analysis data with many estimates per study, clustered SEs are usually much larger than HC1, so a silent fallback anti-conservatively shrinks every reported SE while the output still reads as study-clustered. The most common trigger is mundane: one NA in a model column makes the model drop rows, the full-length cluster vector then mismatches `nobs`, and `sandwich::vcovCL` errors. All three downgrade paths (clustered step failed, `match_cluster_length` guard rejected the cluster, final `stats::vcov()` resort) now emit a `cli` warning gated at verbosity >= 2. Numeric results are unchanged.

**`t_stat` kept no sign information for zero-SE rows.** `effect/0` evaluates correctly to signed infinity, but the code overwrote all zero-SE rows with `+Inf`, so a negative effect with a degenerate SE got a sign-flipped t-statistic and `0/0` became "infinitely significant" instead of undefined. Now `+Inf`/`-Inf` follow the effect's sign and `0/0` maps to `NA` (behavior change for degenerate zero-SE inputs only; these already warn).

## Tests

New tests pin the signed-infinity/NA mapping and, for the vcov ladder, that each downgrade path warns, a working clustered step stays quiet, and verbosity 1 suppresses the message. Consumer suites (linear, exogeneity, best-practice, data-compute) pass locally: 382 tests, 0 failures. Changed files lint clean.

Findings from a six-area parallel numeric audit; remaining areas follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)