### PR TITLE
fix(bpe): apply overrides and report estimates on the raw effect scale

### DIFF
--- a/inst/artma/econometric/best_practice_estimate.R
+++ b/inst/artma/econometric/best_practice_estimate.R
@@ -32,6 +32,12 @@ resolve_bpe_context <- function(df, bma_data) {
   }
 
   if (is.null(aligned_df)) {
+    # Singleton clusters mean the "clustered" vcov collapses to a plain
+    # heteroskedasticity-robust one and study rows become per-observation
+    # rows; that must never happen silently.
+    cli::cli_alert_warning(
+      "Could not align BMA rows with the source data; study clustering is disabled and study rows are per-observation."
+    )
     fallback <- seq_len(nrow(bma_data))
     return(list(study_id = fallback, study_label = as.character(fallback)))
   }
@@ -53,7 +59,7 @@ resolve_bpe_vcov <- function(ols_model, cluster_ids = NULL) {
     model = ols_model,
     cluster = cluster_ids,
     engine = "sandwich",
-    clustered_type = "HC0",
+    clustered_type = "HC1",
     match_cluster_length = TRUE
   )
 }
@@ -70,7 +76,8 @@ compute_bpe_point_estimate <- function(predictor_values, coef_post_mean, include
 }
 
 build_bpe_row <- function(scope, study_id, study_label, predictor_values, coef_post_mean,
-                          include_intercept, vcov_matrix, z_value) {
+                          include_intercept, vcov_matrix, z_value,
+                          effect_center = 0, effect_scale = 1) {
   estimate <- compute_bpe_point_estimate(
     predictor_values = predictor_values,
     coef_post_mean = coef_post_mean,
@@ -81,6 +88,12 @@ build_bpe_row <- function(scope, study_id, study_label, predictor_values, coef_p
     include_intercept = include_intercept,
     vcov_matrix = vcov_matrix
   )
+
+  # The BMA fit (and thus the linear combination) is on the standardized
+  # effect scale whenever the pipeline z-scored the data; report on the raw
+  # effect scale.
+  estimate <- effect_center + effect_scale * estimate
+  standard_error <- effect_scale * standard_error
 
   ci_lower <- if (is.finite(estimate) && is.finite(standard_error)) {
     estimate - z_value * standard_error
@@ -141,7 +154,7 @@ compute_linear_combo_se <- function(predictor_values, include_intercept, vcov_ma
 #' @keywords internal
 compute_bpe_economic_significance <- function(predictors, bma_data, coef_post_mean,
                                               bpe_reference_estimate, pip_values, config,
-                                              round_to, pip_threshold) {
+                                              round_to, pip_threshold, effect_scale = 1) {
   empty <- data.frame(
     variable = character(0),
     var_label = character(0),
@@ -164,8 +177,11 @@ compute_bpe_economic_significance <- function(predictors, bma_data, coef_post_me
     values <- values[is.finite(values)]
     beta <- coef_post_mean[[var_name]]
 
-    sd_change <- if (length(values) > 1) beta * stats::sd(values) else NA_real_
-    range_change <- if (length(values)) beta * (max(values) - min(values)) else NA_real_
+    # beta and values share the (possibly standardized) model scale, so
+    # beta * delta is a change in standardized effect units; effect_scale
+    # converts it to the raw effect scale the reference estimate lives on.
+    sd_change <- if (length(values) > 1) effect_scale * beta * stats::sd(values) else NA_real_
+    range_change <- if (length(values)) effect_scale * beta * (max(values) - min(values)) else NA_real_
 
     config_key <- find_config_key_for_var(var_name, config)
     var_label <- var_name
@@ -208,7 +224,8 @@ compute_bpe_economic_significance <- function(predictors, bma_data, coef_post_me
 #' override.
 #' @keywords internal
 compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_mean, include_intercept,
-                                       vcov_matrix, z_value, overrides, round_to) {
+                                       vcov_matrix, z_value, overrides, round_to,
+                                       centers = NULL, scales = NULL) {
   empty <- data.frame(
     scope = character(0),
     study_id = character(0),
@@ -235,11 +252,18 @@ compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_m
     }
 
     var_label <- var_cfg$var_name_verbose %||% var_name
+    # Configured equal/threshold values are on the raw data scale; compare
+    # them against raw values (and label groups with raw boundaries), not the
+    # z-scored column, where a raw threshold lands tens of SDs out and turns
+    # the split into "everything vs nothing".
+    var_center <- centers[[var_name]] %||% 0
+    var_scale <- scales[[var_name]] %||% 1
+    raw_values <- var_center + var_scale * as.numeric(bma_data[[var_name]])
     groups <- resolve_variable_groups(
       var_label = var_label,
       equal_val = var_cfg$bpe_equal,
       gltl_val = var_cfg$bpe_gltl,
-      var_values = bma_data[[var_name]],
+      var_values = raw_values,
       round_to = round_to,
       auto_levels = TRUE
     )
@@ -253,7 +277,9 @@ compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_m
         bma_data = bma_data,
         row_idx = group$row_idx,
         predictors = predictors,
-        overrides = overrides
+        overrides = overrides,
+        centers = centers,
+        scales = scales
       )
 
       row <- build_bpe_row(
@@ -264,7 +290,9 @@ compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_m
         coef_post_mean = coef_post_mean,
         include_intercept = include_intercept,
         vcov_matrix = vcov_matrix,
-        z_value = z_value
+        z_value = z_value,
+        effect_center = centers[["effect"]] %||% 0,
+        effect_scale = scales[["effect"]] %||% 1
       )
       row$n_obs <- length(group$row_idx)
       rows[[length(rows) + 1]] <- row
@@ -284,17 +312,20 @@ compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_m
   out
 }
 
-compute_context_values <- function(bma_data, row_idx, predictors, overrides) {
+compute_context_values <- function(bma_data, row_idx, predictors, overrides,
+                                   centers = NULL, scales = NULL) {
   values <- vapply(predictors, function(var_name) {
     resolve_bpe_value(
       values = bma_data[row_idx, var_name, drop = TRUE],
-      override = overrides[[var_name]]
+      override = overrides[[var_name]],
+      center = centers[[var_name]] %||% 0,
+      scale = scales[[var_name]] %||% 1
     )
   }, numeric(1))
   values
 }
 
-resolve_bpe_value <- function(values, override) {
+resolve_bpe_value <- function(values, override, center = 0, scale = 1) {
   numeric_values <- as.numeric(values)
   numeric_values <- numeric_values[is.finite(numeric_values)]
 
@@ -312,7 +343,12 @@ resolve_bpe_value <- function(values, override) {
   }
 
   if (is.numeric(parsed) && length(parsed) == 1 && !is.na(parsed)) {
-    return(as.numeric(parsed))
+    # Configured overrides are on the raw data scale; the stored column may be
+    # z-scored, so move the override onto the column's actual scale. On an
+    # unscaled column center/scale are 0/1 and this is the identity. Without
+    # this shift, the flagship "se = 0" correction plugged in the SAMPLE MEAN
+    # of se (the standardized zero), erasing the publication-bias adjustment.
+    return((as.numeric(parsed) - center) / scale)
   }
 
   switch(parsed,

--- a/inst/artma/econometric/bma.R
+++ b/inst/artma/econometric/bma.R
@@ -301,14 +301,24 @@ get_bma_data <- function(input_data, input_var_list, variable_info, scale_data =
 
   if (scale_data) {
     source_colnames <- colnames(bma_data)
+    # NA is not a level: a 0/1 dummy with missing values must stay a dummy,
+    # not get z-scored because NA inflated its unique count.
     is_binary <- function(x) {
-      length(unique(x)) == 2
+      length(unique(stats::na.omit(x))) == 2
     }
     binary_cols <- vapply(bma_data, is_binary, logical(1))
-    bma_data[, !binary_cols] <- lapply(bma_data[, !binary_cols, drop = FALSE], function(x) {
-      as.numeric(scale(x))
-    })
-    colnames(bma_data) <- source_colnames
+    centers <- stats::setNames(rep(0, length(source_colnames)), source_colnames)
+    scales <- stats::setNames(rep(1, length(source_colnames)), source_colnames)
+    for (column in source_colnames[!binary_cols]) {
+      scaled <- scale(bma_data[[column]])
+      bma_data[[column]] <- as.numeric(scaled)
+      centers[[column]] <- as.numeric(attr(scaled, "scaled:center"))
+      scales[[column]] <- as.numeric(attr(scaled, "scaled:scale"))
+    }
+    # Consumed by the best-practice estimate to move raw-scale overrides onto
+    # the standardized scale and to move its outputs back off it.
+    attr(bma_data, "bpe_scale_centers") <- centers
+    attr(bma_data, "bpe_scale_scales") <- scales
   }
 
   bma_data

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -157,13 +157,26 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   context <- resolve_bpe_context(df = df, bma_data = bma_data)
   ols_model <- stats::lm(formula = bma_formula, data = bma_data)
   vcov_matrix <- resolve_bpe_vcov(ols_model = ols_model, cluster_ids = context$study_id)
-  z_value <- stats::qnorm((1 + conf_level) / 2)
+
+  # SEs are study-clustered, so t quantiles use G - 1 degrees of freedom (the
+  # normal quantile understates critical values at typical study counts).
+  n_clusters <- length(unique(context$study_id))
+  z_value <- stats::qt((1 + conf_level) / 2, df = max(n_clusters - 1L, 1L))
+
+  # Scaling metadata recorded by get_bma_data(); absent (identity) when the
+  # BMA data was never standardized.
+  scale_centers <- as.list(attr(bma_data, "bpe_scale_centers") %||% numeric(0))
+  scale_scales <- as.list(attr(bma_data, "bpe_scale_scales") %||% numeric(0))
+  effect_center <- scale_centers[["effect"]] %||% 0
+  effect_scale <- scale_scales[["effect"]] %||% 1
 
   author_values <- compute_context_values(
     bma_data = bma_data,
     row_idx = seq_len(nrow(bma_data)),
     predictors = predictors,
-    overrides = resolved_overrides
+    overrides = resolved_overrides,
+    centers = scale_centers,
+    scales = scale_scales
   )
 
   # Computed unconditionally (regardless of include_author_row/include_study_rows)
@@ -176,7 +189,9 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     coef_post_mean = coef_post_mean,
     include_intercept = include_intercept,
     vcov_matrix = vcov_matrix,
-    z_value = z_value
+    z_value = z_value,
+    effect_center = effect_center,
+    effect_scale = effect_scale
   )
 
   # First-appearance level order keeps summary rows in data order; NA study
@@ -193,7 +208,9 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       bma_data = bma_data,
       row_idx = row_idx,
       predictors = predictors,
-      overrides = resolved_overrides
+      overrides = resolved_overrides,
+      centers = scale_centers,
+      scales = scale_scales
     )
 
     study_rows[[i]] <- build_bpe_row(
@@ -204,7 +221,9 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       coef_post_mean = coef_post_mean,
       include_intercept = include_intercept,
       vcov_matrix = vcov_matrix,
-      z_value = z_value
+      z_value = z_value,
+      effect_center = effect_center,
+      effect_scale = effect_scale
     )
   }
 
@@ -237,7 +256,14 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       character(1)
     ),
     has_recommendation = as.logical(has_recommendation[predictors]),
-    author_value = round_if_finite(as.numeric(author_values[predictors]), round_to),
+    # Report the plugged-in values on the raw data scale, not the z-scored one.
+    author_value = round_if_finite(
+      vapply(predictors, function(var_name) {
+        (scale_centers[[var_name]] %||% 0) +
+          (scale_scales[[var_name]] %||% 1) * as.numeric(author_values[[var_name]])
+      }, numeric(1)),
+      round_to
+    ),
     stringsAsFactors = FALSE
   )
 
@@ -260,7 +286,8 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       pip_values = pip_values,
       config = config,
       round_to = round_to,
-      pip_threshold = economic_significance_pip_threshold
+      pip_threshold = economic_significance_pip_threshold,
+      effect_scale = effect_scale
     )
   }
 
@@ -274,7 +301,9 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       vcov_matrix = vcov_matrix,
       z_value = z_value,
       overrides = resolved_overrides,
-      round_to = round_to
+      round_to = round_to,
+      centers = scale_centers,
+      scales = scale_scales
     )
   }
 

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -339,6 +339,11 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
     include_reference_groups = FALSE
   )
 
+  # Column subsetting below drops custom attributes, so hold the scaling
+  # metadata aside and re-attach it (pruned to surviving columns) at the end.
+  scale_centers <- attr(bma_data, "bpe_scale_centers")
+  scale_scales <- attr(bma_data, "bpe_scale_scales")
+
   if (!"effect" %in% colnames(bma_data)) {
     cli::cli_abort("BMA data must include an {.code effect} column.")
   }
@@ -465,6 +470,11 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
         sole_moderator
       )
     ))
