### PR TITLE
feat(fma): cluster-robust standard errors clustered by study_id

### DIFF
--- a/inst/artma/econometric/fma.R
+++ b/inst/artma/econometric/fma.R
@@ -68,11 +68,14 @@ resolve_fma_predictors <- function(bma_data, bma_model) {
 #' @param bma_data *\[data.frame\]* Data used for BMA estimation (effect in first column).
 #' @param bma_model *\[bma\]* BMA model used to order predictors.
 #' @param input_var_list *\[data.frame\]* Variable metadata with verbose names.
+#' @param cluster_ids *\[vector, optional\]* Cluster membership (e.g. study IDs)
+#'   for each row of `bma_data`. When supplied, coefficient standard errors are
+#'   cluster-robust (CR1); when `NULL`, classical iid standard errors are used.
 #' @param round_to *\[integer, optional\]* Digits for printed output; NULL uses global default.
-#' @param print_results *\[character\]* One of "none", "fast", "verbose", "all", or "table".
+#' @param print_results *\[character\]* One of "none", "fast", "verbose", or "all".
 #' @return *\[list\]* List with `coefficients` and `weights`.
 #' @export
-run_fma <- function(bma_data, bma_model, input_var_list, round_to = NULL, print_results = "none") {
+run_fma <- function(bma_data, bma_model, input_var_list, cluster_ids = NULL, round_to = NULL, print_results = "none") {
   box::use(
     artma / libs / core / validation[assert, validate]
   )
@@ -85,6 +88,20 @@ run_fma <- function(bma_data, bma_model, input_var_list, round_to = NULL, print_
     colnames(bma_data)[1] == "effect",
     print_results %in% c("none", "fast", "verbose", "all")
   )
+
+  cluster_factor <- NULL
+  if (!is.null(cluster_ids)) {
+    validate(
+      is.atomic(cluster_ids),
+      length(cluster_ids) == nrow(bma_data),
+      !any(is.na(cluster_ids))
+    )
+    assert(
+      length(unique(cluster_ids)) > 1L,
+      "Clustered FMA requires at least two distinct clusters."
+    )
+    cluster_factor <- factor(cluster_ids)
+  }
 
   assert(ncol(bma_data) >= 2, "FMA requires at least one predictor variable.")
 
@@ -138,10 +155,21 @@ run_fma <- function(bma_data, bma_model, input_var_list, round_to = NULL, print_
     e_i <- Y - x_tilda %*% beta.star
     e[, i] <- e_i
 
-    sigma_i <- as.numeric(crossprod(e_i) / (n - i))
-    var.matrix.star <- diag(sigma_i, i, i)
-    var.matrix.hat <- var.matrix.star %*% (Q %*% diag(lambda_adj^-1, i, i) %*% t(Q))
-    var.matrix[1:i, i] <- diag(var.matrix.hat)
+    # Eigen-floored (X'X)^-1: both variance paths share it so collinear
+    # designs degrade identically instead of erroring in solve().
+    xtx_inv <- Q %*% diag(lambda_adj^-1, i, i) %*% t(Q)
+    if (is.null(cluster_factor)) {
+      sigma_i <- as.numeric(crossprod(e_i) / (n - i))
+      var.matrix[1:i, i] <- sigma_i * diag(xtx_inv)
+    } else {
+      # CR1 cluster-robust vcov with the Stata small-sample correction,
+      # numerically identical to sandwich::vcovCL(type = "HC1").
+      scores <- rowsum(X * as.numeric(e_i), cluster_factor)
+      n_clusters <- nlevels(cluster_factor)
+      dfc <- (n_clusters / (n_clusters - 1)) * ((n - 1) / (n - i))
+      cl_vcov <- dfc * xtx_inv %*% crossprod(scores) %*% xtx_inv
+      var.matrix[1:i, i] <- diag(cl_vcov)
+    }
   }
 
   e_k <- e[, M, drop = FALSE]

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -33,12 +33,14 @@ fma <- function(df, bma_result = NULL) {
       constraint = function(x) x %in% c("none", "fast", "verbose", "all"),
       constraint_msg = "print_results must be one of: none, fast, verbose, all"
     ),
-    round_to = opt_spec(default = NA_integer_, type = "numeric", allow_na = TRUE)
+    round_to = opt_spec(default = NA_integer_, type = "numeric", allow_na = TRUE),
+    cluster = opt_spec(default = TRUE, type = "logical")
   ))
 
   verbose_output <- fma_resolved$verbose_output
   print_results <- fma_resolved$print_results
   round_to <- fma_resolved$round_to
+  cluster <- fma_resolved$cluster
 
   # Suppress individual FMA text output unless verbose_output is enabled
   effective_print <- if (verbose_output) print_results else "none"
@@ -123,10 +125,13 @@ fma <- function(df, bma_result = NULL) {
     bma_model <- run_bma(bma_data, bma_params, quiet = !verbose_output)
   }
 
+  cluster_ids <- if (cluster) resolve_fma_cluster_ids(df, bma_data) else NULL
+
   fma_results <- run_fma(
     bma_data = bma_data,
     bma_model = bma_model,
     input_var_list = bma_var_list,
+    cluster_ids = cluster_ids,
     round_to = round_to,
     print_results = effective_print
   )
@@ -138,9 +143,53 @@ fma <- function(df, bma_result = NULL) {
       model = bma_model,
       data = bma_data,
       params = bma_params,
-      var_list = bma_var_list
+      var_list = bma_var_list,
+      clustered = !is.null(cluster_ids)
     )
   )
