### PR TITLE
test: silence all interleaved output in parallel test runs

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -22,3 +22,59 @@ local({
     options(box.path = unique(c(extra_paths, getOption("box.path"))))
   }
 })
+
+# Suppress incidental console output for the whole parallel test run (`make
+# test`), so it shows only testthat's own per-file/per-run summary - no
+# interleaved `> file: text` lines. Every genuine test signal survives this
+# untouched: testthat detects and reports failures, errors, and uncaught
+# warnings via a structured protocol between the worker and the parent
+# process, not by writing to stdout/stderr, and
+# expect_message()/expect_warning()/capture_messages()/capture_warnings()
+# install their own inner condition handlers, which R always consults before
+# these sinks ever come into play - so assertions on message/warning content
+# keep working exactly as before (verified directly, not just by reading the
+# docs).
+#
+# Gated to parallel workers only. `devtools::test_active_file()` /
+# `make test-file` run in the *current* R session rather than a spawned
+# worker, so testthat's own progress/summary output shares this session's
+# stdout/stderr too - sinking it there would silence the pass/fail summary
+# along with everything else, not just the noise. `callr_startup_hook` only
+# ever appears on the call stack inside a callr-spawned worker process
+# (confirmed by dumping sys.calls() from both a `make test` worker and a
+# `test_active_file()` run), so it reliably tells the two apart; there is no
+# public testthat API for this and the env var that marks "am I parallel"
+# (`TESTTHAT_IS_PARALLEL`) isn't set yet at the point setup.R runs.
+if (any(vapply(sys.calls(), function(call) identical(as.character(call[[1]]), "callr_startup_hook"), logical(1)))) {
+  # Two separate sinks, because "output" and "message" behave differently:
+  #   * "output" (print()/cat()-based content, e.g. cli::cat_print()) properly
+  #     stacks - nested capture.output()/sink() calls elsewhere in the suite
+  #     push and pop their own layer on top of this one without disturbing it.
+  #   * "message" (message()/warning()-based content, which is how
+  #     essentially all cli:: output and every base R warning ultimately gets
+  #     printed) does NOT stack - R supports only one active diversion at a
+  #     time (see `?sink`, "type = 'message'"). A second `sink(type =
+  #     "message")` call anywhere - including a bare `capture.output(x, type
+  #     = "message")` - silently replaces this one instead of layering on it,
+  #     and popping that second one then removes this one too rather than
+  #     restoring it. That ruled out `capture.output(fn(), type = "message")`
+  #     as a per-test-file suppression technique (an earlier version of this
+  #     branch leaned on it): it works in isolation but corrupts this sink
+  #     the first time any test file happens to run afterward in the same
+  #     worker session, permanently reverting the rest of that worker's
+  #     queue to raw console output.
+  #
+  # Condition-based alternatives (suppressMessages(), capture_messages(),
+  # testthat's own expect_message()/expect_warning()) don't call sink() at
+  # all, so they compose safely with this - use those instead of
+  # `capture.output(..., type = "message")` in new tests. The one exception
+  # is `tests/testthat/test-cli.R`, which legitimately needs to capture raw
+  # stdout/stderr to test `cli.run()`'s actual command-line behavior; it
+  # explicitly suspends and restores this sink around its own capture (see
+  # the comment there) rather than nesting inside it.
+  sink(file(nullfile(), open = "wt"), type = "output")
+
+  .artma_test_null_message <- file(nullfile(), open = "wt")
+  sink(.artma_test_null_message, type = "message")
+  options(artma.test.null_message_con = .artma_test_null_message)
+}

