### PR TITLE
fix(tests): probe an actual JAGS model fit in robma test

### DIFF
--- a/tests/testthat/test-robma.R
+++ b/tests/testthat/test-robma.R
@@ -6,26 +6,35 @@ box::use(
   withr[local_options]
 )
 
-# RoBMA fits through JAGS, a system library. rjags only loads when JAGS is
-# present, which makes it a reliable probe for a machine that can actually
-# fit -- but load the namespace in a subprocess, not here: on some platforms
-# (observed on macOS oldrel CI) rjags segfaults on dyn.load when its bundled
-# JAGS version doesn't match the system library, which would otherwise crash
-# the whole test process instead of just failing this one probe.
+# RoBMA fits through JAGS, a system library. Loading the rjags namespace is
+# not a sufficient probe: on some platforms (observed on macOS oldrel CI)
+# rjags loads fine but segfaults later, when it asks the *system* JAGS to
+# load its dynamic modules while compiling an actual model. Reproduce that
+# step in a subprocess, not here, so a crash kills only the disposable probe
+# instead of the whole test process.
 skip_if_no_jags <- function() {
   skip_if_not_installed("RoBMA")
   rscript <- file.path(R.home("bin"), "Rscript")
+  probe_expr <- paste(
+    "ok <- tryCatch({",
+    "  m <- rjags::jags.model(",
+    "    textConnection('model { x ~ dnorm(0, 1) }'), n.chains = 1, quiet = TRUE",
+    "  );",
+    "  TRUE",
+    "}, error = function(e) FALSE);",
+    "quit(status = !isTRUE(ok))"
+  )
   probe <- tryCatch(
     system2(
       rscript,
-      c("-e", shQuote("quit(status = !requireNamespace('rjags', quietly = TRUE))")),
+      c("-e", shQuote(probe_expr)),
       stdout = FALSE, stderr = FALSE
     ),
     error = function(e) 1L,
     warning = function(w) 1L
   )
   if (!identical(probe, 0L)) {
-    skip("JAGS is not available")
+    skip("JAGS is not available or crashes on this platform")
   }
 }
 


### PR DESCRIPTION
## Problem

r-universe's [check table](https://petrcala.r-universe.dev/artma#checktable) shows `macos-oldrel-arm64` and `macos-oldrel-x86_64` failing with `R CMD check` ERROR. Both logs show the test process is killed by SIGSEGV (exit code -11) while running `test-robma.R`'s `"robma fits the ensemble and returns estimates and components"` test.

## Root cause

- macOS binary repos for R 4.5 (oldrel) already ship `RoBMA_4.0.0.tgz`; R 4.6 (release) still only has `RoBMA_3.6.1.tgz`. On release, 3.6.1 fails to load, so the test self-skips before ever touching JAGS, accidentally hiding the issue.
- On oldrel, RoBMA 4.0.0 loads fine and `skip_if_no_jags()` passes, so the test proceeds to fit a real JAGS model — where it segfaults inside the rjags/JAGS native stack.

This is a known, previously-fought issue. Two earlier commits (`d6af276`, `5e030dd`/`4c4b38f`) narrowed the pre-flight probe, first checking `Sys.which("jags")`, then `requireNamespace("rjags")` in a subprocess. Neither reproduces the actual crash trigger: rjags's own namespace loads fine, but it segfaults later, when `rjags::jags.model()` asks the *system* JAGS to load its dynamic modules while compiling a model.

## Fix

Strengthen the subprocess probe to actually compile a trivial JAGS model, the real crash trigger, instead of just loading the rjags namespace. A crash there now kills only the disposable probe subprocess (already correctly checked via `system2`'s exit status), and the real test skips cleanly instead of taking down the whole check.

Verified locally: `make test-file FILE=test-robma.R` passes all 20 assertions, `make lint` is clean, and `styler` finds nothing to change.