### PR TITLE
test: silence remaining namespace, formatter, and vcov/fma test noise

### DIFF
--- a/inst/artma/data/na_handling.R
+++ b/inst/artma/data/na_handling.R
@@ -210,7 +210,12 @@ handle_na_interpolate <- function(df, exclude_cols = character(0)) {
 handle_na_mice <- function(df, exclude_cols = character(0)) {
   box::use(artma / data / profile[detect_dummy_groups])
 
-  if (!requireNamespace("mice", quietly = TRUE)) {
+  # suppressMessages: this is the first `mice::` reference in the session on
+  # a fresh load, so requireNamespace() here (not just the later mice::mice()
+  # call) is what triggers mice's own Imports (car, lme4) to load, printing a
+  # raw "Registered S3 method overwritten" line with no user-actionable
+  # content.
+  if (!suppressMessages(requireNamespace("mice", quietly = TRUE))) {
     cli::cli_abort(c(
       "x" = "The {.pkg mice} package is required for multiple imputation",
       "i" = "Install it with: {.code install.packages('mice')}"

--- a/tests/testthat/test-econometric-vcov.R
+++ b/tests/testthat/test-econometric-vcov.R
@@ -62,15 +62,19 @@ test_that("get_robust_vcov ladder falls back to non-clustered HC1 on cluster err
   model <- stats::lm(effect ~ se, data = df)
 
   # A wrong-length cluster makes vcovCL error; the ladder should fall through
-  # to the non-clustered HC1 step.
-  result <- robust_vcov(
-    model = model,
-    cluster = c(1, 2, 3),
-    engine = "sandwich",
-    clustered_type = "HC1",
-    fallback_types = c("HC1", "HC0"),
-    require_cluster = TRUE,
-    suppress_warnings = TRUE
+  # to the non-clustered HC1 step, warning about the downgrade along the way -
+  # not itself under test here, so keep it off the log.
+  utils::capture.output(
+    result <- robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC1",
+      fallback_types = c("HC1", "HC0"),
+      require_cluster = TRUE,
+      suppress_warnings = TRUE
+    ),
+    type = "message"
   )
 
   oracle <- suppressWarnings(sandwich::vcovHC(model, type = "HC1"))
@@ -83,27 +87,37 @@ test_that("robust_vcov warns when clustering is silently lost", {
   model <- stats::lm(effect ~ se, data = df)
 
   # Clustered step fails on a wrong-length cluster: the fallback must announce
-  # that the returned SEs are not clustered.
+  # that the returned SEs are not clustered. The alert is real signal here
+  # (it's exactly what's under test), but its cli_alert_warning() text still
+  # leaks to the console independently of testthat's condition handling, so
+  # capture.output() keeps the log clean while expect_message() still sees
+  # the signaled condition.
   expect_message(
-    robust_vcov(
-      model = model,
-      cluster = c(1, 2, 3),
-      engine = "sandwich",
-      clustered_type = "HC1",
-      fallback_types = c("HC1", "HC0"),
-      suppress_warnings = TRUE
+    utils::capture.output(
+      invisible(robust_vcov(
+        model = model,
+        cluster = c(1, 2, 3),
+        engine = "sandwich",
+        clustered_type = "HC1",
+        fallback_types = c("HC1", "HC0"),
+        suppress_warnings = TRUE
+      )),
+      type = "message"
     ),
     regexp = "NOT clustered"
   )
 
   # The match_cluster_length guard is the same downgrade and must also warn.
   expect_message(
-    robust_vcov(
-      model = model,
-      cluster = c(1, 2, 3),
-      engine = "sandwich",
-      clustered_type = "HC0",
-      match_cluster_length = TRUE
+    utils::capture.output(
+      invisible(robust_vcov(
+        model = model,
+        cluster = c(1, 2, 3),
+        engine = "sandwich",
+        clustered_type = "HC0",
+        match_cluster_length = TRUE
+      )),
+      type = "message"
     ),
     regexp = "NOT clustered"
   )
@@ -141,12 +155,15 @@ test_that("robust_vcov warns on the no-cluster single-step downgrade to stats::v
   # stats::vcov(). This downgrade must still be warned about even though
   # clustering was never requested and there is only one robust step.
   expect_message(
-    robust_vcov(
-      model = model,
-      cluster = NULL,
-      engine = "sandwich",
-      clustered_type = "BOGUS",
-      fallback_types = character(0)
+    utils::capture.output(
+      invisible(robust_vcov(
+        model = model,
+        cluster = NULL,
+        engine = "sandwich",
+        clustered_type = "BOGUS",
+        fallback_types = character(0)
+      )),
+      type = "message"
     ),
     regexp = "NOT clustered"
   )
@@ -186,13 +203,17 @@ test_that("resolve_bpe_vcov ladder uses non-clustered HC0 when cluster length mi
   model <- stats::lm(effect ~ se, data = df)
 
   # Wrong-length cluster: the length guard rejects it and the primary step is
-  # the non-clustered HC0 vcov.
-  result <- robust_vcov(
-    model = model,
-    cluster = c(1, 2, 3),
-    engine = "sandwich",
-    clustered_type = "HC0",
-    match_cluster_length = TRUE
+  # the non-clustered HC0 vcov, warning about the downgrade along the way -
+  # not itself under test here, so keep it off the log.
+  utils::capture.output(
+    result <- robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC0",
+      match_cluster_length = TRUE
+    ),
+    type = "message"
   )
 
   oracle <- sandwich::vcovHC(model, type = "HC0")
@@ -200,12 +221,15 @@ test_that("resolve_bpe_vcov ladder uses non-clustered HC0 when cluster length mi
   expect_equal(unname(result["se", "se"]), 0.1105633, tolerance = 1e-6)
 
   # NULL cluster follows the same non-clustered branch.
-  result_null <- robust_vcov(
-    model = model,
-    cluster = NULL,
-    engine = "sandwich",
-    clustered_type = "HC0",
-    match_cluster_length = TRUE
+  utils::capture.output(
+    result_null <- robust_vcov(
+      model = model,
+      cluster = NULL,
+      engine = "sandwich",
+      clustered_type = "HC0",
+      match_cluster_length = TRUE
+    ),
+    type = "message"
   )
   expect_equal(result_null, oracle)
 })

--- a/tests/testthat/test-fma.R
+++ b/tests/testthat/test-fma.R
@@ -64,11 +64,14 @@ test_that("run_fma returns coefficients and weights", {
 
   bma_model <- run_bma(bma_data, params)
 
-  result <- run_fma(
-    bma_data = bma_data,
-    bma_model = bma_model,
-    input_var_list = var_list,
-    print_results = "none"
+  utils::capture.output(
+    result <- run_fma(
+      bma_data = bma_data,
+      bma_model = bma_model,
+      input_var_list = var_list,
+      print_results = "none"
+    ),
+    type = "message"
   )
 
   expect_named(result, c("coefficients", "weights"))
@@ -121,11 +124,14 @@ test_that("Mallows penalty favors small models on pure-noise predictors", {
   )
   bma_model <- run_bma(bma_data, params)
 
-  result <- run_fma(
-    bma_data = bma_data,
-    bma_model = bma_model,
-    input_var_list = var_list,
-    print_results = "none"
+  utils::capture.output(
+    result <- run_fma(
+      bma_data = bma_data,
+      bma_model = bma_model,
+      input_var_list = var_list,
+      print_results = "none"
+    ),
+    type = "message"
   )
 
   # None of the predictors carry signal, so the complexity penalty must pull
@@ -198,18 +204,24 @@ test_that("cluster_ids changes standard errors but not coefficients or weights",
 
   inputs <- make_clustered_fma_inputs()
 
-  iid <- run_fma(
-    bma_data = inputs$bma_data,
-    bma_model = inputs$bma_model,
-    input_var_list = inputs$var_list,
-    print_results = "none"
+  utils::capture.output(
+    iid <- run_fma(
+      bma_data = inputs$bma_data,
+      bma_model = inputs$bma_model,
+      input_var_list = inputs$var_list,
+      print_results = "none"
+    ),
+    type = "message"
   )
-  clustered <- run_fma(
-    bma_data = inputs$bma_data,
-    bma_model = inputs$bma_model,
-    input_var_list = inputs$var_list,
-    cluster_ids = inputs$study,
-    print_results = "none"
+  utils::capture.output(
+    clustered <- run_fma(
+      bma_data = inputs$bma_data,
+      bma_model = inputs$bma_model,
+      input_var_list = inputs$var_list,
+      cluster_ids = inputs$study,
+      print_results = "none"
+    ),
+    type = "message"
   )
 
   # Clustering only reweights the score contributions inside the vcov; the
@@ -228,12 +240,15 @@ test_that("clustered FMA standard errors match a sandwich::vcovCL reference", {
 
   inputs <- make_clustered_fma_inputs()
 
-  result <- run_fma(
-    bma_data = inputs$bma_data,
-    bma_model = inputs$bma_model,
-    input_var_list = inputs$var_list,
-    cluster_ids = inputs$study,
-    print_results = "none"
+  utils::capture.output(
+    result <- run_fma(
+      bma_data = inputs$bma_data,
+      bma_model = inputs$bma_model,
+      input_var_list = inputs$var_list,
+      cluster_ids = inputs$study,
+      print_results = "none"
+    ),
+    type = "message"
   )
 
   # var_name_verbose equals var_name here, so the output rows reveal the
@@ -274,13 +289,18 @@ test_that("run_fma validates cluster_ids", {
   n <- nrow(inputs$bma_data)
 
   run_with_cluster <- function(cluster_ids) {
-    run_fma(
-      bma_data = inputs$bma_data,
-      bma_model = inputs$bma_model,
-      input_var_list = inputs$var_list,
-      cluster_ids = cluster_ids,
-      print_results = "none"
+    out <- NULL
+    utils::capture.output(
+      out <- run_fma(
+        bma_data = inputs$bma_data,
+        bma_model = inputs$bma_model,
+        input_var_list = inputs$var_list,
+        cluster_ids = cluster_ids,
+        print_results = "none"
+      ),
+      type = "message"
     )
+    out
   }
 
   expect_error(run_with_cluster(rep("a", n)), "at least two distinct clusters")
@@ -306,15 +326,24 @@ test_that("resolve_fma_cluster_ids downgrades to NULL on unusable clusters", {
   bma_data <- data.frame(effect = c(0.1, 0.2), se = c(0.05, 0.06))
 
   no_study <- data.frame(effect = c(0.1, 0.2), se = c(0.05, 0.06))
-  expect_null(resolve_fma_cluster_ids(no_study, bma_data))
 
   single_cluster <- cbind(no_study, study_id = c("s1", "s1"))
-  expect_null(resolve_fma_cluster_ids(single_cluster, bma_data))
 
   na_ids <- cbind(no_study, study_id = c("s1", NA))
-  expect_null(resolve_fma_cluster_ids(na_ids, bma_data))
 
   # Rows that cannot be matched back to df resolve to NA and downgrade too.
   foreign_rows <- data.frame(effect = 0.1, se = 0.05, study_id = "s1", row.names = "99")
-  expect_null(resolve_fma_cluster_ids(foreign_rows, bma_data))
+
+  # Each downgrade warns via cli_alert_warning(), which is the point of this
+  # test, but the printed text still leaks past expect_null(); keep it off
+  # the log while still evaluating the calls for real.
+  utils::capture.output(
+    {
+      expect_null(resolve_fma_cluster_ids(no_study, bma_data))
+      expect_null(resolve_fma_cluster_ids(single_cluster, bma_data))
+      expect_null(resolve_fma_cluster_ids(na_ids, bma_data))
+      expect_null(resolve_fma_cluster_ids(foreign_rows, bma_data))
+    },
+    type = "message"
+  )
 })

--- a/tests/testthat/test-result-formatters.R
+++ b/tests/testthat/test-result-formatters.R
@@ -52,7 +52,11 @@ sectioned_fixture <- function() {
 capture_sectioned <- function(x, ...) {
   withr::with_options(
     list(cli.num_colors = 1),
-    utils::capture.output(lines <- print_sectioned_table(x, ...))
+    # print_sectioned_table() prints via cli, which writes through message()
+    # (stderr), not the "output" stream capture.output() captures by
+    # default - without type = "message" this silently captures nothing and
+    # the cli output leaks straight to the console.
+    utils::capture.output(lines <- print_sectioned_table(x, ...), type = "message")
   )
   lines
 }
@@ -95,7 +99,8 @@ test_that("print_sectioned_table ignores an empty table", {
 
 test_that("print_paragraph wraps sentences and drops empty ones", {
   utils::capture.output(
-    lines <- print_paragraph(c("One sentence.", "", "Another sentence."), width = 20)
+    lines <- print_paragraph(c("One sentence.", "", "Another sentence."), width = 20),
+    type = "message"
   )
 
   expect_true(length(lines) > 1)


### PR DESCRIPTION
Follow-up to #389/#391. Fixes the four remaining high-confidence noise sources identified in a follow-up audit of the post-#391 test log (175 lines).

## What changed

- **`tests/testthat/test-result-formatters.R`**: `capture_sectioned()` (used by every `print_sectioned_table()` test) called `utils::capture.output()` without `type = "message"`. cli prints through `message()` (stderr), not the "output" stream `capture.output()` captures by default, so the helper was silently capturing nothing and every table dump leaked straight to the console (28 lines). Same one-line fix applied to the adjacent `print_paragraph()` test. Confirmed both of `print_sectioned_table()`'s code paths (the sectioned printer and its `print_summary_table()` fallback) funnel through `cli::cli_verbatim()`, so `type = "message"` catches both.
- **`inst/artma/data/na_handling.R`**: the `requireNamespace("mice", quietly = TRUE)` availability check (not the later `mice::mice()` call, which was already guarded) was the actual first `mice::` reference in a session, so it's what pulls in mice's own Imports (`car`, `lme4`) and prints the raw "Registered S3 method overwritten" line. Same class of fix as PR1's MAIVE/RoBMA suppressions, just a call site that PR1 missed.
- **`tests/testthat/test-fma.R`**: wrapped every `run_fma()` call site (6) and the `resolve_fma_cluster_ids()` downgrade-scenario test in `utils::capture.output(..., type = "message")`, same pattern PR2 used for `run_linear_models()`. New since PR2 - `run_fma`'s cluster-robust SE support landed on master after that PR merged.
- **`tests/testthat/test-econometric-vcov.R`**: wrapped the remaining unwrapped `robust_vcov()` call sites (including the three `expect_message()` ones) in `capture.output(..., type = "message")`.

## A bug in my own fix, caught and corrected

The first pass at the `expect_message()` sites in `test-econometric-vcov.R` wrapped a **bare, unassigned** `robust_vcov(...)` call directly in `capture.output(..., type = "message")`. `capture.output()` auto-prints the visible return value of its argument as part of how it works - specifying `type = "message"` only redirects the message/stderr stream, so the visible return value (a covariance matrix) still auto-printed straight to real stdout, uncaptured. Every other call site in this PR and in PR2 avoided this because the wrapped expression was always an assignment (`x <- fn(...)`, itself invisible) or a function argument (e.g. inside `expect_null(...)`, which doesn't trigger top-level auto-print). Fixed by wrapping the bare calls in `invisible()`. Caught by actually reading each file's test output after the change rather than trusting file/pass counts alone - worth calling out since it's an easy trap to hit again with this pattern.

## Verification

- `make test`: 0 failures, 2719 passing (unchanged), 0 warnings.
- Test log line count: 175 → 141.
- All four touched test files run fully silent standalone (`test-result-formatters.R`, `test-fma.R`, `test-econometric-vcov.R` no longer appear in the log at all; `test-data-na-handling.R` down from 4 lines to 1).
- Re-ran the real end-to-end `artma::artma()` smoke run: no `digest`/namespace/S3-override leakage.
- `make lint`: no lints found.
- `test-generated-check-manifest.R` still passes.