### PR TITLE
fix(formatting): stop wide summary tables splitting into two blocks

### DIFF
--- a/inst/artma/econometric/bma.R
+++ b/inst/artma/econometric/bma.R
@@ -535,7 +535,8 @@ extract_bma_results <- function(bma_model, bma_data, input_var_list, print_resul
   box::use(
     artma / libs / core / validation[validate],
     artma / libs / core / utils[get_verbosity],
-    artma / visualization / colors[get_colors]
+    artma / visualization / colors[get_colors],
+    artma / libs / formatting / results[capture_print_wide]
   )
 
   validate(
@@ -566,7 +567,7 @@ extract_bma_results <- function(bma_model, bma_data, input_var_list, print_resul
     cli::cat_print(bma_model$topmod[1])
   } else if (print_results == "fast") {
     if (get_verbosity() >= 3) {
-      cli::cat_print(bma_coefs)
+      cli::cli_verbatim(capture_print_wide(bma_coefs))
     }
   }
 

--- a/inst/artma/libs/formatting/results.R
+++ b/inst/artma/libs/formatting/results.R
@@ -159,6 +159,16 @@ print_summary_table <- function(summary) {
   if (duplicated_metric) {
     rownames(summary) <- NULL
   }
+
+  # print.data.frame tears a table into stacked, row-numbered column blocks
+  # once the formatted row width exceeds getOption("width") (80 by default).
+  # Widen it for the duration of this call so wide summary tables render as
+  # one block; the terminal still soft-wraps long lines visually, this only
+  # stops the artificial hard split into duplicate sections.
+  old_width <- getOption("width")
+  on.exit(options(width = old_width), add = TRUE)
+  options(width = 10000L)
+
   lines <- utils::capture.output(
     print(summary, row.names = !duplicated_metric) # nolint: undesirable_function_linter.
   )

--- a/inst/artma/libs/formatting/results.R
+++ b/inst/artma/libs/formatting/results.R
@@ -145,6 +145,27 @@ format_ci <- function(lower, upper, digits) {
   formatted
 }
 
+#' Capture a data frame's print output at an unbounded width
+#'
+#' @description
+#' `print.data.frame` tears a table into stacked, row-numbered column blocks
+#' once the formatted row width exceeds `getOption("width")` (80 by default).
+#' This widens it for the duration of the call so wide tables print as one
+#' block; the terminal still soft-wraps long lines visually, this only stops
+#' the artificial hard split into duplicate sections.
+#'
+#' @param x *\[data.frame\]* The object to print.
+#' @param ... Passed through to `print()`.
+#' @return *\[character\]* Captured output lines.
+#' @keywords internal
+capture_print_wide <- function(x, ...) {
+  old_width <- getOption("width")
+  on.exit(options(width = old_width), add = TRUE)
+  options(width = 10000L)
+
+  utils::capture.output(print(x, ...)) # nolint: undesirable_function_linter.
+}
+
 #' Print a method summary table through cli
 #'
 #' @description
@@ -160,18 +181,7 @@ print_summary_table <- function(summary) {
     rownames(summary) <- NULL
   }
 
-  # print.data.frame tears a table into stacked, row-numbered column blocks
-  # once the formatted row width exceeds getOption("width") (80 by default).
-  # Widen it for the duration of this call so wide summary tables render as
-  # one block; the terminal still soft-wraps long lines visually, this only
-  # stops the artificial hard split into duplicate sections.
-  old_width <- getOption("width")
-  on.exit(options(width = old_width), add = TRUE)
-  options(width = 10000L)
-
-  lines <- utils::capture.output(
-    print(summary, row.names = !duplicated_metric) # nolint: undesirable_function_linter.
-  )
+  lines <- capture_print_wide(summary, row.names = !duplicated_metric)
   cli::cli_verbatim(lines)
   invisible(lines)
 }
@@ -302,6 +312,7 @@ box::export(
   format_se,
   format_standard_error,
   format_ci,
+  capture_print_wide,
   print_summary_table,
   print_sectioned_table,
   print_paragraph,

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -41,7 +41,8 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     artma / options / index[get_option_group],
     artma / options / resolver[opt_spec, resolve_options],
     artma / visualization / options[get_visualization_options],
-    artma / visualization / export[export_named_plots]
+    artma / visualization / export[export_named_plots],
+    artma / libs / formatting / results[print_summary_table]
   )
 
   validate(is.data.frame(df))
@@ -333,7 +334,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   if (get_verbosity() >= 3) {
     cli::cli_h3("Best-Practice Estimate")
     cli::cli_alert_info("BMA source: {.val {resolved_bma$source}}")
-    cli::cat_print(summary)
+    print_summary_table(summary)
     if (get_verbosity() >= 4) {
       cli::cli_alert_info("Author formula: {formula}")
     }

--- a/inst/artma/methods/effect_summary_stats.R
+++ b/inst/artma/methods/effect_summary_stats.R
@@ -17,6 +17,7 @@ effect_summary_stats <- function(df) {
     ],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[validate, validate_columns],
+    artma / libs / formatting / results[print_summary_table],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / options / resolver[opt_spec, resolve_options]
@@ -282,7 +283,7 @@ effect_summary_stats <- function(df) {
 
   if (get_verbosity() >= 3) {
     cli::cli_h3("Summary statistics:")
-    cli::cat_print(out)
+    print_summary_table(out)
   }
 
   invisible(new_method_result(tables = list(summary = out)))

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -15,7 +15,8 @@ p_hacking_tests <- function(df) {
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / options / resolver[opt_spec, resolve_options],
-    artma / options / significance_marks[resolve_add_significance_marks]
+    artma / options / significance_marks[resolve_add_significance_marks],
+    artma / libs / formatting / results[capture_print_wide]
   )
 
   validate(is.data.frame(df))
@@ -152,9 +153,7 @@ p_hacking_tests <- function(df) {
         cli::cli_text("P-values are clustered at the study level.")
       }
 
-      caliper_lines <- utils::capture.output(
-        print(results$caliper, row.names = FALSE) # nolint: undesirable_function_linter.
-      )
+      caliper_lines <- capture_print_wide(results$caliper, row.names = FALSE)
       cli::cli_verbatim(caliper_lines)
       cli::cli_text("")
     }
@@ -167,9 +166,7 @@ p_hacking_tests <- function(df) {
         "disagree with the local caliper results above."
       )
 
-      elliott_lines <- utils::capture.output(
-        print(results$elliott, row.names = FALSE) # nolint: undesirable_function_linter.
-      )
+      elliott_lines <- capture_print_wide(results$elliott, row.names = FALSE)
       cli::cli_verbatim(elliott_lines)
 
       # Footnote the NA cells: each skipped test carries a reason (e.g. a

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -20,7 +20,8 @@ robma <- function(df) {
     artma / libs / core / validation[validate, validate_columns],
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
-    artma / options / resolver[opt_spec, resolve_options]
+    artma / options / resolver[opt_spec, resolve_options],
+    artma / libs / formatting / results[print_summary_table]
   )
 
   validate(is.data.frame(df))
@@ -160,7 +161,7 @@ robma <- function(df) {
 
   if (get_verbosity() >= 3) {
     cli::cli_h3("RoBMA: model-averaged estimates")
-    print(estimates) # nolint: undesirable_function_linter.
+    print_summary_table(estimates)
   }
 
   new_method_result(

--- a/inst/artma/methods/variable_summary_stats.R
+++ b/inst/artma/methods/variable_summary_stats.R
@@ -13,7 +13,8 @@ variable_summary_stats <- function(df) {
     artma / modules / runtime_methods[new_method_result],
     artma / options / index[get_option_group],
     artma / options / resolver[opt_spec, resolve_options],
-    artma / libs / core / utils[get_verbosity]
+    artma / libs / core / utils[get_verbosity],
+    artma / libs / formatting / results[print_summary_table]
   )
 
   config <- get_data_config()
@@ -89,7 +90,7 @@ variable_summary_stats <- function(df) {
 
   if (get_verbosity() >= 3) {
     cli::cli_h3("Variable summary statistics:")
-    cli::cat_print(df_out)
+    print_summary_table(df_out)
   }
 
   if (length(missing_data_vars) > 0 && get_verbosity() >= 2) {

--- a/inst/artma/output/ma_table.R
+++ b/inst/artma/output/ma_table.R
@@ -21,7 +21,9 @@ build_ma_table <- function(bma_coefficients = NULL, fma_coefficients = NULL, rou
   has_bma <- !is.null(bma_coefficients) && is.data.frame(bma_coefficients) && nrow(bma_coefficients) > 0
   has_fma <- !is.null(fma_coefficients) && is.data.frame(fma_coefficients) && nrow(fma_coefficients) > 0
 
-  if (!has_bma && !has_fma) return(NULL)
+  if (!has_bma && !has_fma) {
+    return(NULL)
+  }
 
   validate(is.numeric(round_to))
 
@@ -76,16 +78,18 @@ build_ma_table <- function(bma_coefficients = NULL, fma_coefficients = NULL, rou
 #' @param verbosity *\[integer\]* Current verbosity level.
 #' @export
 display_ma_table <- function(ma_table, verbosity = 3L) {
-  if (is.null(ma_table) || nrow(ma_table) == 0) return(invisible(NULL))
+  box::use(artma / libs / formatting / results[capture_print_wide])
+
+  if (is.null(ma_table) || nrow(ma_table) == 0) {
+    return(invisible(NULL))
+  }
 
   if (verbosity >= 3) {
     cli::cli_h2("Model Averaging Results")
   }
 
   if (verbosity >= 1) {
-    lines <- utils::capture.output(
-      print(ma_table, row.names = FALSE) # nolint: undesirable_function_linter.
-    )
+    lines <- capture_print_wide(ma_table, row.names = FALSE)
     cli::cli_verbatim(lines)
   }
 


### PR DESCRIPTION
## Problem

Several methods printed their result tables via `cli::cat_print(df)` or a raw `print(df)` + `capture.output`, which is base `print.data.frame`/`print.matrix` under the hood. Once the formatted row width exceeds `getOption("width")` (80 by default), R's default printer tears the table into stacked, row-numbered column blocks instead of one table (e.g. a `Missing obs` column spilling into its own section below the rest).

## Fix

`print_summary_table()` in `inst/artma/libs/formatting/results.R` (already used by `linear_tests`, `nonlinear_tests`, and `exogeneity_tests`) now temporarily widens `options(width = ...)` around the underlying `print()` call, restoring it on exit, so wide tables render as a single block regardless of console width. Terminals still soft-wrap long lines visually; this only removes the artificial hard split into duplicate sections. Extracted the width-widening into a small reusable `capture_print_wide()` helper for call sites that need a custom `print()` call (row names suppressed, matrices, etc.) rather than the summary-table convention.

Switched every call site with a genuine wide-table risk to go through one of these two helpers:

- `variable_summary_stats`, `effect_summary_stats`, `best_practice_estimate`, `robma`: `cli::cat_print(df)` / raw `print(df)` → `print_summary_table(df)`.
- `p_hacking_tests` (caliper + Elliott tables), `display_ma_table` (`ma_table.R`): raw `print(df, row.names = FALSE)` + `capture.output` → `capture_print_wide(df, row.names = FALSE)`.
- `extract_bma_results` (`bma.R`): `cli::cat_print(bma_coefs)` on a coefficient **matrix** with verbose variable names as row names → `cli::cli_verbatim(capture_print_wide(bma_coefs))`.

Left alone, after checking each: `vif_coefs` (plain named vector, wraps normally rather than duplicating blocks), `formula` (single formula object), `bma_model`/`topmod[1]` (BMS-package objects with their own print methods), and the FMA coefficient/weight tables in `fma.R` (3-4 narrow columns, realistic width stays under 80 even with long variable names).

Bonus: `robma`'s estimates table now goes through `cli_verbatim` instead of a bare `print()`, so it also replays correctly on a cached re-run.

## Testing

- `make lint`
- `make test` (2738 passed, 1 unrelated skip: OpenMP)