### PR TITLE
fix: require MAIVE 0.2.5 for unrounded estimates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     jsonlite (>= 1.8.0),
     knitr (>= 1.50),
     lintr (>= 3.2.0),
-    MAIVE (>= 0.2.5),
+    MAIVE (>= 0.2.4),
     mathjaxr (>= 1.8-0),
     mice (>= 3.16.0),
     NlcOptim (>= 0.6),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     jsonlite (>= 1.8.0),
     knitr (>= 1.50),
     lintr (>= 3.2.0),
-    MAIVE (>= 0.2.4),
+    MAIVE (>= 0.2.5),
     mathjaxr (>= 1.8-0),
     mice (>= 3.16.0),
     NlcOptim (>= 0.6),

--- a/inst/artma/calc/methods/maive.R
+++ b/inst/artma/calc/methods/maive.R
@@ -1,6 +1,8 @@
 # 0.2.5 is the first release that returns unrounded estimates; older versions
 # round beta, SE, and Egger terms to 3 decimals, distorting the p-values and
 # CIs derived from them and zeroing out standard errors below 0.0005.
+# DESCRIPTION pins only the newest CRAN release so dependency resolution
+# works; this constant enforces the real floor at runtime.
 MAIVE_MIN_VERSION <- "0.2.5"
 
 #' @title Check whether the installed MAIVE version meets the minimum requirement
@@ -91,4 +93,4 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
   result
 }
 
-box::export(maive, maive_version_ok)
+box::export(maive, maive_version_ok, MAIVE_MIN_VERSION)

--- a/inst/artma/calc/methods/maive.R
+++ b/inst/artma/calc/methods/maive.R
@@ -1,4 +1,7 @@
-MAIVE_MIN_VERSION <- "0.2.4"
+# 0.2.5 is the first release that returns unrounded estimates; older versions
+# round beta, SE, and Egger terms to 3 decimals, distorting the p-values and
+# CIs derived from them and zeroing out standard errors below 0.0005.
+MAIVE_MIN_VERSION <- "0.2.5"
 
 #' @title Check whether the installed MAIVE version meets the minimum requirement
 #' @param installed_version *[character]* Version string to check, e.g. from `packageVersion("MAIVE")`.

--- a/tests/testthat/test-calc-maive.R
+++ b/tests/testthat/test-calc-maive.R
@@ -6,7 +6,7 @@ box::use(
     skip_if_not_installed,
     test_that
   ],