--- a/tests/testthat/test-cli.R
+++ b/tests/testthat/test-cli.R
@@ -14,6 +14,17 @@ box::use(
 run_cli <- function(args) {
   outcon <- textConnection("outbuf", "w", local = TRUE)
   errcon <- textConnection("errbuf", "w", local = TRUE)
+
+  # R supports only one active "message" diversion at a time (see ?sink) -
+  # unlike "output", it does not stack. setup.R keeps one sunk for the whole
+  # test run to silence incidental cli/warning noise; pushing a second one
+  # here would silently replace it, and popping ours back off would then
+  # remove the global one too instead of restoring it. Suspend it explicitly
+  # for the duration of this capture and restore it afterward, since this
+  # test genuinely needs cli.run()'s raw stderr content, not just silence.
+  null_message_con <- getOption("artma.test.null_message_con")
+  if (sink.number(type = "message") > 0) sink(type = "message")
+
   sink(outcon, type = "output")
   sink(errcon, type = "message")
   code <- tryCatch(
@@ -21,6 +32,7 @@ run_cli <- function(args) {
     finally = {
       sink(type = "message")
       sink(type = "output")
+      if (!is.null(null_message_con)) sink(null_message_con, type = "message")
     }
   )
   close(outcon)

--- a/tests/testthat/test-econometric-vcov.R
+++ b/tests/testthat/test-econometric-vcov.R
@@ -63,18 +63,16 @@ test_that("get_robust_vcov ladder falls back to non-clustered HC1 on cluster err
 
   # A wrong-length cluster makes vcovCL error; the ladder should fall through
   # to the non-clustered HC1 step, warning about the downgrade along the way -
-  # not itself under test here, so keep it off the log.
-  utils::capture.output(
-    result <- robust_vcov(
-      model = model,
-      cluster = c(1, 2, 3),
-      engine = "sandwich",
-      clustered_type = "HC1",
-      fallback_types = c("HC1", "HC0"),
-      require_cluster = TRUE,
-      suppress_warnings = TRUE
-    ),
-    type = "message"
+  # not itself under test here; the test session's global sink (see
+  # setup.R) keeps it off the log.
+  result <- robust_vcov(
+    model = model,
+    cluster = c(1, 2, 3),
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = c("HC1", "HC0"),
+    require_cluster = TRUE,
+    suppress_warnings = TRUE
   )
 
   oracle <- suppressWarnings(sandwich::vcovHC(model, type = "HC1"))
@@ -88,36 +86,29 @@ test_that("robust_vcov warns when clustering is silently lost", {
 
   # Clustered step fails on a wrong-length cluster: the fallback must announce
   # that the returned SEs are not clustered. The alert is real signal here
-  # (it's exactly what's under test), but its cli_alert_warning() text still
-  # leaks to the console independently of testthat's condition handling, so
-  # capture.output() keeps the log clean while expect_message() still sees
-  # the signaled condition.
+  # (it's exactly what's under test); the test session's global sink (see
+  # setup.R) keeps it off the log while expect_message()'s own inner handler
+  # still sees the signaled condition.
   expect_message(
-    utils::capture.output(
-      invisible(robust_vcov(
-        model = model,
-        cluster = c(1, 2, 3),
-        engine = "sandwich",
-        clustered_type = "HC1",
-        fallback_types = c("HC1", "HC0"),
-        suppress_warnings = TRUE
-      )),
-      type = "message"
+    robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC1",
+      fallback_types = c("HC1", "HC0"),
+      suppress_warnings = TRUE
     ),
     regexp = "NOT clustered"
   )
 
   # The match_cluster_length guard is the same downgrade and must also warn.
   expect_message(
-    utils::capture.output(
-      invisible(robust_vcov(
-        model = model,
-        cluster = c(1, 2, 3),
-        engine = "sandwich",
-        clustered_type = "HC0",
-        match_cluster_length = TRUE
-      )),
-      type = "message"
+    robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC0",
+      match_cluster_length = TRUE
     ),
     regexp = "NOT clustered"
   )
@@ -155,15 +146,12 @@ test_that("robust_vcov warns on the no-cluster single-step downgrade to stats::v
   # stats::vcov(). This downgrade must still be warned about even though
   # clustering was never requested and there is only one robust step.
   expect_message(
-    utils::capture.output(
-      invisible(robust_vcov(
-        model = model,
-        cluster = NULL,
-        engine = "sandwich",
-        clustered_type = "BOGUS",
-        fallback_types = character(0)
-      )),
-      type = "message"
+    robust_vcov(
+      model = model,
+      cluster = NULL,
+      engine = "sandwich",
+      clustered_type = "BOGUS",
+      fallback_types = character(0)
     ),
     regexp = "NOT clustered"
   )
@@ -204,16 +192,14 @@ test_that("resolve_bpe_vcov ladder uses non-clustered HC0 when cluster length mi
 
   # Wrong-length cluster: the length guard rejects it and the primary step is
   # the non-clustered HC0 vcov, warning about the downgrade along the way -
-  # not itself under test here, so keep it off the log.
-  utils::capture.output(
-    result <- robust_vcov(
-      model = model,
-      cluster = c(1, 2, 3),
-      engine = "sandwich",
-      clustered_type = "HC0",
-      match_cluster_length = TRUE
-    ),
-    type = "message"
+  # not itself under test here; the test session's global sink (see
+  # setup.R) keeps it off the log.
+  result <- robust_vcov(
+    model = model,
+    cluster = c(1, 2, 3),
+    engine = "sandwich",
+    clustered_type = "HC0",
+    match_cluster_length = TRUE
   )
 
   oracle <- sandwich::vcovHC(model, type = "HC0")
@@ -221,15 +207,12 @@ test_that("resolve_bpe_vcov ladder uses non-clustered HC0 when cluster length mi
   expect_equal(unname(result["se", "se"]), 0.1105633, tolerance = 1e-6)
 
   # NULL cluster follows the same non-clustered branch.
-  utils::capture.output(
-    result_null <- robust_vcov(
-      model = model,
-      cluster = NULL,
-      engine = "sandwich",
-      clustered_type = "HC0",
-      match_cluster_length = TRUE
-    ),
-    type = "message"
+  result_null <- robust_vcov(
+    model = model,
+    cluster = NULL,
+    engine = "sandwich",
+    clustered_type = "HC0",
+    match_cluster_length = TRUE
   )
   expect_equal(result_null, oracle)
 })

--- a/tests/testthat/test-fma.R
+++ b/tests/testthat/test-fma.R
@@ -64,14 +64,11 @@ test_that("run_fma returns coefficients and weights", {
 
   bma_model <- run_bma(bma_data, params)
 
-  utils::capture.output(
-    result <- run_fma(
-      bma_data = bma_data,
-      bma_model = bma_model,
-      input_var_list = var_list,
-      print_results = "none"
-    ),
-    type = "message"
+  result <- run_fma(
+    bma_data = bma_data,
+    bma_model = bma_model,
+    input_var_list = var_list,
+    print_results = "none"
   )
 
   expect_named(result, c("coefficients", "weights"))
@@ -124,14 +121,11 @@ test_that("Mallows penalty favors small models on pure-noise predictors", {
   )
   bma_model <- run_bma(bma_data, params)
 
-  utils::capture.output(
-    result <- run_fma(
-      bma_data = bma_data,
-      bma_model = bma_model,
-      input_var_list = var_list,
-      print_results = "none"
-    ),
-    type = "message"
+  result <- run_fma(
+    bma_data = bma_data,
+    bma_model = bma_model,
+    input_var_list = var_list,
+    print_results = "none"
   )
 
   # None of the predictors carry signal, so the complexity penalty must pull
@@ -204,24 +198,18 @@ test_that("cluster_ids changes standard errors but not coefficients or weights",
 
   inputs <- make_clustered_fma_inputs()
 
-  utils::capture.output(
-    iid <- run_fma(
-      bma_data = inputs$bma_data,
-      bma_model = inputs$bma_model,
-      input_var_list = inputs$var_list,
-      print_results = "none"
-    ),
-    type = "message"
+  iid <- run_fma(
+    bma_data = inputs$bma_data,
+    bma_model = inputs$bma_model,
+    input_var_list = inputs$var_list,
+    print_results = "none"
   )
-  utils::capture.output(
-    clustered <- run_fma(
-      bma_data = inputs$bma_data,
-      bma_model = inputs$bma_model,
-      input_var_list = inputs$var_list,
-      cluster_ids = inputs$study,
-      print_results = "none"
-    ),
-    type = "message"
+  clustered <- run_fma(
+    bma_data = inputs$bma_data,
+    bma_model = inputs$bma_model,
+    input_var_list = inputs$var_list,
+    cluster_ids = inputs$study,
+    print_results = "none"
   )
 
   # Clustering only reweights the score contributions inside the vcov; the
@@ -240,15 +228,12 @@ test_that("clustered FMA standard errors match a sandwich::vcovCL reference", {
 
   inputs <- make_clustered_fma_inputs()
 
-  utils::capture.output(
-    result <- run_fma(
-      bma_data = inputs$bma_data,
-      bma_model = inputs$bma_model,
-      input_var_list = inputs$var_list,
-      cluster_ids = inputs$study,
-      print_results = "none"
-    ),
-    type = "message"
+  result <- run_fma(
+    bma_data = inputs$bma_data,
+    bma_model = inputs$bma_model,
+    input_var_list = inputs$var_list,
+    cluster_ids = inputs$study,
+    print_results = "none"
   )
 
   # var_name_verbose equals var_name here, so the output rows reveal the
@@ -289,18 +274,13 @@ test_that("run_fma validates cluster_ids", {
   n <- nrow(inputs$bma_data)
 
   run_with_cluster <- function(cluster_ids) {
-    out <- NULL
-    utils::capture.output(
-      out <- run_fma(
-        bma_data = inputs$bma_data,
-        bma_model = inputs$bma_model,
-        input_var_list = inputs$var_list,
-        cluster_ids = cluster_ids,
-        print_results = "none"
-      ),
-      type = "message"
+    run_fma(
+      bma_data = inputs$bma_data,
+      bma_model = inputs$bma_model,
+      input_var_list = inputs$var_list,
+      cluster_ids = cluster_ids,
+      print_results = "none"
     )
-    out
   }
 
   expect_error(run_with_cluster(rep("a", n)), "at least two distinct clusters")
@@ -335,15 +315,9 @@ test_that("resolve_fma_cluster_ids downgrades to NULL on unusable clusters", {
   foreign_rows <- data.frame(effect = 0.1, se = 0.05, study_id = "s1", row.names = "99")
 
   # Each downgrade warns via cli_alert_warning(), which is the point of this
-  # test, but the printed text still leaks past expect_null(); keep it off
-  # the log while still evaluating the calls for real.
-  utils::capture.output(
-    {
-      expect_null(resolve_fma_cluster_ids(no_study, bma_data))
-      expect_null(resolve_fma_cluster_ids(single_cluster, bma_data))
-      expect_null(resolve_fma_cluster_ids(na_ids, bma_data))
-      expect_null(resolve_fma_cluster_ids(foreign_rows, bma_data))
-    },
-    type = "message"
-  )
+  # test; the test session's global sink (see setup.R) keeps it off the log.
+  expect_null(resolve_fma_cluster_ids(no_study, bma_data))
+  expect_null(resolve_fma_cluster_ids(single_cluster, bma_data))
+  expect_null(resolve_fma_cluster_ids(na_ids, bma_data))
+  expect_null(resolve_fma_cluster_ids(foreign_rows, bma_data))
 })

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -115,7 +115,7 @@ test_that("run_linear_models flags and marks conflicting rows on high-leverage d
   )
 
   set.seed(100)
-  utils::capture.output(res <- run_linear_models(df, opts), type = "message")
+  res <- run_linear_models(df, opts)
 
   conflicts <- res$coefficients[res$coefficients$ci_conflict %in% TRUE, , drop = FALSE]
   expect_gt(nrow(conflicts), 0)
@@ -138,11 +138,11 @@ test_that("linear_tests warns when few bootstrap replications are requested", {
     "artma.verbose" = 1
   )
 
-  # linear_tests() prints its result table regardless of verbosity (the table
-  # is the method's deliverable, not progress narration); capture.output
-  # keeps that off the test log while expect_message still sees the signaled
-  # condition, since sink redirection and condition signaling are orthogonal.
-  expect_message(utils::capture.output(linear_tests(df), type = "message"), "Only 10 bootstrap replications")
+  # linear_tests() prints its result table regardless of verbosity (the
+  # table is the method's deliverable, not progress narration); the test
+  # session's global sink (see setup.R) keeps that off the log, while
+  # expect_message's own inner handler still sees the signaled condition.
+  expect_message(linear_tests(df), "Only 10 bootstrap replications")
 })
 
 test_that("linear_tests does not warn about replications when the count is high enough", {
@@ -156,7 +156,7 @@ test_that("linear_tests does not warn about replications when the count is high 
     "artma.verbose" = 1
   )
 
-  expect_no_message(utils::capture.output(linear_tests(df), type = "message"), message = "bootstrap replications")
+  expect_no_message(linear_tests(df), message = "bootstrap replications")
 })
 
 test_that("linear_tests reports the count of estimates with disagreeing stars and CIs", {
@@ -172,7 +172,7 @@ test_that("linear_tests reports the count of estimates with disagreeing stars an
   )
 
   set.seed(100)
-  expect_message(utils::capture.output(linear_tests(df), type = "message"), "estimates are.*marked with")
+  expect_message(linear_tests(df), "estimates are.*marked with")
 })
 
 test_that("linear tests return tidy coefficients and summary", {
@@ -188,7 +188,7 @@ test_that("linear tests return tidy coefficients and summary", {
     "artma.verbose" = 1
   )
 
-  utils::capture.output(res <- linear_tests(df), type = "message")
+  res <- linear_tests(df)
 
   expect_named(res, c("tables", "plots", "meta"))
   expect_named(res$tables, "summary")
@@ -242,7 +242,7 @@ test_that("linear tests gracefully skip models with missing columns", {
     "artma.verbose" = 1
   )
 
-  utils::capture.output(res <- linear_tests(df), type = "message")
+  res <- linear_tests(df)
 
   expect_false("ols_precision_weighted" %in% res$meta$coefficients$model)
   expect_true("ols_precision_weighted" %in% names(res$meta$skipped))
@@ -261,10 +261,10 @@ test_that("bootstrap CIs are deterministic and seed-identical to the tidy-path i
   )
 
   set.seed(123)
-  utils::capture.output(res <- run_linear_models(df, options = opts), type = "message")
+  res <- run_linear_models(df, options = opts)
 
   set.seed(123)
-  utils::capture.output(res_repeat <- run_linear_models(df, options = opts), type = "message")
+  res_repeat <- run_linear_models(df, options = opts)
 
   ci_cols <- c("model", "term", "bootstrap_lower", "bootstrap_upper")
   ci <- res$coefficients[, ci_cols]
@@ -314,17 +314,14 @@ test_that("FE effect-beyond-bias SE comes from the auxiliary intercept model, no
   skip_if_not_installed("plm")
 
   df <- make_unbalanced_data()
-  utils::capture.output(
-    res <- run_linear_models(
-      df,
-      options = list(
-        add_significance_marks = FALSE,
-        bootstrap_replications = 0L,
-        conf_level = 0.95,
-        round_to = 3L
-      )
-    ),
-    type = "message"
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
   )
 
   fe <- res$coefficients[res$coefficients$model == "fe", , drop = FALSE]
@@ -345,17 +342,14 @@ test_that("FE effect-beyond-bias SE comes from the auxiliary intercept model, no
 
 test_that("study-weighted OLS gives each study equal total weight", {
   df <- make_unbalanced_data()
-  utils::capture.output(
-    res <- run_linear_models(
-      df,
-      options = list(
-        add_significance_marks = FALSE,
-        bootstrap_replications = 0L,
-        conf_level = 0.95,
-        round_to = 3L
-      )
-    ),
-    type = "message"
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
   )
 
   sw <- res$coefficients[res$coefficients$model == "ols_study_weighted", , drop = FALSE]
@@ -739,17 +733,14 @@ test_that("two-cluster data skips RE and BE with a plain-language reason", {
   df <- make_demo_data()
   df <- df[df$study_id %in% c("S1", "S2"), , drop = FALSE]
 
-  utils::capture.output(
-    res <- run_linear_models(
-      df,
-      options = list(
-        add_significance_marks = FALSE,
-        bootstrap_replications = 0L,
-        conf_level = 0.95,
-        round_to = 3L
-      )
-    ),
-    type = "message"
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
   )
 
   expect_true(all(c("re", "be") %in% names(res$skipped)))
@@ -778,17 +769,14 @@ test_that("singleton-cluster data skips FE and RE with a plain-language reason",
     check.names = FALSE
   )
 
-  utils::capture.output(
-    res <- run_linear_models(
-      df,
-      options = list(
-        add_significance_marks = FALSE,
-        bootstrap_replications = 0L,
-        conf_level = 0.95,
-        round_to = 3L
-      )
-    ),
-    type = "message"
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
   )
 
   expect_true(all(c("fe", "re") %in% names(res$skipped)))
@@ -807,17 +795,14 @@ test_that("constant within-cluster se skips FE and RE even with many clusters", 
   df <- make_demo_data()
   df$se <- stats::ave(df$se, df$study_id)
 
-  utils::capture.output(
-    res <- run_linear_models(
-      df,
-      options = list(
-        add_significance_marks = FALSE,
-        bootstrap_replications = 0L,
-        conf_level = 0.95,
-        round_to = 3L
-      )
-    ),
-    type = "message"
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
+    )
   )
 
   expect_true(all(c("fe", "re") %in% names(res$skipped)))
@@ -830,18 +815,15 @@ test_that("constant within-cluster se skips FE and RE even with many clusters", 
 test_that("panel models are skipped with a clear message when plm is unavailable", {
   df <- make_demo_data()
 
-  utils::capture.output(
-    res <- run_linear_models(
-      df,
-      options = list(
-        add_significance_marks = FALSE,
-        bootstrap_replications = 0L,
-        conf_level = 0.95,
-        round_to = 3L
-      ),
-      is_pkg_available = function(pkg) pkg != "plm"
+  res <- run_linear_models(
+    df,
+    options = list(
+      add_significance_marks = FALSE,
+      bootstrap_replications = 0L,
+      conf_level = 0.95,
+      round_to = 3L
     ),
-    type = "message"
+    is_pkg_available = function(pkg) pkg != "plm"
   )
 
   panel_models <- c("fe", "be", "re")

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -42,7 +42,7 @@ make_p_hacking_df <- function(seed = 1, n = 60) {
 test_that("p_hacking_tests returns the standard contract with a caliper table", {
   local_caliper_only_options()
 
-  utils::capture.output(result <- p_hacking_tests(make_p_hacking_df()), type = "message")
+  result <- p_hacking_tests(make_p_hacking_df())
 
   expect_true(is.list(result))
   expect_true(is.data.frame(result$tables$caliper))
@@ -58,7 +58,7 @@ test_that("p_hacking_tests aborts when a required column is missing", {
 test_that("p_hacking_tests prints a significance legend matching significance_mark thresholds", {
   local_caliper_only_options()
 
-  output <- utils::capture.output(p_hacking_tests(make_p_hacking_df()), type = "message")
+  output <- testthat::capture_messages(p_hacking_tests(make_p_hacking_df()))
 
   expect_true(any(grepl("Significance marks: \\* p <= 0.1, \\*\\* p <= 0.05, \\*\\*\\* p <= 0.01", output)))
 })
@@ -108,12 +108,7 @@ test_that("a custom elliott_supports option flows through to the Cox-Shi call", 
   run_with_supports <- function(supports) {
     opts <- elliott_base_options()
     opts$artma.methods.p_hacking_tests.elliott_supports <- supports
-    result <- NULL
-    utils::capture.output(
-      result <- with_options(opts, p_hacking_tests(df)),
-      type = "message"
-    )
-    result
+    with_options(opts, p_hacking_tests(df))
   }
 
   default_result <- run_with_supports(c(0.05, 0.1))
@@ -149,9 +144,12 @@ test_that("p_hacking_tests surfaces the Cox-Shi skip reason in output and meta",
     study_id = rep(seq_len(20), each = 10)
   )
 
-  messages <- with_options(
-    elliott_base_options(),
-    utils::capture.output(result <- p_hacking_tests(df), type = "message")
+  # capture_messages() forces its `code` argument lazily in this frame (like
+  # the capture.output() it replaces), so a plain assignment here lands in
+  # this test_that block's own scope; <<- would skip past it instead.
+  result <- NULL
+  messages <- testthat::capture_messages(
+    with_options(elliott_base_options(), result <- p_hacking_tests(df))
   )
 
   # The summary table keeps NA in the p-value column.
@@ -188,7 +186,7 @@ test_that("exogeneity_tests returns the standard contract with IV results", {
   skip_if_not_installed("AER")
   local_options(artma.verbose = 1)
 
-  utils::capture.output(result <- exogeneity_tests(make_exogeneity_df()), type = "message")
+  result <- exogeneity_tests(make_exogeneity_df())
 
   expect_true(is.list(result))
   expect_true(is.data.frame(result$tables$summary))
@@ -217,10 +215,7 @@ test_that("exogeneity_tests handles mock data with too few significant p-uniform
   df <- create_mock_df(nrow = 600, n_studies = 30)
   df$study_size <- unname(as.integer(table(df$study_id)[as.character(df$study_id)]))
 
-  utils::capture.output(
-    result <- expect_no_error(exogeneity_tests(df)),
-    type = "message"
-  )
+  result <- expect_no_error(exogeneity_tests(df))
 
   expect_true(is.data.frame(result$tables$summary))
   expect_equal(nrow(result$tables$summary), 7L)

--- a/tests/testthat/test-result-formatters.R
+++ b/tests/testthat/test-result-formatters.R
@@ -48,17 +48,13 @@ sectioned_fixture <- function() {
 }
 
 # The printer returns the exact lines it emitted, so assertions can read them
-# without fighting cli's output connection.
+# directly; the test session's global sink (see setup.R) keeps the cli
+# output itself off the log.
 capture_sectioned <- function(x, ...) {
   withr::with_options(
     list(cli.num_colors = 1),
-    # print_sectioned_table() prints via cli, which writes through message()
-    # (stderr), not the "output" stream capture.output() captures by
-    # default - without type = "message" this silently captures nothing and
-    # the cli output leaks straight to the console.
-    utils::capture.output(lines <- print_sectioned_table(x, ...), type = "message")
+    print_sectioned_table(x, ...)
   )
-  lines
 }
 
 test_that("print_sectioned_table underlines every section heading", {
@@ -98,10 +94,7 @@ test_that("print_sectioned_table ignores an empty table", {
 })
 
 test_that("print_paragraph wraps sentences and drops empty ones", {
-  utils::capture.output(
-    lines <- print_paragraph(c("One sentence.", "", "Another sentence."), width = 20),
-    type = "message"
-  )
+  lines <- print_paragraph(c("One sentence.", "", "Another sentence."), width = 20)
 
   expect_true(length(lines) > 1)
   expect_match(paste(lines, collapse = " "), "One sentence\\. Another sentence\\.")


### PR DESCRIPTION
## What

Finishes the test-log cleanup chain (#389, #391, #392): `make test` now
prints nothing but testthat's own progress and summary lines. No
`> file: text` noise at all.

## Why the previous attempts stopped short

The parallel runner's `PROCESS_OUTPUT` events (raw worker stdout/stderr
forwarded to the parent as `> file: text`) are unconditional and
unconfigurable; the only way to stop them is to stop the worker from
writing to stdout/stderr in the first place. Two approaches don't work:

- `globalCallingHandlers()` from `setup.R` errors ("should not be called
  with handlers on the stack") because testthat's own `source_file()`
  already wraps setup in `withCallingHandlers()`.
- A naive `sink()` in `setup.R` looked promising but `sink(type =
  "message")` does not stack the way `sink(type = "output")` does; R
  only supports one active message diversion. A second
  `capture.output(x, type = "message")` call anywhere downstream (the
  pattern PR2/PR3 relied on) silently replaces the outer sink instead of
  layering on it, and popping the inner one then removes the outer one
  too, permanently reverting the rest of that worker's queue to raw
  console output.

## What this does instead

- `setup.R` installs one persistent, properly-paired output/message sink
  per parallel worker, gated on `callr_startup_hook` appearing in
  `sys.calls()` (the only reliable "am I a spawned worker" signal;
  `TESTTHAT_IS_PARALLEL` isn't set yet at `setup.R` load time). Gating
  matters: `make test-file` runs `devtools::test_active_file()` in the
  current session, where testthat's summary output shares the same
  stdout/stderr as the code under test, so an ungated sink would silence
  the pass/fail summary along with the noise.
- Every per-test-file `capture.output(..., type = "message")` call is
  removed and replaced with either a plain call (when nothing needs to
  inspect the message text) or `testthat::capture_messages()` (when a
  test asserts on message content). These use the condition system, not
  `sink()`, so they compose safely with the persistent sink instead of
  corrupting it.
- `test-cli.R` is the one legitimate exception: it tests `cli.run()`'s
  actual stdout/stderr behavior, so it suspends the persistent sink via
  `getOption("artma.test.null_message_con")` and restores it afterward
  rather than nesting inside it.

## Verification

- `make test`: `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 2719 ]`, zero
  `> file:` lines in the log (down from 690 pre-chain, 141 after #392).
- `make test-file FILE=test-cli.R`: summary output intact,
  `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 56 ]`.
- `make test-file FILE=test-generated-check-manifest.R`: no drift.
- `make lint`: clean.
