### PR TITLE
test: silence expected warnings and result-table noise in test log

### DIFF
--- a/inst/artma/data/schema_reconcile.R
+++ b/inst/artma/data/schema_reconcile.R
@@ -45,7 +45,8 @@ emit_reconcile_complete <- function() {
 #' @keywords internal
 reconcile_schema <- function(raw_df, mode = NULL) {
   box::use(
-    artma / libs / core / autonomy[should_prompt_user]
+    artma / libs / core / autonomy[should_prompt_user],
+    artma / libs / core / utils[get_verbosity]
   )
 
   mode <- mode %||% getOption("artma.data.reconcile_mode", "ask")
@@ -155,8 +156,13 @@ reconcile_schema <- function(raw_df, mode = NULL) {
     raw_df = raw_df
   )
 
-  # Show unified diff
-  show_drift_summary(drift, proposals_roles, proposals_moderators, role_sources)
+  # Show unified diff. Unlike emit_reconcile_complete()'s plain success note,
+  # this is drift detail worth a "Warnings + errors" gate rather than always
+  # printing - it was previously ungated, unlike every sibling cli call in
+  # this module.
+  if (get_verbosity() >= 2) {
+    show_drift_summary(drift, proposals_roles, proposals_moderators, role_sources)
+  }
 
   # Collect decisions
   do_prompt <- (mode == "ask") && should_prompt_user(required_level = "autonomous")

--- a/tests/testthat/modules/testing/fixtures/helper_test_cache.R
+++ b/tests/testthat/modules/testing/fixtures/helper_test_cache.R
@@ -1,7 +1,13 @@
-# Silence cli output so it doesn't clutter testthat reports
+# Silence cli output so it doesn't clutter testthat reports. `cli.autoprint`
+# alone only affects auto-printing of returned cli objects at the console top
+# level - it does nothing for cli_alert()/cli_inform() calls made inside
+# function bodies, which is what actually clutters test output. Drop
+# artma.verbose to "errors only" too; this does not hide genuine warning()/
+# stop() conditions, which aren't gated by artma.verbose.
 local_cli_silence <- function(env = parent.frame()) {
   old <- options(cli.autoprint = FALSE)
   withr::defer(options(old), envir = env)
+  withr::local_options(list("artma.verbose" = 1), .local_envir = env)
 }
 
 # Synthetic "expensive" function used in cache tests --------------------------

--- a/tests/testthat/test-data-auto-detection-confirmation.R
+++ b/tests/testthat/test-data-auto-detection-confirmation.R
@@ -156,9 +156,12 @@ test_that("present_detected_mapping handles required columns only", {
 
   withr::local_options(list("artma.verbose" = 1))
 
-  # Test that function doesn't error with required columns only
+  # climenu::select() legitimately warns "Not running in interactive mode" as
+  # its documented non-interactive fallback behavior (see the climenu package's
+  # own test suite) - suppress it here since this test asserts on the absence
+  # of an error, not on that expected warning.
   expect_no_error(
-    tryCatch(
+    suppressWarnings(tryCatch(
       {
         present_detected_mapping(
           auto_mapping = auto_mapping,
@@ -171,7 +174,7 @@ test_that("present_detected_mapping handles required columns only", {
         # That's expected behavior
         "modify"
       }
-    )
+    ))
   )
 })
 
@@ -199,8 +202,10 @@ test_that("present_detected_mapping handles mixed required and optional", {
 
   withr::local_options(list("artma.verbose" = 1))
 
+  # See the comment on the previous test: suppress climenu's expected
+  # non-interactive-mode fallback warning.
   expect_no_error(
-    tryCatch(
+    suppressWarnings(tryCatch(
       {
         present_detected_mapping(
           auto_mapping = auto_mapping,
@@ -209,7 +214,7 @@ test_that("present_detected_mapping handles mixed required and optional", {
         )
       },
       error = function(e) "modify"
-    )
+    ))
   )
 })
 

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -115,7 +115,7 @@ test_that("run_linear_models flags and marks conflicting rows on high-leverage d
   )
 
   set.seed(100)
-  res <- run_linear_models(df, opts)
+  utils::capture.output(res <- run_linear_models(df, opts), type = "message")
 
   conflicts <- res$coefficients[res$coefficients$ci_conflict %in% TRUE, , drop = FALSE]
   expect_gt(nrow(conflicts), 0)
@@ -138,7 +138,11 @@ test_that("linear_tests warns when few bootstrap replications are requested", {
     "artma.verbose" = 1
   )
 
-  expect_message(linear_tests(df), "Only 10 bootstrap replications")
+  # linear_tests() prints its result table regardless of verbosity (the table
+  # is the method's deliverable, not progress narration); capture.output
+  # keeps that off the test log while expect_message still sees the signaled
+  # condition, since sink redirection and condition signaling are orthogonal.
+  expect_message(utils::capture.output(linear_tests(df), type = "message"), "Only 10 bootstrap replications")
 })
 
 test_that("linear_tests does not warn about replications when the count is high enough", {
@@ -152,7 +156,7 @@ test_that("linear_tests does not warn about replications when the count is high 
     "artma.verbose" = 1
   )
 
-  expect_no_message(linear_tests(df), message = "bootstrap replications")
+  expect_no_message(utils::capture.output(linear_tests(df), type = "message"), message = "bootstrap replications")
 })
 
 test_that("linear_tests reports the count of estimates with disagreeing stars and CIs", {
@@ -168,7 +172,7 @@ test_that("linear_tests reports the count of estimates with disagreeing stars an
   )
 
   set.seed(100)
-  expect_message(linear_tests(df), "estimates are.*marked with")
+  expect_message(utils::capture.output(linear_tests(df), type = "message"), "estimates are.*marked with")
 })
 
 test_that("linear tests return tidy coefficients and summary", {
@@ -184,7 +188,7 @@ test_that("linear tests return tidy coefficients and summary", {
     "artma.verbose" = 1
   )
 
-  res <- linear_tests(df)
+  utils::capture.output(res <- linear_tests(df), type = "message")
 
   expect_named(res, c("tables", "plots", "meta"))
   expect_named(res$tables, "summary")
@@ -238,7 +242,7 @@ test_that("linear tests gracefully skip models with missing columns", {
     "artma.verbose" = 1
   )
 
-  res <- linear_tests(df)
+  utils::capture.output(res <- linear_tests(df), type = "message")
 
   expect_false("ols_precision_weighted" %in% res$meta$coefficients$model)
   expect_true("ols_precision_weighted" %in% names(res$meta$skipped))
@@ -257,10 +261,10 @@ test_that("bootstrap CIs are deterministic and seed-identical to the tidy-path i
   )
 
   set.seed(123)
-  res <- run_linear_models(df, options = opts)
+  utils::capture.output(res <- run_linear_models(df, options = opts), type = "message")
 
   set.seed(123)
-  res_repeat <- run_linear_models(df, options = opts)
+  utils::capture.output(res_repeat <- run_linear_models(df, options = opts), type = "message")
 
   ci_cols <- c("model", "term", "bootstrap_lower", "bootstrap_upper")
   ci <- res$coefficients[, ci_cols]
@@ -310,14 +314,17 @@ test_that("FE effect-beyond-bias SE comes from the auxiliary intercept model, no
   skip_if_not_installed("plm")
 
   df <- make_unbalanced_data()
-  res <- run_linear_models(
-    df,
-    options = list(
-      add_significance_marks = FALSE,
-      bootstrap_replications = 0L,
-      conf_level = 0.95,
-      round_to = 3L
-    )
+  utils::capture.output(
+    res <- run_linear_models(
+      df,
+      options = list(
+        add_significance_marks = FALSE,
+        bootstrap_replications = 0L,
+        conf_level = 0.95,
+        round_to = 3L
+      )
+    ),
+    type = "message"
   )
 
   fe <- res$coefficients[res$coefficients$model == "fe", , drop = FALSE]
@@ -338,14 +345,17 @@ test_that("FE effect-beyond-bias SE comes from the auxiliary intercept model, no
 
 test_that("study-weighted OLS gives each study equal total weight", {
   df <- make_unbalanced_data()
-  res <- run_linear_models(
-    df,
-    options = list(
-      add_significance_marks = FALSE,
-      bootstrap_replications = 0L,
-      conf_level = 0.95,
-      round_to = 3L
-    )
+  utils::capture.output(
+    res <- run_linear_models(
+      df,
+      options = list(
+        add_significance_marks = FALSE,
+        bootstrap_replications = 0L,
+        conf_level = 0.95,
+        round_to = 3L
+      )
+    ),
+    type = "message"
   )
 
   sw <- res$coefficients[res$coefficients$model == "ols_study_weighted", , drop = FALSE]
@@ -408,7 +418,11 @@ test_that("bootstrap fast paths match slow-path refits on resampled data", {
         next
       }
 
-      slow_tidy <- spec$tidy(slow_model, boot_data)
+      # Small resampled clusters can legitimately fail clustered vcov
+      # estimation; spec$tidy() reports that with a cli_alert_warning that
+      # isn't test-relevant here (this test compares estimates, not vcov
+      # diagnostics), so keep it off the log.
+      slow_tidy <- suppressMessages(spec$tidy(slow_model, boot_data))
       slow <- stats::setNames(slow_tidy$estimate, slow_tidy$term)
 
       expect_equal(
@@ -725,14 +739,17 @@ test_that("two-cluster data skips RE and BE with a plain-language reason", {
   df <- make_demo_data()
   df <- df[df$study_id %in% c("S1", "S2"), , drop = FALSE]
 
-  res <- run_linear_models(
-    df,
-    options = list(
-      add_significance_marks = FALSE,
-      bootstrap_replications = 0L,
-      conf_level = 0.95,
-      round_to = 3L
-    )
+  utils::capture.output(
+    res <- run_linear_models(
+      df,
+      options = list(
+        add_significance_marks = FALSE,
+        bootstrap_replications = 0L,
+        conf_level = 0.95,
+        round_to = 3L
+      )
+    ),
+    type = "message"
   )
 
   expect_true(all(c("re", "be") %in% names(res$skipped)))
@@ -761,14 +778,17 @@ test_that("singleton-cluster data skips FE and RE with a plain-language reason",
     check.names = FALSE
   )
 
-  res <- run_linear_models(
-    df,
-    options = list(
-      add_significance_marks = FALSE,
-      bootstrap_replications = 0L,
-      conf_level = 0.95,
-      round_to = 3L
-    )
+  utils::capture.output(
+    res <- run_linear_models(
+      df,
+      options = list(
+        add_significance_marks = FALSE,
+        bootstrap_replications = 0L,
+        conf_level = 0.95,
+        round_to = 3L
+      )
+    ),
+    type = "message"
   )
 
   expect_true(all(c("fe", "re") %in% names(res$skipped)))
@@ -787,14 +807,17 @@ test_that("constant within-cluster se skips FE and RE even with many clusters", 
   df <- make_demo_data()
   df$se <- stats::ave(df$se, df$study_id)
 
-  res <- run_linear_models(
-    df,
-    options = list(
-      add_significance_marks = FALSE,
-      bootstrap_replications = 0L,
-      conf_level = 0.95,
-      round_to = 3L
-    )
+  utils::capture.output(
+    res <- run_linear_models(
+      df,
+      options = list(
+        add_significance_marks = FALSE,
+        bootstrap_replications = 0L,
+        conf_level = 0.95,
+        round_to = 3L
+      )
+    ),
+    type = "message"
   )
 
   expect_true(all(c("fe", "re") %in% names(res$skipped)))
@@ -807,15 +830,18 @@ test_that("constant within-cluster se skips FE and RE even with many clusters", 
 test_that("panel models are skipped with a clear message when plm is unavailable", {
   df <- make_demo_data()
 
-  res <- run_linear_models(
-    df,
-    options = list(
-      add_significance_marks = FALSE,
-      bootstrap_replications = 0L,
-      conf_level = 0.95,
-      round_to = 3L
+  utils::capture.output(
+    res <- run_linear_models(
+      df,
+      options = list(
+        add_significance_marks = FALSE,
+        bootstrap_replications = 0L,
+        conf_level = 0.95,
+        round_to = 3L
+      ),
+      is_pkg_available = function(pkg) pkg != "plm"
     ),
-    is_pkg_available = function(pkg) pkg != "plm"
+    type = "message"
   )
 
   panel_models <- c("fe", "be", "re")

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -42,7 +42,7 @@ make_p_hacking_df <- function(seed = 1, n = 60) {
 test_that("p_hacking_tests returns the standard contract with a caliper table", {
   local_caliper_only_options()
 
-  result <- p_hacking_tests(make_p_hacking_df())
+  utils::capture.output(result <- p_hacking_tests(make_p_hacking_df()), type = "message")
 
   expect_true(is.list(result))
   expect_true(is.data.frame(result$tables$caliper))
@@ -108,7 +108,12 @@ test_that("a custom elliott_supports option flows through to the Cox-Shi call", 
   run_with_supports <- function(supports) {
     opts <- elliott_base_options()
     opts$artma.methods.p_hacking_tests.elliott_supports <- supports
-    with_options(opts, p_hacking_tests(df))
+    result <- NULL
+    utils::capture.output(
+      result <- with_options(opts, p_hacking_tests(df)),
+      type = "message"
+    )
+    result
   }
 
   default_result <- run_with_supports(c(0.05, 0.1))
@@ -183,7 +188,7 @@ test_that("exogeneity_tests returns the standard contract with IV results", {
   skip_if_not_installed("AER")
   local_options(artma.verbose = 1)
 
-  result <- exogeneity_tests(make_exogeneity_df())
+  utils::capture.output(result <- exogeneity_tests(make_exogeneity_df()), type = "message")
 
   expect_true(is.list(result))
   expect_true(is.data.frame(result$tables$summary))
@@ -212,7 +217,10 @@ test_that("exogeneity_tests handles mock data with too few significant p-uniform
   df <- create_mock_df(nrow = 600, n_studies = 30)
   df$study_size <- unname(as.integer(table(df$study_id)[as.character(df$study_id)]))
 
-  result <- expect_no_error(exogeneity_tests(df))
+  utils::capture.output(
+    result <- expect_no_error(exogeneity_tests(df)),
+    type = "message"
+  )
 
   expect_true(is.data.frame(result$tables$summary))
   expect_equal(nrow(result$tables$summary), 7L)


### PR DESCRIPTION
Follow-up to #389 (source-side fixes). This pass targets the test suite itself: expected warnings that leaked as testthat `WARNING:` blocks, and the three biggest table-dump test files.

## What changed

- **`tests/testthat/test-data-auto-detection-confirmation.R`**: two tests call `present_detected_mapping()` in a non-interactive session, which legitimately triggers `climenu::select()`'s documented "Not running in interactive mode" warning (verified against climenu's own test suite). Both were only wrapped in `expect_no_error`, so the warning propagated as a testthat `WARNING:` block with a 17-line backtrace. Now wrapped in `suppressWarnings()`.
- **`tests/testthat/modules/testing/fixtures/helper_test_cache.R`**: `local_cli_silence()` only toggled `cli.autoprint`, which affects auto-printing of returned cli objects at the console top level and does nothing for `cli_alert()`/`cli_inform()` calls made inside function bodies - the actual source of test-log clutter. It's used in 6 test files under a name that implied broader silencing than it delivered. Now also drops `artma.verbose` to 1 ("errors only") for the duration, which doesn't hide genuine `warning()`/`stop()` conditions since those aren't gated by `artma.verbose`.
- **`tests/testthat/test-linear-tests.R`**: `linear_tests()` prints its full result table regardless of verbosity by design (the table is the method's deliverable, not progress narration - confirmed via the existing `display_ma_table` test that pins this behavior at `verbose = 1`). Wrapped every call site (`linear_tests()`, `run_linear_models()`, and the low-level `spec$tidy()` used by the fast-path comparison tests) in `utils::capture.output(..., type = "message")` where the printed output isn't itself under test, so the returned object is still fully assertable. Two `expect_message()`/`expect_no_message()` sites needed the same treatment - `capture.output()`'s sink redirection and `expect_message()`'s condition handling are orthogonal, so both compose correctly.
- **`tests/testthat/test-methods-p-hacking-exogeneity.R`**: same treatment for the remaining unwrapped `p_hacking_tests()`/`exogeneity_tests()` call sites (two test files already used this pattern for some calls, just not consistently).
- **`inst/artma/data/schema_reconcile.R`**: found while chasing `test-schema-reconcile-integration.R`'s noise - `show_drift_summary()` (the "artma detected dataset changes" banner) was the one cli call in this module with no `get_verbosity()` gate at all, unlike its sibling `emit_reconcile_complete()` and everything in `auto_decisions()`. Gated it at `verbose >= 2` ("Warnings + errors"), which still shows at the default verbosity (3) for real users and only actually changes behavior for callers that explicitly lower verbosity to 1.

## Verification

- `make test`: 0 failures, 2703 passing (unchanged), 0 warnings (down from 2).
- Test log line count: 671 → 171 (a ~75% reduction on top of #389's 690 → 671).
- `make lint`: no lints found.
- `test-generated-check-manifest.R` still passes (no `box::use()` import drift from the new `get_verbosity` import in `schema_reconcile.R`).

The remaining ~170 lines are legitimate: a full end-to-end integration test's real output (`test-report-integration.R`), expected operational messages (schema detection, options validation errors under deliberately-invalid fixtures, na-handling notices), and a handful of one-time namespace-loading lines from direct `memoise`/`RoBMA` calls in test code itself (not package source, and not worth chasing further for the line count they cost).