### PR TITLE
fix(vcov): warn on no-cluster single-step downgrade to stats::vcov()

### DIFF
--- a/inst/artma/econometric/vcov.R
+++ b/inst/artma/econometric/vcov.R
@@ -152,9 +152,10 @@ robust_vcov <- function(model,
     }
   }
 
-  if (use_cluster || length(steps) > 1L) {
-    warn_downgrade("all robust estimators failed; using stats::vcov()")
-  }
+  # Reaching this point means every robust step errored, so the caller is
+  # about to receive classical (non-robust, non-clustered) SEs regardless of
+  # whether clustering was ever requested; always warn about that downgrade.
+  warn_downgrade("all robust estimators failed; using stats::vcov()")
   final_step()
 }
 

--- a/tests/testthat/test-econometric-vcov.R
+++ b/tests/testthat/test-econometric-vcov.R
@@ -131,6 +131,27 @@ test_that("robust_vcov warns when clustering is silently lost", {
   )
 })
 
+test_that("robust_vcov warns on the no-cluster single-step downgrade to stats::vcov()", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  # No cluster and no fallback_types: the sole (non-clustered) HC step is
+  # forced to fail with a bogus type, so the ladder falls through to
+  # stats::vcov(). This downgrade must still be warned about even though
+  # clustering was never requested and there is only one robust step.
+  expect_message(
+    robust_vcov(
+      model = model,
+      cluster = NULL,
+      engine = "sandwich",
+      clustered_type = "BOGUS",
+      fallback_types = character(0)
+    ),
+    regexp = "NOT clustered"
+  )
+})
+
 test_that("robust_vcov errors when a required cluster is NULL", {
   df <- make_vcov_fixture()
   model <- stats::lm(effect ~ se, data = df)


### PR DESCRIPTION
## Summary
Fixes #385. `warn_downgrade()` in `robust_vcov()` only fired the "everything failed, fell back to `stats::vcov()`" warning when `use_cluster || length(steps) > 1L`. A future call site passing `cluster = NULL` and an empty `fallback_types`, whose single HC step fails, would silently downgrade to classical (non-robust) inference without the warning PR #376 was written to catch.

No current call site hits this: all six real callers (exogeneity.R, best_practice_estimate.R, linear.R x3, nonlinear.R) always pass either a non-NULL cluster or a non-empty `fallback_types`.

## Changes
- Broadened the final-fallback warning condition in `robust_vcov()` (`inst/artma/econometric/vcov.R`) to fire unconditionally whenever every robust step fails and the ladder falls through to `stats::vcov()`, covering the previously-unwarned single-step no-cluster case.
- Added a regression test (`tests/testthat/test-econometric-vcov.R`) exercising `cluster = NULL`, `fallback_types = character(0)`, with the sole HC step forced to fail, asserting the warning fires.

## Testing
- `make test-file FILE=test-econometric-vcov.R`
- `make lint`
- `make test` (0 failures)