+}
+
+#' Align `study_id` cluster IDs with the prepared BMA frame
+#'
+#' `prepare_bma_inputs()` drops rows via `stats::na.omit()`, so the prepared
+#' frame is matched back to `df` through its surviving row names. Returns
+#' `NULL` (iid standard errors) with a warning whenever a usable cluster
+#' vector cannot be built.
+#'
+#' @param df *\[data.frame\]* The preprocessed data frame passed to the method.
+#' @param bma_data *\[data.frame\]* The prepared BMA/FMA estimation frame.
+#' @return *\[vector, optional\]* Cluster IDs aligned with `bma_data` rows, or `NULL`.
+resolve_fma_cluster_ids <- function(df, bma_data) {
+  box::use(
+    artma / libs / core / utils[get_verbosity]
+  )
+
+  # Downgrading to iid inference changes reported SEs materially; never do it
+  # silently (mirrors robust_vcov's warn_downgrade contract).
+  warn_downgrade <- function(reason) {
+    if (get_verbosity() >= 2) {
+      cli::cli_alert_warning(
+        "Clustered FMA unavailable ({reason}); standard errors are NOT clustered."
+      )
+    }
+  }
+
+  if (!"study_id" %in% colnames(df)) {
+    warn_downgrade("the data have no study_id column")
+    return(NULL)
+  }
+
+  ids <- df[rownames(bma_data), "study_id"]
+  if (any(is.na(ids))) {
+    warn_downgrade("cluster IDs could not be aligned with the estimation frame")
+    return(NULL)
+  }
+  if (length(unique(ids)) < 2L) {
+    warn_downgrade("fewer than two distinct clusters")
+    return(NULL)
+  }
+
+  ids
 }
 
 box::use(
@@ -155,4 +204,4 @@ run <- register_runtime_method(
   suggests = c("BMS", "quadprog")
 )
 
-box::export(fma, run)
+box::export(fma, resolve_fma_cluster_ids, run)

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -619,6 +619,17 @@ methods:
         Scale parameter of the inverse-gamma prior on the heterogeneity.
 
   fma:
+    cluster:
+      type: "logical"
+      default: true
+      help: |
+        If `TRUE` (default), report cluster-robust (CR1) standard errors for
+        the FMA coefficients, clustered by `study_id`. Falls back to classical
+        iid standard errors, with a warning, when the data lack a usable
+        `study_id` column or contain fewer than two clusters. Model weights
+        and coefficients are unaffected; only standard errors and p-values
+        change.
+
     round_to:
       type: "integer"
       allow_na: true

--- a/tests/testthat/test-fma.R
+++ b/tests/testthat/test-fma.R
@@ -1,7 +1,10 @@
 box::use(
   testthat[
     expect_equal,
+    expect_error,
+    expect_false,
     expect_named,
+    expect_null,
     expect_true,
     skip_if_not_installed,
     test_that
@@ -10,7 +13,8 @@ box::use(
 
 box::use(
   artma / econometric / bma[get_bma_data, run_bma],
-  artma / econometric / fma[run_fma]
+  artma / econometric / fma[run_fma],
+  artma / methods / fma[resolve_fma_cluster_ids]
 )
 
 make_demo_fma_data <- function() {
@@ -131,4 +135,186 @@ test_that("Mallows penalty favors small models on pure-noise predictors", {
   small_half <- sum(result$weights[seq_len(ceiling(m / 2))])
   expect_true(small_half > 0.5)
   expect_true(result$weights[m] < 0.5)
+})
+
+# Study-clustered DGP: shared study shocks make cluster-robust and iid SEs
+# diverge visibly. Every predictor carries signal so the full model keeps
+# Mallows weight; a predictor excluded from all weighted models would get an
+# exact-zero SE and trip the positivity checks below.
+make_clustered_fma_inputs <- function() {
+  set.seed(321)
+  n_studies <- 12L
+  per_study <- 5L
+  n <- n_studies * per_study
+  study <- rep(seq_len(n_studies), each = per_study)
+  study_shock <- stats::rnorm(n_studies, sd = 0.1)
+
+  se_col <- stats::runif(n, min = 0.05, max = 0.15)
+  moderator1 <- stats::rnorm(n)
+  moderator2 <- stats::rbinom(n, size = 1, prob = 0.5)
+  df <- data.frame(
+    effect = 0.2 + 2 * se_col + 0.8 * moderator1 + 0.6 * moderator2 +
+      study_shock[study] + stats::rnorm(n, sd = 0.05),
+    se = se_col,
+    moderator1 = moderator1,
+    moderator2 = moderator2,
+    stringsAsFactors = FALSE
+  )
+
+  var_list <- data.frame(
+    var_name = c("effect", "se", "moderator1", "moderator2"),
+    var_name_verbose = c("effect", "se", "moderator1", "moderator2"),
+    bma = rep(TRUE, 4L),
+    to_log_for_bma = rep(FALSE, 4L),
+    bma_reference_var = rep(FALSE, 4L),
+    stringsAsFactors = FALSE
+  )
+
+  bma_data <- get_bma_data(
+    df,
+    var_list,
+    variable_info = c("effect", "se", "moderator1", "moderator2"),
+    scale_data = FALSE,
+    from_vector = TRUE,
+    include_reference_groups = FALSE
+  )
+
+  params <- list(
+    burn = 100L, iter = 500L, nmodel = 10L,
+    g = "UIP", mprior = "uniform", mcmc = "bd"
+  )
+
+  list(
+    study = study,
+    var_list = var_list,
+    bma_data = bma_data,
+    bma_model = run_bma(bma_data, params)
+  )
+}
+
+test_that("cluster_ids changes standard errors but not coefficients or weights", {
+  skip_if_not_installed("BMS")
+  skip_if_not_installed("quadprog")
+
+  inputs <- make_clustered_fma_inputs()
+
+  iid <- run_fma(
+    bma_data = inputs$bma_data,
+    bma_model = inputs$bma_model,
+    input_var_list = inputs$var_list,
+    print_results = "none"
+  )
+  clustered <- run_fma(
+    bma_data = inputs$bma_data,
+    bma_model = inputs$bma_model,
+    input_var_list = inputs$var_list,
+    cluster_ids = inputs$study,
+    print_results = "none"
+  )
+
+  # Clustering only reweights the score contributions inside the vcov; the
+  # point estimates and the Mallows weights must be untouched.
+  expect_equal(clustered$coefficients$coefficient, iid$coefficients$coefficient)
+  expect_equal(clustered$weights, iid$weights)
+
+  expect_true(all(is.finite(clustered$coefficients$se)))
+  expect_true(all(clustered$coefficients$se > 0))
+  expect_false(isTRUE(all.equal(clustered$coefficients$se, iid$coefficients$se)))
+})
+
+test_that("clustered FMA standard errors match a sandwich::vcovCL reference", {
+  skip_if_not_installed("BMS")
+  skip_if_not_installed("quadprog")
+
+  inputs <- make_clustered_fma_inputs()
+
+  result <- run_fma(
+    bma_data = inputs$bma_data,
+    bma_model = inputs$bma_model,
+    input_var_list = inputs$var_list,
+    cluster_ids = inputs$study,
+    print_results = "none"
+  )
+
+  # var_name_verbose equals var_name here, so the output rows reveal the
+  # predictor order run_fma actually used.
+  predictor_order <- setdiff(result$coefficients$variable, "Intercept")
+  x_data <- cbind(1, as.matrix(inputs$bma_data[predictor_order]))
+  scale_vector <- apply(abs(x_data), 2, max)
+  x_scaled <- sweep(x_data, 2, scale_vector, "/")
+  y <- inputs$bma_data$effect
+
+  m <- ncol(x_scaled)
+  beta <- matrix(0, nrow = m, ncol = m)
+  var_matrix <- matrix(0, nrow = m, ncol = m)
+  for (i in seq_len(m)) {
+    x_i <- x_scaled[, seq_len(i), drop = FALSE]
+    fit_i <- stats::lm(y ~ 0 + x_i)
+    beta[seq_len(i), i] <- stats::coef(fit_i)
+    var_matrix[seq_len(i), i] <- diag(
+      sandwich::vcovCL(fit_i, cluster = inputs$study, type = "HC1")
+    )
+  }
+
+  weights <- result$weights
+  beta_avg <- beta %*% weights
+  bias_sq <- (beta - as.numeric(beta_avg))^2
+  expected_coef <- as.numeric(beta_avg / scale_vector)
+  expected_se <- as.numeric((sqrt(var_matrix + bias_sq) %*% weights) / scale_vector)
+
+  expect_equal(result$coefficients$coefficient, expected_coef, tolerance = 1e-6)
+  expect_equal(result$coefficients$se, expected_se, tolerance = 1e-6)
+})
+
+test_that("run_fma validates cluster_ids", {
+  skip_if_not_installed("BMS")
+  skip_if_not_installed("quadprog")
+
+  inputs <- make_clustered_fma_inputs()
+  n <- nrow(inputs$bma_data)
+
+  run_with_cluster <- function(cluster_ids) {
+    run_fma(
+      bma_data = inputs$bma_data,
+      bma_model = inputs$bma_model,
+      input_var_list = inputs$var_list,
+      cluster_ids = cluster_ids,
+      print_results = "none"
+    )
+  }
+
+  expect_error(run_with_cluster(rep("a", n)), "at least two distinct clusters")
+  expect_error(run_with_cluster(inputs$study[-1]))
+  expect_error(run_with_cluster(c(NA, inputs$study[-1])))
+})
+
+test_that("resolve_fma_cluster_ids aligns study_id through na.omit row names", {
+  df <- data.frame(
+    effect = c(0.1, NA, 0.3, 0.4, 0.5, 0.6),
+    se = c(0.05, 0.06, 0.07, NA, 0.09, 0.1),
+    study_id = c("s1", "s1", "s2", "s2", "s3", "s3"),
+    stringsAsFactors = FALSE
+  )
+  bma_data <- stats::na.omit(df[c("effect", "se")])
+
+  ids <- resolve_fma_cluster_ids(df, bma_data)
+  expect_equal(ids, c("s1", "s2", "s3", "s3"))
+  expect_equal(length(ids), nrow(bma_data))
+})
+
+test_that("resolve_fma_cluster_ids downgrades to NULL on unusable clusters", {
+  bma_data <- data.frame(effect = c(0.1, 0.2), se = c(0.05, 0.06))
+
+  no_study <- data.frame(effect = c(0.1, 0.2), se = c(0.05, 0.06))
+  expect_null(resolve_fma_cluster_ids(no_study, bma_data))
+
+  single_cluster <- cbind(no_study, study_id = c("s1", "s1"))
+  expect_null(resolve_fma_cluster_ids(single_cluster, bma_data))
+
+  na_ids <- cbind(no_study, study_id = c("s1", NA))
+  expect_null(resolve_fma_cluster_ids(na_ids, bma_data))
+
+  # Rows that cannot be matched back to df resolve to NA and downgrade too.
+  foreign_rows <- data.frame(effect = 0.1, se = 0.05, study_id = "s1", row.names = "99")
+  expect_null(resolve_fma_cluster_ids(foreign_rows, bma_data))
 })


### PR DESCRIPTION
## Summary

Adds cluster-robust (CR1) standard errors to frequentist model averaging, clustered by `study_id` and on by default. Based on a contribution by Matyáš Tvrz (bachelor thesis under prof. Havránková, IES), reworked to fit the current estimator and the package conventions.

### What his contribution provided

The core idea and the CRVE math: cluster-summed scores, `(X'X)^-1` bread, and the Stata small-sample correction `G/(G-1) * (n-1)/(n-k)`. His formula is numerically identical to `sandwich::vcovCL(type = "HC1")`; the new reference test pins that equivalence per nested model.

### What changed relative to his draft

- Single `run_fma(cluster_ids = NULL)` parameter instead of a duplicated `run_fma_cluster` function with a separate `clustered` flag.
- His port passed residuals as an n x 1 matrix into `X * e`, which errors as non-conformable from the second nested model on; residuals are coerced to a vector and cluster sums are computed with `rowsum()`.
- His draft branched from the pre-a25c69b estimator, so it carried the sign-flipped sigma^4 Mallows penalty and full-model bias centering fixed on master yesterday; the clustered path now sits on top of the corrected criterion and Buckland centering.
- The CRVE bread reuses the eigen-floored `(X'X)^-1` already computed in the loop, so collinear designs degrade the same way as the iid path instead of erroring in `solve()`.

### Wiring

- `methods/fma.R` resolves `study_id` from the preprocessed frame and aligns it with the prepared BMA frame through row names (rows dropped by `na.omit` in `prepare_bma_inputs` stay matched).
- New template option `methods.fma.cluster` (default `true`). Downgrades to iid SEs with a warning when `study_id` is missing, unalignable, or has fewer than two clusters, mirroring the `robust_vcov` downgrade contract.
- Method result `meta` now records `clustered` so downstream consumers can tell which inference was used.

### Scope notes

- Only standard errors and p-values change; Mallows weights and coefficients are invariant to clustering (tested). The Mallows criterion itself remains iid-based.
- p-values stay normal-based, matching the package convention (`linear.R`, `maive.R`).

## Testing

- `make test-file FILE=test-fma.R`: 25 pass. New tests cover the sandwich::vcovCL HC1 per-model equivalence composed through the Buckland SE formula, coefficient and weight invariance to clustering, cluster_ids validation, row-name alignment through na.omit, and every downgrade path.
- `make test-filter FILTER=options`: 290 pass (template parity and migration).
- `make lint`: clean.
