### PR TITLE
fix: quiet dependency and validation noise in real runs and logs

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -112,12 +112,12 @@ options.validate <- function(
   if (length(errors) > 0) {
     cli::cli_alert_danger("Validation failed.")
 
-    cli::cli_h1("Validation errors found:")
-    for (err in errors) {
-      cli::cli_alert_danger(err$message)
-    }
-
     if (get_verbosity() >= 2) {
+      cli::cli_h1("Validation errors found:")
+      for (err in errors) {
+        cli::cli_alert_danger(err$message)
+      }
+
       cli::cli_h3("Possible Resolutions:")
       cli::cli_ul()
       cli::cli_li("Run {.code artma::options.help(c('opt.name1', 'opt.name2', ...))} to view detailed descriptions of the specified options.")

--- a/inst/artma/calc/methods/maive.R
+++ b/inst/artma/calc/methods/maive.R
@@ -69,9 +69,13 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
     cli::cli_abort("Missing required columns for MAIVE: {.field {missing_cols}}")
   }
 
-  # Call the MAIVE package function
+  # Call the MAIVE package function. MAIVE's own warnings are suppressed:
+  # the weak-instrument warning duplicates the diagnostic maive.R (the
+  # econometric wrapper) already re-derives and reports via cli_alert_warning,
+  # and clubSandwich's first-load "Registered S3 method overwritten" message
+  # is session noise with no user-actionable content.
   result <- tryCatch(
-    MAIVE::maive(
+    suppressWarnings(suppressMessages(MAIVE::maive(
       dat = dat,
       method = as.integer(method),
       weight = as.integer(weight),
@@ -81,7 +85,7 @@ maive <- function(dat, method = 3L, weight = 0L, instrument = 1L, studylevel = 2
       AR = as.integer(AR),
       first_stage = as.integer(first_stage),
       seed = as.integer(seed)
-    ),
+    ))),
     error = function(e) {
       cli::cli_abort(c(
         "MAIVE estimation failed: {e$message}",

--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -88,9 +88,21 @@ enforce_data_types <- function(df) {
       next
     }
     if (dtype %in% c("int", "dummy")) {
-      df[[col_name]] <- as.integer(df[[col_name]])
+      old_col <- df[[col_name]]
+      new_col <- suppressWarnings(as.integer(old_col))
+      n_coerced <- sum(is.na(new_col) & !is.na(old_col))
+      if (n_coerced > 0 && get_verbosity() >= 2) {
+        cli::cli_alert_warning("Coerced {.val {n_coerced}} non-integer value{?s} to {.val NA} in column {.field {col_name}}.")
+      }
+      df[[col_name]] <- new_col
     } else if (dtype %in% c("float", "perc")) {
-      df[[col_name]] <- as.numeric(df[[col_name]])
+      old_col <- df[[col_name]]
+      new_col <- suppressWarnings(as.numeric(old_col))
+      n_coerced <- sum(is.na(new_col) & !is.na(old_col))
+      if (n_coerced > 0 && get_verbosity() >= 2) {
+        cli::cli_alert_warning("Coerced {.val {n_coerced}} non-numeric value{?s} to {.val NA} in column {.field {col_name}}.")
+      }
+      df[[col_name]] <- new_col
     } else if (dtype == "category") {
       df[[col_name]] <- as.character(df[[col_name]])
     }
@@ -229,7 +241,7 @@ winsorize_data <- function(df) {
   }
 
   if (get_verbosity() >= 3) {
-    cli::cli_inform("Winsorizing data at {.val {winsorization_level}} level...")
+    cli::cli_alert_info("Winsorizing data at {.val {winsorization_level}} level...")
   }
 
   # Winsorize effect column

--- a/inst/artma/econometric/bma.R
+++ b/inst/artma/econometric/bma.R
@@ -478,7 +478,7 @@ extract_bma_results <- function(bma_model, bma_data, input_var_list, print_resul
     cli::cli_h3("Bayesian Model Averaging Results")
   }
 
-  if (print_results %in% c("verbose", "all")) {
+  if (print_results %in% c("verbose", "all") && get_verbosity() >= 2) {
     cli::cat_print(bma_model)
     cli::cat_print(bma_model$topmod[1])
   } else if (print_results == "fast") {
@@ -503,8 +503,8 @@ extract_bma_results <- function(bma_model, bma_data, input_var_list, print_resul
     )
 
     has_corrplot <- requireNamespace("corrplot", quietly = TRUE)
-    if (!has_corrplot) {
-      cli::cli_warn("Package {.pkg corrplot} is not installed; skipping the BMA correlation plot. Install with: install.packages('corrplot')")
+    if (!has_corrplot && get_verbosity() >= 2) {
+      cli::cli_alert_info("Package {.pkg corrplot} is not installed; skipping the BMA correlation plot. Install with: install.packages('corrplot')")
     }
 
     bma_matrix <- stats::cor(bma_data)
@@ -580,7 +580,7 @@ extract_bma_results <- function(bma_model, bma_data, input_var_list, print_resul
       )
       safe_render_plot(main_plot_call, "image plot")
       grDevices::dev.off()
-    } else {
+    } else if (get_verbosity() >= 3) {
       cli::cli_alert_info(
         "Skipping the BMA image plot export: it needs at least 4 regressors (model has {n_regressors})."
       )

--- a/inst/artma/libs/infrastructure/cache.R
+++ b/inst/artma/libs/infrastructure/cache.R
@@ -240,8 +240,14 @@ cache_cli <- function(fun,
 
   resolve_memoised <- function() {
     if (is.null(memo_state$memoised)) {
-      resolved_cache <- if (is.null(supplied_cache)) default_cache() else supplied_cache
-      memo_state$memoised <- memoise::memoise(worker, cache = resolved_cache)
+      # suppressMessages: constructing the cache (memoise::cache_filesystem())
+      # and memoise::memoise() itself both load the digest namespace on first
+      # use in a session, printing a raw "Loading required namespace: digest"
+      # line with no user-actionable content.
+      resolved_cache <- suppressMessages(
+        if (is.null(supplied_cache)) default_cache() else supplied_cache
+      )
+      memo_state$memoised <- suppressMessages(memoise::memoise(worker, cache = resolved_cache))
       memo_state$drop <- memoise::drop_cache(memo_state$memoised)
     }
     memo_state

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -121,17 +121,20 @@ robma <- function(df) {
     )
   }
 
-  effect_prior <- RoBMA::prior(
+  # suppressMessages: RoBMA lazily loads its runjags backend on first use,
+  # which prints a raw "Loading required namespace: runjags" line with no
+  # user-actionable content.
+  effect_prior <- suppressMessages(RoBMA::prior(
     distribution = "cauchy",
     parameters = list(location = 0, scale = effect_prior_scale),
     truncation = list(lower = 0, upper = Inf)
-  )
-  heterogeneity_prior <- RoBMA::prior(
+  ))
+  heterogeneity_prior <- suppressMessages(RoBMA::prior(
     distribution = "invgamma",
     parameters = list(shape = heterogeneity_shape, scale = heterogeneity_scale)
-  )
+  ))
 
-  fit <- RoBMA::RoBMA(
+  fit <- suppressMessages(RoBMA::RoBMA(
     yi = fit_data$effect,
     sei = fit_data$se,
     cluster = cluster_ids,
@@ -146,7 +149,7 @@ robma <- function(df) {
     autofit = isTRUE(autofit),
     seed = if (is.na(seed)) NULL else as.integer(seed),
     silent = get_verbosity() < 4
-  )
+  ))
 
   ensemble <- summary(fit)
   models <- RoBMA::summary_models(fit, type = "individual")

--- a/inst/artma/modules/runtime_methods.R
+++ b/inst/artma/modules/runtime_methods.R
@@ -235,7 +235,11 @@ missing_suggested_packages <- function(suggests, is_installed = NULL) {
     return(character())
   }
   if (is.null(is_installed)) {
-    is_installed <- function(pkg) requireNamespace(pkg, quietly = TRUE)
+    # suppressMessages: requireNamespace(quietly = TRUE) still lets through
+    # namespace-loading messages from a suggested package's own dependencies
+    # (e.g. RoBMA lazily loading runjags), which have no user-actionable
+    # content and only fire once per session anyway.
+    is_installed <- function(pkg) suppressMessages(requireNamespace(pkg, quietly = TRUE))
   }
   suggests <- as.character(suggests)
   suggests[!vapply(suggests, function(pkg) isTRUE(is_installed(pkg)), logical(1))]


### PR DESCRIPTION
Follow-up to a log-cleanliness audit of `make test` and a real `artma::artma()` run. Fixes the sources that affect a real user's console, plus the biggest test-log offender; test-hygiene cleanup (climenu fallback warnings, big table dumps, `local_cli_silence`) is a separate follow-up PR.

## What changed

- **`R/options.R`**: the per-error validation list (`Missing option: ...`) now gates on `get_verbosity() >= 2`, matching the "Possible Resolutions" block right below it. Previously it printed unconditionally regardless of verbosity - the single biggest contributor to test-log length (135 lines from one test file alone).
- **`inst/artma/calc/methods/maive.R`**: `MAIVE::maive()` is called under `suppressWarnings(suppressMessages(...))`. Its raw "Very weak instrument" warning duplicated a diagnostic artma already re-derives and reports via a styled `cli_alert_warning`; the `clubSandwich` S3-override message is one-time session noise.
- **`inst/artma/methods/robma.R`**: `RoBMA::prior()` / `RoBMA::RoBMA()` calls wrapped in `suppressMessages()` - RoBMA lazily loads its `runjags` backend on first use, printing an unstyled "Loading required namespace" line mid-output.
- **`inst/artma/libs/infrastructure/cache.R`**: the cache construction + `memoise::memoise()` call wrapped in `suppressMessages()`. Confirmed via a real end-to-end run that this line ("Loading required namespace: digest") was interrupting normal-verbosity output between "Schema reconciliation complete" and "Winsorizing data".
- **`inst/artma/modules/runtime_methods.R`**: the shared suggests-package check (`missing_suggested_packages`) now suppresses messages from `requireNamespace()`, since a suggested package's own dependency loading can leak the same kind of namespace-loading text for any method, not just RoBMA/MAIVE.
- **`inst/artma/econometric/bma.R`**: the missing-`corrplot` notice is now gated at `verbose >= 2` and downgraded from `cli_warn` (a real R warning) to `cli_alert_info`, since it's routine skippable behavior, not an error condition - and it fired on every `bma()` call on any machine without corrplot installed, unlike every neighboring diagnostic in the file. Also gated the "verbose"/"all" model-object dump at `verbose >= 2` (it previously ignored `artma.verbose` entirely) and gated the "Skipping the BMA image plot export" alert at `verbose >= 3` to match its siblings.
- **`inst/artma/data/preprocess.R`**: numeric/integer type coercion now wraps `as.integer()`/`as.numeric()` in `suppressWarnings()` and reports the count of values actually coerced to `NA` via `cli_alert_warning` instead of leaking R's raw "NAs introduced by coercion" warning. Also swapped one `cli_inform()` for `cli_alert_info()` for consistency with its sibling messages at the same verbosity gate.

## Verification

- `make test`: 0 failures, 2696 passing (same as before), WARN dropped from 3 to 2 (the MAIVE weak-instrument warning is gone; the 2 remaining are expected `climenu` non-interactive-mode fallback warnings, left for the test-hygiene follow-up).
- Test log line count: 690 → 671.
- A real `artma::artma()` run against the E2E smoke fixture is now free of the mid-run "Loading required namespace" interruption that showed up between schema reconciliation and winsorizing.
- `make lint`: no lints found.
- No `box::use()` imports changed, so no check-manifest regen was needed; `test-generated-check-manifest.R` still passes.