### PR TITLE
fix(bma): five numeric-audit fixes in econometric/bma.R

### DIFF
--- a/inst/artma/econometric/bma.R
+++ b/inst/artma/econometric/bma.R
@@ -33,20 +33,16 @@ handle_bma_params <- function(bma_params) {
   validate(is.list(bma_params))
 
   adj_bma_params <- list()
-  param_counts <- unique(vapply(bma_params, length, integer(1)))
+  param_lengths <- vapply(bma_params, length, integer(1))
+  multi_lengths <- unique(param_lengths[param_lengths != 1])
 
-  if (length(param_counts) == 1) {
+  if (length(multi_lengths) == 0) {
     adj_bma_params[[1]] <- bma_params
-  } else if (length(param_counts) == 2) {
-    model_count <- param_counts[!param_counts == 1]
+  } else if (length(multi_lengths) == 1) {
+    model_count <- multi_lengths
     for (i in seq_len(model_count)) {
-      single_model_params <- lapply(bma_params, function(x) x[1])
-      adj_bma_params[[i]] <- single_model_params
-      bma_params <- lapply(bma_params, function(x) {
-        if (length(x) > 1) {
-          return(x[-1])
-        }
-        x
+      adj_bma_params[[i]] <- lapply(bma_params, function(x) {
+        if (length(x) > 1) x[i] else x
       })
     }
   } else {
@@ -161,7 +157,11 @@ find_optimal_bma_formula <- function(input_data, input_var_list, max_groups_to_r
   }, logical(1))
   input_data <- input_data[, non_const_cols, drop = FALSE]
 
-  bma_potential_vars_bool <- input_var_list$bma & non_const_cols
+  # Mask in var-list row order: a row is usable only if its column survived the
+  # constancy filter above. Indexing by data-frame column order would pair the
+  # mask with the wrong rows whenever the orders (or lengths) differ.
+  var_is_usable <- input_var_list$var_name %in% colnames(input_data)
+  bma_potential_vars_bool <- input_var_list$bma & var_is_usable
   potential_vars <- input_var_list$var_name[bma_potential_vars_bool]
   var_grouping <- input_var_list$group_category[bma_potential_vars_bool]
 
@@ -184,9 +184,19 @@ find_optimal_bma_formula <- function(input_data, input_var_list, max_groups_to_r
     highest_vif_coef_idx <- which(potential_vars == highest_vif_coef_name)
     highest_vif_group <- var_grouping[highest_vif_coef_idx]
 
-    vars_to_remove <- potential_vars[var_grouping == highest_vif_group]
-    potential_vars <- potential_vars[!potential_vars %in% vars_to_remove]
-    var_grouping <- var_grouping[!var_grouping %in% highest_vif_group]
+    # "other" is the catch-all for unconfigured variables, not a real dummy
+    # group; removing it wholesale would wipe out every ungrouped moderator.
+    remove_whole_group <- length(highest_vif_group) == 1 &&
+      !is.na(highest_vif_group) &&
+      highest_vif_group != "other"
+    vars_to_remove <- if (remove_whole_group) {
+      potential_vars[var_grouping == highest_vif_group]
+    } else {
+      highest_vif_coef_name
+    }
+    keep_mask <- !potential_vars %in% vars_to_remove
+    potential_vars <- potential_vars[keep_mask]
+    var_grouping <- var_grouping[keep_mask]
 
     bma_formula <- get_bma_formula(potential_vars, input_data)
     bma_lm <- stats::lm(bma_formula, data = input_data)
@@ -201,7 +211,7 @@ find_optimal_bma_formula <- function(input_data, input_var_list, max_groups_to_r
     removed_groups_verbose <- c(removed_groups_verbose, vars_to_remove)
   }
 
-  if (max_groups_to_remove == 0) {
+  if (any(vif_coefs > 10)) {
     cli::cli_abort("Maximum number of groups to remove reached. Optimal BMA formula not found.")
   }
 
@@ -398,8 +408,9 @@ rename_bma_model <- function(bma_model, input_var_list) {
 
   bma_names <- bma_model$reg.names
   idx <- match(bma_names, input_var_list$var_name)
-  bma_names[!is.na(idx)] <- input_var_list$var_name_verbose[stats::na.omit(idx)]
-  bma_names[is.na(idx)] <- "Intercept"
+  # Names absent from the var list stay as they are; renaming them would
+  # corrupt the labels and the downstream ma_table join.
+  bma_names[!is.na(idx)] <- input_var_list$var_name_verbose[idx[!is.na(idx)]]
   bma_model$reg.names <- bma_names
 
   bma_model

--- a/tests/testthat/test-bma.R
+++ b/tests/testthat/test-bma.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_error,
     expect_false,
     expect_length,
     expect_match,
@@ -19,7 +20,9 @@ box::use(
   artma / econometric / bma[
     get_bma_formula,
     handle_bma_params,
-    get_bma_data
+    get_bma_data,
+    find_optimal_bma_formula,
+    rename_bma_model
   ],
   artma / methods / bma[bma, prepare_bma_inputs]
 )
@@ -89,6 +92,33 @@ test_that("handle_bma_params returns list of parameter lists", {
   expect_length(result, 1)
   expect_equal(result[[1]]$burn, 1000L)
   expect_equal(result[[1]]$iter, 5000L)
+})
+
+test_that("handle_bma_params treats uniformly multi-valued parameters as multiple models", {
+  params <- list(
+    burn = c(100L, 200L),
+    iter = c(500L, 1000L),
+    g = c("UIP", "BRIC")
+  )
+
+  result <- handle_bma_params(params)
+
+  expect_length(result, 2)
+  expect_equal(result[[1]]$burn, 100L)
+  expect_equal(result[[1]]$g, "UIP")
+  expect_equal(result[[2]]$burn, 200L)
+  expect_equal(result[[2]]$iter, 1000L)
+  expect_equal(result[[2]]$g, "BRIC")
+})
+
+test_that("handle_bma_params aborts on mixed multi-value lengths", {
+  params <- list(
+    burn = c(100L, 200L),
+    mprior = c("uniform", "random", "fixed"),
+    g = "UIP"
+  )
+
+  expect_error(handle_bma_params(params), "1 or n values")
 })
 
 test_that("handle_bma_params splits multiple model configurations", {
@@ -364,6 +394,177 @@ test_that("prepare_bma_inputs excludes constant moderators before scaling", {
   expect_false("const_mod" %in% colnames(prepared$bma_data))
   expect_true(all(c("effect", "se", "moderator1") %in% colnames(prepared$bma_data)))
   expect_true(nrow(prepared$bma_data) > 0)
+})
+
+make_collinear_pair_data <- function() {
+  set.seed(7)
+  n <- 100L
+  x1 <- rnorm(n)
+  data.frame(
+    effect = rnorm(n),
+    x1 = x1,
+    x2 = x1 + rnorm(n, sd = 0.01),
+    y1 = rnorm(n),
+    y2 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+}
+
+make_ungrouped_var_list <- function(var_names) {
+  data.frame(
+    var_name = var_names,
+    bma = TRUE,
+    group_category = "other",
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("find_optimal_bma_formula aligns the constancy mask with var-list rows", {
+  skip_if_not_installed("car")
+
+  set.seed(11)
+  n <- 60L
+  # Data columns are deliberately ordered differently from the var-list rows,
+  # with the constant column first, so a mask computed in data order would
+  # pair with the wrong rows.
+  df <- data.frame(
+    const_var = 1,
+    effect = rnorm(n),
+    mod2 = rnorm(n),
+    mod1 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+  var_list <- make_ungrouped_var_list(c("effect", "mod1", "mod2", "const_var"))
+
+  result <- find_optimal_bma_formula(
+    df,
+    var_list,
+    return_variable_vector_instead = TRUE,
+    verbose = FALSE
+  )
+
+  expect_equal(result$result, c("mod1", "mod2"))
+  expect_equal(result$removed_groups, 0)
+})
+
+test_that("find_optimal_bma_formula removes 'other' variables one at a time", {
+  skip_if_not_installed("car")
+
+  df <- make_collinear_pair_data()
+  var_list <- make_ungrouped_var_list(c("effect", "x1", "x2", "y1", "y2"))
+
+  result <- find_optimal_bma_formula(
+    df,
+    var_list,
+    return_variable_vector_instead = TRUE,
+    verbose = FALSE
+  )
+
+  # Only one member of the collinear pair is dropped; the unrelated
+  # moderators sharing the "other" category survive.
+  expect_length(result$result, 3)
+  expect_true(all(c("y1", "y2") %in% result$result))
+  expect_length(result$removed_groups_verbose, 1)
+})
+
+test_that("find_optimal_bma_formula still removes genuine dummy groups wholesale", {
+  skip_if_not_installed("car")
+
+  set.seed(13)
+  n <- 120L
+  # Near dummy trap: the three region dummies cover all but one observation,
+  # so their VIFs blow up without the model becoming aliased.
+  category <- rep(c("a", "b", "c", "base"), times = c(55L, 56L, 8L, 1L))
+  df <- data.frame(
+    effect = rnorm(n),
+    reg_a = as.integer(category == "a"),
+    reg_b = as.integer(category == "b"),
+    reg_c = as.integer(category == "c"),
+    y1 = rnorm(n),
+    y2 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+  var_list <- data.frame(
+    var_name = c("effect", "reg_a", "reg_b", "reg_c", "y1", "y2"),
+    bma = TRUE,
+    group_category = c("other", "region", "region", "region", "other", "other"),
+    stringsAsFactors = FALSE
+  )
+
+  result <- find_optimal_bma_formula(
+    df,
+    var_list,
+    return_variable_vector_instead = TRUE,
+    verbose = FALSE
+  )
+
+  expect_equal(result$result, c("y1", "y2"))
+  expect_equal(result$removed_groups, 1)
+  expect_equal(sort(result$removed_groups_verbose), c("reg_a", "reg_b", "reg_c"))
+})
+
+test_that("find_optimal_bma_formula succeeds when the last allowed removal fixes VIF", {
+  skip_if_not_installed("car")
+
+  df <- make_collinear_pair_data()
+  var_list <- make_ungrouped_var_list(c("effect", "x1", "x2", "y1", "y2"))
+
+  result <- find_optimal_bma_formula(
+    df,
+    var_list,
+    max_groups_to_remove = 1,
+    return_variable_vector_instead = TRUE,
+    verbose = FALSE
+  )
+
+  expect_equal(result$removed_groups, 1)
+  expect_true(all(c("y1", "y2") %in% result$result))
+})
+
+test_that("find_optimal_bma_formula aborts only when removals are exhausted and VIFs remain high", {
+  skip_if_not_installed("car")
+
+  set.seed(17)
+  n <- 100L
+  x1 <- rnorm(n)
+  z1 <- rnorm(n)
+  df <- data.frame(
+    effect = rnorm(n),
+    x1 = x1,
+    x2 = x1 + rnorm(n, sd = 0.01),
+    z1 = z1,
+    z2 = z1 + rnorm(n, sd = 0.01),
+    y1 = rnorm(n),
+    stringsAsFactors = FALSE
+  )
+  var_list <- make_ungrouped_var_list(c("effect", "x1", "x2", "z1", "z2", "y1"))
+
+  expect_error(
+    find_optimal_bma_formula(
+      df,
+      var_list,
+      max_groups_to_remove = 1,
+      return_variable_vector_instead = TRUE,
+      verbose = FALSE
+    ),
+    "Optimal BMA formula not found"
+  )
+})
+
+test_that("rename_bma_model leaves unmatched regressor names untouched", {
+  model <- structure(
+    list(reg.names = c("mod1", "not_in_list")),
+    class = "bma"
+  )
+  var_list <- data.frame(
+    var_name = c("effect", "mod1"),
+    var_name_verbose = c("Effect", "Moderator 1"),
+    stringsAsFactors = FALSE
+  )
+
+  renamed <- rename_bma_model(model, var_list)
+
+  expect_equal(renamed$reg.names, c("Moderator 1", "not_in_list"))
 })
 
 test_that("prepare_bma_inputs warns about the excluded constant moderator", {


### PR DESCRIPTION
Fixes five verified defects in inst/artma/econometric/bma.R found by the numeric audit (continuing the #369-#380 series). All are independent of the BPE standardization fixes.

## Changes

1. **find_optimal_bma_formula: misaligned constancy mask.** The non-constant-column mask was computed in data-frame column order but AND-ed with input_var_list$bma, which is in var-list row order; differing order or length silently recycled and paired the mask with the wrong rows. The eligibility mask is now computed per var-list row (a row is usable only if its column survived the constancy filter).

2. **find_optimal_bma_formula: "other" treated as a dummy group.** "other" is the catch-all category for every unconfigured variable, so one VIF hit on any ungrouped moderator removed all of them in a single step, potentially leaving an intercept-only model where car::vif errors. Members of "other" (or an NA category) are now removed one at a time; genuine dummy groups are still removed wholesale.

3. **find_optimal_bma_formula: off-by-one on the removal budget.** When exactly max_groups_to_remove removals brought all VIFs under 10, the counter hit 0 and the function aborted despite succeeding. It now aborts only when removals are exhausted and VIFs still exceed 10.

4. **handle_bma_params: wrong branching on parameter lengths.** If every parameter had length n, unique lengths had one element and the list was treated as a single model, passing length-n vectors straight to BMS::bms; mixed multi-value lengths (e.g. 2 and 3) made seq_len error on a length-2 count. Branching is now on the set of lengths greater than 1: none means one model, one shared length means n models, and mixed lengths abort with the existing message.

5. **rename_bma_model: unmatched names renamed to "Intercept".** Regressor names absent from input_var_list$var_name were relabeled "Intercept", corrupting labels and the ma_table join. Unmatched names are now left untouched.

## Tests

Seven new tests in tests/testthat/test-bma.R cover mask alignment across differing column/row orders, individual removal of "other" members, wholesale removal of a genuine dummy group, success on the last allowed removal, abort when removals are exhausted with high VIFs, uniformly multi-valued and mixed-length parameter lists, and unmatched regressor names surviving rename.

Full suite: 2608 pass, 0 fail. styler and lintr clean.