### PR TITLE
build: bump roxygen2 pin to 8.0.0 and regenerate docs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,11 +28,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # roxygen2 is pinned to the RoxygenNote version in DESCRIPTION so the
+          # roxygen2 is pinned to the Config/roxygen2/version in DESCRIPTION
+          # (roxygen2 8 writes that field instead of RoxygenNote) so the
           # docs-drift check below regenerates the exact same output as a
           # contributor running `make document` locally with that version.
-          # Bump this alongside RoxygenNote if it ever changes.
-          extra-packages: any::lintr, roxygen2@7.3.3, local::.
+          # Bump this alongside Config/roxygen2/version if it ever changes.
+          extra-packages: any::lintr, roxygen2@8.0.0, local::.
           needs: lint
 
       - name: Lint
@@ -52,6 +53,6 @@ jobs:
           Rscript scripts/R/generate_check_manifest.R
           Rscript -e "devtools::document()"
           if ! git diff --exit-code -- man NAMESPACE R/generated_check_manifest.R; then
-            echo "::error::man/, NAMESPACE, or R/generated_check_manifest.R are out of date. Run 'make document' locally and commit the result. This job pins roxygen2 to the RoxygenNote version in DESCRIPTION, so a clean local diff with the same roxygen2 version means this is real drift, not version skew."
+            echo "::error::man/, NAMESPACE, or R/generated_check_manifest.R are out of date. Run 'make document' locally and commit the result. This job pins roxygen2 to the Config/roxygen2/version in DESCRIPTION, so a clean local diff with the same roxygen2 version means this is real drift, not version skew."
             exit 1
           fi

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,4 +77,4 @@ Config/testthat/start-first: github-actions, release
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/man/artma-package.Rd
+++ b/man/artma-package.Rd
@@ -18,5 +18,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Petr Čala \email{61505008@fsv.cuni.cz}
 
+Authors:
+\itemize{
+  \item Petr Čala \email{61505008@fsv.cuni.cz}
+}
+
 }
 \keyword{internal}


### PR DESCRIPTION
## Why

Local machines now have roxygen2 8.0.0 while the lint workflow pinned 7.3.3. Every local `make document` produced drift that the docs-up-to-date gate rejected: roxygen2 8 records its version in `Config/roxygen2/version` instead of `RoxygenNote` and adds an Authors block to `man/artma-package.Rd`.

## What

- Pin `roxygen2@8.0.0` in `.github/workflows/lint.yaml`; the comment and the drift error message now reference `Config/roxygen2/version` instead of `RoxygenNote`.
- Regenerate docs with 8.0.0 under `LC_ALL=en_US.UTF-8`: DESCRIPTION now carries `Config/roxygen2/version: 8.0.0` in place of `RoxygenNote`, and `man/artma-package.Rd` gains the Authors block.

## Verification

- `make lint`: no lints.
- `make test`: 2738 passed, 0 failed, 1 skip (pre-existing OpenMP skip, unrelated).