### PR TITLE
fix(stem,robma): cluster RoBMA by study, align stem MSE table and plot rows

### DIFF
--- a/inst/artma/calc/methods/stem.R
+++ b/inst/artma/calc/methods/stem.R
@@ -83,7 +83,10 @@ stem_compute <- function(beta, se, sigma0) {
   sigma_stem <- sqrt(var_stem)
   estimates <- cbind(beta_stem, se_stem, sigma_stem, n_stem)
   colnames(estimates) <- c("beta_stem", "se_stem", "sigma_stem", "n_stem")
-  mse_table <- rbind(mse, var_all[n_stem_min:n], bias[(n_stem_min - 1):(n - 1)])
+  # mse and bias are both already aligned to n_stem = n_stem_min..n; subsetting
+  # bias again would shift it one row up (a bug inherited from the reference
+  # implementation).
+  mse_table <- rbind(mse, var_all[n_stem_min:n], bias)
   rownames(mse_table) <- c("MSE", "", "")
   list(estimates = estimates, MSE = mse_table)
 }
@@ -196,12 +199,14 @@ stem_MSE <- function(MSE_matrix) { # nolint: object_name_linter.
   bias_sq <- MSE_matrix[, 3]
   variance <- MSE_matrix[, 2]
   n_study <- nrow(MSE_matrix)
-  n_min <- 2
-  num_study <- (n_min + 1):(n_study + 1)
+  # Row k of the MSE matrix belongs to n_stem = k + 2 (stems start at 3
+  # studies); plotting rows against their own stem size keeps the minimum at
+  # the reported n_stem.
+  num_study <- seq_len(n_study) + 2
   graphics::layout(matrix(c(1, 2, 3, 3), 2, 2, byrow = TRUE))
-  graphics::plot(num_study, bias_sq[n_min:n_study], type = "l", col = "blue", lwd = 2.5, xlab = "Num of included studies i", ylab = "", main = expression(Bias^2 - b[0]^2))
-  graphics::plot(num_study, variance[n_min:n_study], type = "l", col = "blue", lwd = 2.5, xlab = "Num of included studies i", ylab = "", main = expression(Variance))
-  graphics::plot(num_study, mse[n_min:n_study], type = "l", col = "blue", lwd = 2.5, xlab = "Num of included studies i", ylab = "", main = expression(MSE - b[0]^2))
+  graphics::plot(num_study, bias_sq, type = "l", col = "blue", lwd = 2.5, xlab = "Num of included studies i", ylab = "", main = expression(Bias^2 - b[0]^2))
+  graphics::plot(num_study, variance, type = "l", col = "blue", lwd = 2.5, xlab = "Num of included studies i", ylab = "", main = expression(Variance))
+  graphics::plot(num_study, mse, type = "l", col = "blue", lwd = 2.5, xlab = "Num of included studies i", ylab = "", main = expression(MSE - b[0]^2))
 }
 
 #' Compute median data within clusters

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -92,6 +92,15 @@ robma <- function(df) {
   usable <- is.finite(df$effect) & is.finite(df$se) & df$se > 0
   fit_data <- df[usable, , drop = FALSE]
 
+  # RoBMA's likelihood treats rows as independent; meta-analysis data carries
+  # several estimates per study, so pass study ids for multilevel clustering.
+  cluster_ids <- if ("study_id" %in% colnames(fit_data)) fit_data$study_id else NULL
+  if (is.null(cluster_ids) && get_verbosity() >= 2) {
+    cli::cli_alert_warning(
+      "No study_id column: RoBMA treats all estimates as independent."
+    )
+  }
+
   if (nrow(fit_data) < MIN_OBSERVATIONS) {
     reason <- sprintf(
       "fewer than %d usable observations (%d available)",
@@ -125,6 +134,7 @@ robma <- function(df) {
   fit <- RoBMA::RoBMA(
     yi = fit_data$effect,
     sei = fit_data$se,
+    cluster = cluster_ids,
     measure = measure,
     prior_effect = effect_prior,
     prior_heterogeneity = heterogeneity_prior,

--- a/tests/testthat/test-calc-stem.R
+++ b/tests/testthat/test-calc-stem.R
@@ -100,3 +100,23 @@ test_that("stem is deterministic for identical input", {
 
   expect_equal(stem(effect, se, c(1e-4, 100)), stem(effect, se, c(1e-4, 100)))
 })
+
+test_that("stem MSE table rows are internally aligned", {
+  set.seed(5)
+  n <- 40
+  se <- runif(n, 0.05, 0.5)
+  effect <- 0.3 + rnorm(n, 0, se)
+
+  out <- stem(effect, se, c(1e-4, 100))
+  mse_table <- out$MSE
+
+  # One row per candidate stem size (n_stem = 3..n), no trailing NA row, and
+  # bias_squared must be the same row's MSE minus variance. The previous code
+  # shifted bias_squared one row up.
+  expect_equal(nrow(mse_table), n - 2)
+  expect_true(all(is.finite(mse_table)))
+  expect_equal(
+    unname(mse_table[, "bias_squared"]),
+    unname(mse_table[, "MSE"] - mse_table[, "variance"])
+  )
+})


### PR DESCRIPTION
Part of the numeric-correctness audit continuing #369-#376.

## What changed

**RoBMA treated every estimate as independent (behavior change, high severity).** The wrapper fed all rows to `RoBMA::RoBMA(yi, sei)` without the `cluster` argument, so 50 studies x 20 estimates entered the likelihood as 1000 independent data points; inclusion Bayes factors and the model-averaged CI were correspondingly overstated. RoBMA 4.0.0 (the pinned minimum) accepts `cluster` for multilevel meta-analysis (verified against the official reference docs); the wrapper now passes `study_id` and warns when the column is absent.

**Stem MSE diagnostics table misaligned by one row.** `stem_compute` built `bias` already aligned to stem sizes 3..n, then subset it again when assembling the table, shifting every `bias_squared` value one row up and leaving a trailing NA. Numerically confirmed during the audit: the row for stem size k reported the bias of k+1. The estimation itself was unaffected (`which.min` runs on the unshifted MSE). Bug inherited verbatim from Furukawa's reference implementation.

**Stem MSE plot off by one.** `stem_MSE` plotted rows 2..(n-2) against x-values 3..(n-1), so every point appeared at a stem size one smaller than its own and the first candidate stem was dropped; the plotted MSE minimum disagreed with the reported `n_stem`. Rows now plot against their own stem sizes (3..n). Same reference-code inheritance.

## Tests

New test pins the MSE table alignment: one finite row per candidate stem size and `bias_squared == MSE - variance` row-wise. Stem, RoBMA, and nonlinear suites pass locally (91 tests; the RoBMA fit test skips without the package, as before). Changed files lint clean apart from pre-existing "RoBMA not installed" namespace warnings local to this machine.

Findings from a six-area parallel numeric audit; remaining areas follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)