### PR TITLE
fix(maive): guardrail AR interval when constant N disables instrument

### DIFF
--- a/inst/artma/econometric/maive.R
+++ b/inst/artma/econometric/maive.R
@@ -215,7 +215,8 @@ ci_excludes_zero <- function(ci) {
 #' @param computed *[logical]* Whether AR computation was requested.
 #' @param available *[logical]* Whether MAIVE's guardrails permit the AR
 #'   interval for this specification (it is forced off for the EK model,
-#'   standard weights, and study fixed effects).
+#'   standard weights, study fixed effects, and when N has no variation and
+#'   the instrument gets auto-disabled).
 #' @return *[list]* With `value`, `note`, and `tone`.
 ar_ci_verdict <- function(ci, computed, available = TRUE) {
   if (!isTRUE(computed)) {
@@ -399,9 +400,13 @@ build_maive_summary <- function(maive_output, options, data_info = list(),
   beta_ci <- maive_ci(beta, beta_se)
   add(est, "95% CI", format_ci(beta_ci[[1L]], beta_ci[[2L]], rd))
 
+  # Mirrors MAIVE's own apply_guardrails(): AR is forced off for the EK model,
+  # standard weights, study fixed effects, and when N has no variation and the
+  # instrument gets auto-disabled.
   ar_guardrailed <- identical(as.integer(options$method %||% 3L), 4L) ||
     identical(as.integer(options$weight %||% 0L), 1L) ||
-    (fixed_intercept && !no_study_column)
+    (fixed_intercept && !no_study_column) ||
+    (instrumented && ns_constant)
   ar <- ar_ci_verdict(
     maive_output$AR_CI,
     identical(as.integer(options$ar %||% 0L), 1L),

--- a/tests/testthat/test-econometric-maive.R
+++ b/tests/testthat/test-econometric-maive.R
@@ -321,6 +321,21 @@ test_that("AR interval reports unavailability under MAIVE guardrails", {
   row_na <- summary_na[summary_na$Statistic == "Anderson-Rubin 95% CI", ]
   expect_equal(row_na$Value, "NA")
   expect_match(row_na$Note, "no valid acceptance region")
+
+  # Constant N: MAIVE auto-disables the instrument, which also forces AR off.
+  # Without this guardrail, the missing AR_CI reads as a failed search rather
+  # than an expected consequence of the disabled instrument.
+  summary_ns_constant <- build_maive_summary(
+    make_maive_output(AR_CI = "NA"),
+    base_maive_options(ar = 1L, instrument = 1L),
+    list(has_study_id = TRUE, ns_constant = TRUE)
+  )
+  row_ns_constant <- summary_ns_constant[
+    summary_ns_constant$Statistic == "Anderson-Rubin 95% CI",
+  ]
+  expect_equal(row_ns_constant$Value, "not available")
+  expect_match(row_ns_constant$Note, "does not compute")
+  expect_no_match(row_ns_constant$Note, "no valid acceptance region")
 })
 
 test_that("summary reports the effective study structure and instrument", {
@@ -539,6 +554,26 @@ test_that("run_maive resolves the first stage from the data and reports it", {
 
   expect_equal(result$first_stage$value, 1L)
   expect_true(result$first_stage$automatic)
+})
+
+test_that("run_maive reports the AR guardrail, not a failed search, on constant N", {
+  skip_if_not_installed("MAIVE", minimum_version = MAIVE_MIN_VERSION)
+  local_options(artma.verbose = 1)
+
+  # Constant N makes MAIVE auto-disable the instrument internally, which in
+  # turn forces its Anderson-Rubin interval off; the summary must say so
+  # instead of reporting "no valid acceptance region found".
+  df <- make_maive_df()
+  df$n_obs <- rep(200L, nrow(df))
+
+  # MAIVE itself warns about the auto-disable; that warning is expected here,
+  # not a symptom of a broken test.
+  result <- suppressWarnings(run_maive(df, base_maive_options(ar = 1L, instrument = 1L)))
+
+  expect_true(is.null(result$skipped))
+  row <- result$summary[result$summary$Statistic == "Anderson-Rubin 95% CI", ]
+  expect_equal(row$Value, "not available")
+  expect_match(row$Note, "does not compute")
 })
 
 test_that("run_maive is reproducible across two bootstrap runs", {


### PR DESCRIPTION
## Summary

MAIVE's internal `apply_guardrails` (in `normalize_maive_options`) forces `AR <- 0` in a fourth case beyond the three PR #378 already surfaces: when `instrument = 1` is requested but N has no variation across the data, MAIVE auto-disables the instrument and also zeroes out AR. Our `ar_guardrailed` check in [inst/artma/econometric/maive.R](inst/artma/econometric/maive.R) only checked `method == 4`, `weight == 1`, and `fixed_intercept && !no_study_column`, so this case fell through and the summary reported the misleading "NA / no valid acceptance region found" instead of the correct guardrail message.

Confirmed against the installed MAIVE 0.2.5 namespace (`MAIVE:::normalize_maive_options`'s internal `apply_guardrails`):

```r
if (instrument == 1L) {
  unique_Ns <- unique(stats::na.omit(Ns))
  if (length(unique_Ns) < 2L) {
    instrument <- 0L
    AR <- 0L
  }
}
```

## Changes

- Extend `ar_guardrailed` in [inst/artma/econometric/maive.R](inst/artma/econometric/maive.R) with `(instrumented && ns_constant)`, reusing the `ns_constant` flag already threaded through `data_info` for the "Instrument" spec row.
- Update the `ar_ci_verdict()` roxygen doc to mention the fourth guardrail case.
- Add regression tests in [tests/testthat/test-econometric-maive.R](tests/testthat/test-econometric-maive.R): a `build_maive_summary`-level case and an end-to-end `run_maive` case on constant-N data with `ar = 1, instrument = 1`, both asserting the summary reports "not available" / "does not compute" rather than "no valid acceptance region found".

Closes #386

## Testing

- `make lint`
- `make test`