-  artma / calc / methods / maive[maive, maive_version_ok]
+  artma / calc / methods / maive[maive, maive_version_ok, MAIVE_MIN_VERSION]
 )
 
 make_maive_data <- function(seed = 9, n = 40) {
@@ -19,7 +19,7 @@ make_maive_data <- function(seed = 9, n = 40) {
 }
 
 test_that("maive dispatches to the MAIVE package and returns its contract", {
-  skip_if_not_installed("MAIVE")
+  skip_if_not_installed("MAIVE", minimum_version = MAIVE_MIN_VERSION)
   dat <- make_maive_data()
 
   # Numeric method/weight args are coerced to integer before dispatch.
@@ -32,7 +32,9 @@ test_that("maive dispatches to the MAIVE package and returns its contract", {
 })
 
 test_that("maive aborts when required columns are missing", {
-  skip_if_not_installed("MAIVE")
+  # The version gate fires before the column check, so an old MAIVE would
+  # produce the wrong error here.
+  skip_if_not_installed("MAIVE", minimum_version = MAIVE_MIN_VERSION)
   expect_error(maive(data.frame(bs = 1:3, sebs = rep(0.1, 3)), SE = 1L), regexp = "Ns")
 })
 

--- a/tests/testthat/test-econometric-maive.R
+++ b/tests/testthat/test-econometric-maive.R
@@ -438,7 +438,7 @@ test_that("run_maive reports the installed version when it is too old", {
   result <- run_maive(make_maive_df(), base_maive_options())
 
   expect_true(is.null(result$summary))
-  expect_match(result$skipped, "0\\.2\\.4 or higher")
+  expect_match(result$skipped, "0\\.2\\.5 or higher")
   expect_match(result$skipped, "0\\.0\\.2\\.11")
 })
 

--- a/tests/testthat/test-econometric-maive.R
+++ b/tests/testthat/test-econometric-maive.R
@@ -11,6 +11,7 @@ box::use(
     test_that
   ],
   withr[local_options],
+  artma / calc / methods / maive[MAIVE_MIN_VERSION],
   artma / econometric / maive[
     ar_ci_verdict,
     build_maive_interpretation,
@@ -443,7 +444,7 @@ test_that("run_maive reports the installed version when it is too old", {
 })
 
 test_that("run_maive builds a summary and interpretation from real MAIVE output", {
-  skip_if_not_installed("MAIVE")
+  skip_if_not_installed("MAIVE", minimum_version = MAIVE_MIN_VERSION)
   local_options(artma.verbose = 1)
 
   result <- run_maive(make_maive_df(), base_maive_options())
@@ -455,7 +456,7 @@ test_that("run_maive builds a summary and interpretation from real MAIVE output"
 })
 
 test_that("run_maive resolves the first stage from the data and reports it", {
-  skip_if_not_installed("MAIVE")
+  skip_if_not_installed("MAIVE", minimum_version = MAIVE_MIN_VERSION)
   local_options(artma.verbose = 1)
 
   df <- make_maive_df()
@@ -471,7 +472,7 @@ test_that("run_maive resolves the first stage from the data and reports it", {
 })
 
 test_that("run_maive is reproducible across two bootstrap runs", {
-  skip_if_not_installed("MAIVE")
+  skip_if_not_installed("MAIVE", minimum_version = MAIVE_MIN_VERSION)
   local_options(artma.verbose = 1)
   opts <- base_maive_options(se = 3L) # Wild bootstrap: needs the threaded seed.
 


### PR DESCRIPTION
## Summary

MAIVE up to 0.2.4 rounds beta, SE, egger_coef, and egger_se to 3 decimals before returning them. artma's maive_p_from_coef and maive_ci (inst/artma/econometric/maive.R) form z-ratios, p-values, CIs, and significance verdicts from those values, so verdicts could flip near the 5% boundary (true beta 0.0104, SE 0.00549 gives z 1.894, p 0.058; rounded 0.010/0.005 gives z 2.0, p 0.045), and for partial correlations an SE below 0.0005 rounded to 0.000 and collapsed the estimate section via the se <= 0 guard.

MAIVE 0.2.5 (PetrCala/MAIVE#14) returns unrounded estimates, so this PR raises the floor artma enforces.

## Changes

- Bump MAIVE_MIN_VERSION to 0.2.5 in inst/artma/calc/methods/maive.R with a note on why the pin exists; export the constant so tests can reference it
- Keep DESCRIPTION at MAIVE (>= 0.2.4): 0.2.5 is not on CRAN yet, so a harder pin makes dependency resolution unsolvable in CI; the runtime gate enforces the real floor and soft-skips the method with an upgrade message on 0.2.4
- Gate tests that need real MAIVE output on skip_if_not_installed("MAIVE", minimum_version = MAIVE_MIN_VERSION) so they skip until 0.2.5 is installable, and update the version-gate test that hard-coded the old minimum

## Testing

- With MAIVE 0.2.5 built from the fix branch: test-calc-maive.R and test-econometric-maive.R pass with no skips (13 + 124)
- With CRAN MAIVE 0.2.4 shadowing it (what CI will see): 0 failures, the five real-output tests skip (8 + 117 pass)

## Follow-up

Once MAIVE 0.2.5 reaches CRAN, DESCRIPTION can be bumped to >= 0.2.5 and the test gates become no-ops.