### PR TITLE
ci(lint): run Lint Check on master pushes to seed its dependency cache

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,15 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+  # Also run on master pushes so this job's dependency cache (keyed by its
+  # own extra-packages: lintr, roxygen2@8.0.0, local::.) gets seeded
+  # somewhere durable, mirroring R-CMD-check-extended.yaml. Without this,
+  # the job never ran outside of PRs, cache-cleanup.yaml deletes each PR's
+  # own cache the moment it closes, and every subsequent PR paid a full
+  # from-scratch R + dependency install (13m setup-r + 29m
+  # setup-r-dependencies) instead of restoring a warm cache.
+  push:
+    branches: master
 
 permissions: read-all
 


### PR DESCRIPTION
## What

Adds a `push: branches: master` trigger to `lint.yaml`, alongside its existing `pull_request` and `workflow_call`/`workflow_dispatch` triggers.

## Why

PR #397's `lint` check took **13m32s** on `setup-r@v2` and **28m57s** on `setup-r-dependencies@v2** — vastly longer than every sibling job on the same commit (test-coverage, the three release-matrix R-CMD-check jobs, E2E smoke test), which all completed in 3-4 minutes.

The root cause is a cold dependency cache, every time:

- `lint.yaml` only triggers on `pull_request` (`opened`/`synchronize`) — it never runs on `master`.
- `R-CMD-check-extended.yaml` explicitly runs on `push: branches: master` specifically so its dependency cache gets seeded there, and every PR branch's `setup-r-dependencies` step restores that warm cache (see the comment at the top of that workflow). `lint.yaml` has no equivalent.
- The lint job's cache key is unique anyway (`extra-packages: any::lintr, roxygen2@8.0.0, local::.` differs from every other job's dependency set), so it can't ride on any other job's cache.
- `cache-cleanup.yaml` deletes each PR's own cache the moment the PR closes.

Put together: the lint job's cache is never durably seeded anywhere, and is deleted after every PR — so every PR pays a full from-scratch R + dependency install.

## What this does instead

Mirrors the pattern `R-CMD-check-extended.yaml` already uses: trigger `lint.yaml` on `push: branches: master` too, so a warm cache for lint's specific dependency set gets seeded on every master merge, and subsequent PR runs can restore it instead of compiling everything from source.

## Verification

- `.github/workflows/lint.yaml` parses as valid YAML.
- No behavior change to the job's steps — purely an added trigger, matching an established pattern already used elsewhere in this repo's CI (`R-CMD-check-extended.yaml`).


---
_Generated by [Claude Code](https://claude.ai/code/session_0123FkrY1btJU9g1Zc8nbTCq)_