+  }
+
+  if (!is.null(scale_centers)) {
+    attr(bma_data, "bpe_scale_centers") <- scale_centers[colnames(bma_data)]
+    attr(bma_data, "bpe_scale_scales") <- scale_scales[colnames(bma_data)]
   }
 
   list(

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -17,6 +17,7 @@ box::use(ggplot2[is_ggplot])
 box::use(
   artma / methods / bma[bma],
   artma / methods / best_practice_estimate[best_practice_estimate],
+  artma / econometric / bma[get_bma_data],
   artma / econometric / best_practice_estimate[
     infer_bpe_recommendation,
     format_bpe_recommendation
@@ -333,6 +334,87 @@ test_that("best_practice_estimate returns an empty factor summary table with no 
   result <- best_practice_estimate(df, bma_result = bma_result)
 
   expect_equal(nrow(result$tables$summary_by_factor), 0L)
+})
+
+test_that("get_bma_data records scaling metadata and keeps NA dummies binary", {
+  df <- data.frame(
+    effect = c(0.1, 0.2, 0.3, 0.4),
+    se = c(0.05, 0.10, 0.15, 0.20),
+    dummy = c(0, 1, NA, 1)
+  )
+  var_list <- data.frame(
+    var_name = c("effect", "se", "dummy"),
+    var_name_verbose = c("Effect", "SE", "Dummy"),
+    bma = c(TRUE, TRUE, TRUE),
+    to_log_for_bma = c(FALSE, FALSE, FALSE),
+    bma_reference_var = c(FALSE, FALSE, FALSE),
+    stringsAsFactors = FALSE
+  )
+
+  scaled <- get_bma_data(
+    df, var_list,
+    variable_info = c("effect", "se", "dummy"),
+    scale_data = TRUE, from_vector = TRUE, include_reference_groups = FALSE
+  )
+
+  centers <- attr(scaled, "bpe_scale_centers")
+  scales <- attr(scaled, "bpe_scale_scales")
+  expect_equal(centers[["effect"]], mean(df$effect))
+  expect_equal(scales[["se"]], stats::sd(df$se))
+  # A 0/1 dummy with an NA must not be z-scored (NA is not a third level).
+  expect_equal(centers[["dummy"]], 0)
+  expect_equal(scales[["dummy"]], 1)
+  expect_equal(sort(unique(stats::na.omit(scaled$dummy))), c(0, 1))
+})
+
+test_that("bpe applies the se = 0 correction on the raw effect scale", {
+  skip_if_not_installed("BMS")
+
+  # Strong publication-bias DGP: effect = 0.1 + 1.0 * se + small noise. The
+  # naive mean is ~0.28; the best-practice estimate at se = 0 must land near
+  # the bias-free 0.1. Before the scaling fix the override "0" plugged in the
+  # SAMPLE MEAN of se (standardized zero) and the output stayed on the
+  # z-scored effect scale, reporting ~0 here.
+  set.seed(99)
+  n_studies <- 16L
+  rows_per_study <- 6L
+  n <- n_studies * rows_per_study
+  se <- stats::runif(n, min = 0.05, max = 0.3)
+  moderator <- stats::rnorm(n)
+  df <- data.frame(
+    study_id = rep(seq_len(n_studies), each = rows_per_study),
+    effect = 0.1 + 1.0 * se + 0.05 * moderator + stats::rnorm(n, sd = 0.02),
+    se = se,
+    moderator = moderator,
+    stringsAsFactors = FALSE
+  )
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = list(
+      effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE, bpe = NA),
+      se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE, bpe = 0),
+      moderator = list(var_name = "moderator", var_name_verbose = "Moderator", bma = TRUE, bpe = "mean")
+    ),
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 100L,
+    artma.methods.bma.iter = 1000L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd",
+    artma.methods.best_practice_estimate.include_study_rows = FALSE
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+  author <- result$tables$summary[result$tables$summary$scope == "author", ]
+
+  expect_gt(author$estimate, 0.03)
+  expect_lt(author$estimate, 0.2)
+  expect_true(is.finite(author$standard_error))
+  expect_gt(author$standard_error, 0)
 })
 
 test_that("infer_bpe_recommendation returns NA (no recommendation) for unmatched variables", {

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -4,6 +4,8 @@ box::use(
     expect_error,
     expect_named,
     expect_false,
+    expect_gt,
+    expect_lt,
     expect_setequal,
     expect_true,
     skip_if_not_installed,


### PR DESCRIPTION
Part of the numeric-correctness audit continuing #369-#380. Two independent auditors converged on the same two high-severity findings here.

## The problem

`get_bma_data(scale_data = TRUE)` z-scores every non-binary column, including `effect` and `se`, and the BPE pipeline consumed that frame as if it were raw:

- **The flagship `se = 0` correction did nothing.** Numeric overrides were plugged into the standardized column verbatim, and on a z-scored column the value 0 is the SAMPLE MEAN. Evaluating the MRA at `se = mean(se)` leaves the average publication bias fully in the headline estimate.
- **Estimates and CIs were reported in SD-of-effect units** presented as effect sizes, and the economic-significance percentages divided by a near-zero standardized base.
- **`bpe_equal`/`bpe_gltl` thresholds** (raw-scale config values) were compared against z-scores, so a threshold like `citations >= 50` meant "50 SDs above the mean": one empty group silently dropped, the other group the whole sample.

## The fix

`get_bma_data` now records per-column centers/scales as attributes; `prepare_bma_inputs` carries them through row/column pruning. BPE moves numeric overrides onto the standardized scale (`(v - center)/sd`), back-transforms estimates/SEs/CIs to raw effect units, resolves factor-group thresholds against raw values (labels included), converts economic-significance level changes to raw units, and reports plugged-in author values on the raw scale. All transformations are identity when the data was never scaled.

Also in this PR, from the same audit:
- Binary detection treats NA as a non-level (a 0/1 dummy with missing values no longer gets z-scored, and its 0/1 overrides stay meaningful).
- CIs use t(G - 1) instead of the normal quantile, matching the study-clustered vcov (16 studies: critical value 2.13 vs 1.96).
- `resolve_bpe_vcov` uses CR1 (`vcovCL` type HC1) instead of HC0, adding the finite-sample correction.
- The row-alignment fallback in `resolve_bpe_context` (which silently degraded clustering to singleton clusters) now warns.

Not changed here, flagged for a maintainer decision: `infer_bpe_recommendation` hardcodes EIS-literature keyword rules ("gmm" -> 1, "hall 1988" -> 1, ...) applied to any dataset in the default autonomous path; only the `se -> 0` rule is domain-general. Gating the rest behind an option would change default behavior, so it is left as is.

## Tests

New end-to-end test discriminates old vs new behavior: on a DGP with effect = 0.1 + 1.0 se + noise, the author BPE must land near the bias-free 0.1 (old code reported ~0 on the standardized scale). New unit test pins the scaling metadata and the NA-dummy fix. BPE/BMA suites (208 tests) and consumer suites (fma, ma-table, method-execution, cache; 185 tests) pass; changed files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)