### PR TITLE
feat(nonlinear): report effect heterogeneity (tau) for STEM, Hierarchical, and Endogenous Kink

### DIFF
--- a/inst/artma/calc/methods/endo_kink.R
+++ b/inst/artma/calc/methods/endo_kink.R
@@ -121,7 +121,10 @@ final_endokink_fit <- function(prepared_data, cutoff, verbose) {
 #'
 #' @param data [data.frame] Two column data.frame with effect estimates and standard errors.
 #' @param verbose [logical] Should intermediate summaries be printed? Default `TRUE`.
-#' @return A numeric vector with the point estimates and standard errors in the same order as the legacy implementation.
+#' @return A numeric vector with the point estimates and standard errors in the same order as the
+#'   legacy implementation (`constant`, its SE, `pub_bias`, its SE), plus a 5th element
+#'   `heterogeneity_sd`: the model's residual heterogeneity standard deviation (the same quantity
+#'   used internally to locate the kink cut-off), with no associated standard error of its own.
 run_endogenous_kink <- function(data, verbose = TRUE) {
   stopifnot(
     is.data.frame(data),
@@ -141,7 +144,8 @@ run_endogenous_kink <- function(data, verbose = TRUE) {
     constant <- ones_sebs
     pub_bias <- ones
   })
-  final_endokink_fit(renamed, cutoff, verbose)
+  fit <- final_endokink_fit(renamed, cutoff, verbose)
+  c(fit, heterogeneity_sd = variance$standard_deviation)
 }
 
 box::export(

--- a/inst/artma/econometric/nonlinear.R
+++ b/inst/artma/econometric/nonlinear.R
@@ -317,12 +317,24 @@ run_stem <- function(df, total_n, options) {
   estimate <- estimates[1, "estimate"]
   std_error <- estimates[1, "se"]
   n_included <- as.integer(round(estimates[1, "n_stem"]))
+  # STEM has no standard error for its heterogeneity estimate; NA (not NaN)
+  # is the documented "absent by design" signal degenerate_effect_reason()
+  # and the formatters already understand.
+  heterogeneity_estimate <- estimates[1, "sd of total heterogeneity"]
+  extra_terms <- list(list(
+    term = "effect_heterogeneity",
+    term_label = "Effect Heterogeneity (tau)",
+    estimate = heterogeneity_estimate,
+    std_error = NA_real_,
+    p_value = NA_real_
+  ))
   list(
     effect = list(
       estimate = estimate,
       std_error = std_error,
       p_value = normal_p_value(estimate, std_error)
     ),
+    extra_terms = extra_terms,
     n_model = n_included,
     plots = build_stem_plots(effects, ses, estimates, stem_fit$MSE)
   )
@@ -416,7 +428,8 @@ run_hierarchical <- function(df, total_n, options) {
     result
   })
   draws <- fit$Deltadraw
-  if (is.null(draws) || ncol(draws) < 2) {
+  vbeta_draws <- fit$Vbetadraw
+  if (is.null(draws) || ncol(draws) < 2 || is.null(vbeta_draws) || ncol(vbeta_draws) < 1) {
     cli::cli_abort("Unexpected posterior output from the hierarchical model.")
   }
   effect_draws <- draws[, 1]
@@ -425,6 +438,23 @@ run_hierarchical <- function(df, total_n, options) {
   effect_se <- stats::sd(effect_draws)
   pub_bias_est <- mean(pub_bias_draws)
   pub_bias_se <- stats::sd(pub_bias_draws)
+  # Vbetadraw holds posterior draws of vec(Vbeta), the nvar x nvar covariance
+  # matrix of the cross-study coefficients (column-major, mirroring
+  # Deltadraw's column order); column 1 is therefore Var(intercept), i.e. the
+  # cross-study heterogeneity of the effect. sqrt() of each draw gives
+  # posterior draws of the heterogeneity SD, whose mean/sd form an
+  # estimate/SE pair the same way effect_est/effect_se come from
+  # mean()/sd() of Deltadraw's column.
+  heterogeneity_sd_draws <- sqrt(pmax(vbeta_draws[, 1], 0))
+  heterogeneity_est <- mean(heterogeneity_sd_draws)
+  heterogeneity_se <- stats::sd(heterogeneity_sd_draws)
+  extra_terms <- list(list(
+    term = "effect_heterogeneity",
+    term_label = "Effect Heterogeneity (tau)",
+    estimate = heterogeneity_est,
+    std_error = heterogeneity_se,
+    p_value = normal_p_value(heterogeneity_est, heterogeneity_se)
+  ))
   list(
     effect = list(
       estimate = effect_est,
@@ -436,6 +466,7 @@ run_hierarchical <- function(df, total_n, options) {
       std_error = pub_bias_se,
       p_value = normal_p_value(pub_bias_est, pub_bias_se)
     ),
+    extra_terms = extra_terms,
     n_model = nrow(data)
   )
 }
@@ -532,13 +563,24 @@ run_endogenous <- function(df, total_n) {
     cli::cli_abort("Not enough observations to run the endogenous kink model.")
   }
   estimates <- run_endogenous_kink(data, verbose = FALSE)
-  if (length(estimates) < 4) {
+  if (length(estimates) < 5) {
     cli::cli_abort("Endogenous kink model did not return the expected coefficients.")
   }
   effect_est <- estimates[1]
   effect_se <- estimates[2]
   pub_bias_est <- estimates[3]
   pub_bias_se <- estimates[4]
+  heterogeneity_estimate <- estimates[5]
+  # No standard error is computed for the heterogeneity SD; NA (not NaN) is
+  # the documented "absent by design" signal degenerate_effect_reason() and
+  # the formatters already understand.
+  extra_terms <- list(list(
+    term = "effect_heterogeneity",
+    term_label = "Effect Heterogeneity (tau)",
+    estimate = heterogeneity_estimate,
+    std_error = NA_real_,
+    p_value = NA_real_
+  ))
   list(
     effect = list(
       estimate = effect_est,
@@ -550,6 +592,7 @@ run_endogenous <- function(df, total_n) {
       std_error = pub_bias_se,
       p_value = normal_p_value(pub_bias_est, pub_bias_se)
     ),
+    extra_terms = extra_terms,
     n_model = nrow(data)
   )
 }

--- a/tests/testthat/test-calc-endo-kink.R
+++ b/tests/testthat/test-calc-endo-kink.R
@@ -68,10 +68,12 @@ test_that("run_endogenous_kink recovers a homogeneous true effect", {
 
   out <- run_endogenous_kink(data.frame(effect, se), verbose = FALSE)
 
-  expect_length(out, 4L)
+  expect_length(out, 5L)
   # First element is the mean-effect estimate.
   expect_equal(unname(out[1]), 0.3, tolerance = 0.1)
   expect_true(is.finite(out[2]))
+  # 5th element is the heterogeneity standard deviation: finite and >= 0.
+  expect_true(is.finite(out[5]) && out[5] >= 0)
 })
 
 test_that("run_endogenous_kink matches the Bom & Rachinger reference on low-heterogeneity data", {

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -80,7 +80,11 @@ test_that("nonlinear tests return tidy coefficients and summary", {
       "std_error_formatted"
     )
   )
-  expect_setequal(unique(res$meta$coefficients$term), c("publication_bias", "effect"))
+  # STEM (and, depending on the fixture, Hierarchical and Endogenous Kink)
+  # all report their heterogeneity estimate under the same shared term/label
+  # as the Selection model's tau, so it folds into a single extra row pair
+  # regardless of how many of them succeed on this fixture.
+  expect_setequal(unique(res$meta$coefficients$term), c("publication_bias", "effect", "effect_heterogeneity"))
   expect_true(all(res$meta$coefficients$n_obs_total == nrow(df)))
 
   expect_gt(nrow(res$tables$summary), 0L)
@@ -88,7 +92,8 @@ test_that("nonlinear tests return tidy coefficients and summary", {
     rownames(res$tables$summary),
     c(
       "Publication Bias", "(Std. Error)", "Effect Beyond Bias",
-      "(Std. Error)", "Total observations", "Model observations"
+      "(Std. Error)", "Effect Heterogeneity (tau)", "(Std. Error)",
+      "Total observations", "Model observations"
     )
   )
   expect_equal(res$tables$summary$Metric, rownames(res$tables$summary))
@@ -178,6 +183,50 @@ test_that("selection model runs with negative and zero cutoffs and restructured 
   expect_true("Effect Heterogeneity (tau)" %in% summary$Metric)
   expect_true(any(grepl("Rel. Pub. Probability", summary$Metric, fixed = TRUE)))
   expect_identical(summary$Selection[summary$Metric == "Publication Bias"], "NA")
+})
+
+test_that("STEM, Hierarchical, and Endogenous Kink report effect heterogeneity (tau)", {
+  df <- make_mixed_significance_data()
+
+  local_options(
+    "artma.methods.nonlinear_tests.add_significance_marks" = TRUE,
+    "artma.methods.nonlinear_tests.selection_cutoffs" = c(-1.96, 0, 1.96),
+    "artma.methods.nonlinear_tests.selection_symmetric" = FALSE,
+    "artma.methods.nonlinear_tests.selection_model" = "normal",
+    "artma.methods.nonlinear_tests.hierarchical_iterations" = 20L,
+    "artma.visualization.export_graphics" = FALSE,
+    "artma.verbose" = 0L
+  )
+
+  res <- suppressWarnings(suppressMessages(nonlinear_tests(df)))
+  coefficients <- res$meta$coefficients
+
+  # STEM and Endogenous Kink compute a heterogeneity SD internally but have
+  # no standard error for it: a finite estimate paired with a genuinely-NA
+  # (not NaN) std_error is the documented "absent by design" signal that
+  # degenerate_effect_reason() and the formatters already understand, so the
+  # table cell renders with no parenthetical and no significance stars.
+  for (model in c("stem", "endogenous_kink")) {
+    tau_row <- coefficients[coefficients$model == model & coefficients$term == "effect_heterogeneity", , drop = FALSE]
+    expect_identical(nrow(tau_row), 1L)
+    expect_identical(tau_row$term_label, "Effect Heterogeneity (tau)")
+    expect_true(is.finite(tau_row$estimate))
+    expect_true(is.na(tau_row$std_error) && !is.nan(tau_row$std_error))
+    expect_true(is.na(tau_row$p_value))
+    expect_identical(tau_row$std_error_formatted, "")
+    expect_false(grepl("*", tau_row$estimate_formatted, fixed = TRUE))
+  }
+
+  # Hierarchical derives both an estimate and a standard error from posterior
+  # draws of Vbeta (the cross-study coefficient covariance), so it gets a
+  # full estimate/SE pair, just like Selection's own tau.
+  hier_row <- coefficients[coefficients$model == "hierarchical" & coefficients$term == "effect_heterogeneity", , drop = FALSE]
+  expect_identical(nrow(hier_row), 1L)
+  expect_identical(hier_row$term_label, "Effect Heterogeneity (tau)")
+  expect_true(is.finite(hier_row$estimate) && is.finite(hier_row$std_error))
+
+  summary <- res$tables$summary
+  expect_true("Effect Heterogeneity (tau)" %in% summary$Metric)
 })
 
 test_that("selection model runs with a single zero cutoff (sign selection)", {

--- a/tests/testthat/test-summary-table-characterization.R
+++ b/tests/testthat/test-summary-table-characterization.R
@@ -139,18 +139,24 @@ test_that("nonlinear_tests summary table is pinned on fixture data", {
     list(
       Metric = c(
         "Publication Bias", "(Std. Error)", "Effect Beyond Bias",
-        "(Std. Error)", "Total observations", "Model observations"
+        "(Std. Error)", "Effect Heterogeneity (tau)", "(Std. Error)",
+        "Total observations", "Model observations"
       ),
       # The WAAP standard error is the study-clustered WLS regression SE; the
       # fixture effects are nearly homogeneous, so it rounds below 0.01 here.
-      WAAP = c("NA", "", "0.13***", "(0.00)", "90", "15"),
-      Stem = c("NA", "", "0.15***", "(0.02)", "90", "14"),
-      Hierarch = c("0.56***", "(0.16)", "0.08", "(0.15)", "90", "90"),
-      `Endogenous Kink` = c("0.57***", "(0.03)", "0.10***", "(0.00)", "90", "90")
+      # STEM and Endogenous Kink have no standard error for their
+      # heterogeneity estimate, which on this near-homogeneous fixture also
+      # rounds to exactly zero; Hierarchical derives both an estimate and an
+      # SE from posterior draws of Vbeta.
+      WAAP = c("NA", "", "0.13***", "(0.00)", "", "", "90", "15"),
+      Stem = c("NA", "", "0.15***", "(0.02)", "0.00", "", "90", "14"),
+      Hierarch = c("0.56***", "(0.16)", "0.08", "(0.15)", "0.55***", "(0.10)", "90", "90"),
+      `Endogenous Kink` = c("0.57***", "(0.03)", "0.10***", "(0.00)", "0.00", "", "90", "90")
     ),
     row.names = c(
       "Publication Bias", "(Std. Error)", "Effect Beyond Bias",
-      "(Std. Error)", "Total observations", "Model observations"
+      "(Std. Error)", "Effect Heterogeneity (tau)", "(Std. Error)",
+      "Total observations", "Model observations"
     ),
     class = "data.frame"
   )


### PR DESCRIPTION
## Summary

Extends the non-linear-tests summary table so **STEM**, **Hierarchical**, and **Endogenous Kink** report an "Effect Heterogeneity (tau)" row, the same way the Selection model already does.

`run_selection()` already emits an `extra_terms` list that `build_summary_table()` folds into extra row-pairs, keyed by `term_label`. Three other methods compute an analogous heterogeneity quantity internally but previously discarded it before it reached the table:

- **STEM** (`run_stem()`): `stem()` already returns a `"sd of total heterogeneity"` column, previously only used to feed the funnel plot. No standard error exists for it, so `std_error`/`p_value` are `NA_real_` — the documented "absent by design" path `degenerate_effect_reason()` and the formatters already understand.
- **Hierarchical** (`run_hierarchical()`): reads `bayesm::rhierLinearModel()`'s `Vbetadraw` (posterior draws of the cross-study coefficient covariance) alongside the existing `Deltadraw`. Column 1 of `Vbetadraw` is `Var(intercept)`, mirroring `Deltadraw`'s column 1 = intercept/"effect"; `sqrt(pmax(., 0))` gives posterior draws of the heterogeneity SD, whose mean/sd form the estimate/SE pair — the same way `effect_est`/`effect_se` already come from `mean()`/`sd()` of `Deltadraw`'s column. **Verified** against the `bayesm` documentation (`Vbetadraw : R/keep x nvar*nvar matrix of Vbeta draws`, column-major `vec()`) *and* an empirical simulation with a known, deliberately asymmetric `Vbeta`, confirming column 1 tracks `Var(intercept)` and column 4 tracks `Var(slope)`.
- **Endogenous Kink** (`run_endogenous_kink()` / `run_endogenous()`): widens `run_endogenous_kink()`'s return value with a 5th element carrying the model's residual heterogeneity SD (`compute_variance_component()`'s `standard_deviation`, already computed internally to locate the kink cutoff but previously discarded). As with STEM, no standard error is available.

All three reuse the exact same `term`/`term_label` as Selection's existing entry (`"effect_heterogeneity"` / `"Effect Heterogeneity (tau)"`), so `build_summary_table()`'s existing label-union logic folds them into one shared, compact row pair — **no changes to `build_summary_table()` itself**.

## Tests

- Updated the two fixed assertions in `test-nonlinear-tests.R` that necessarily change once STEM starts emitting `effect_heterogeneity` on the existing fixture (`unique(term)` set and the fixed 6→8-row `rownames(summary)` list).
- Added a dedicated test asserting the STEM/Hierarchical/Endogenous-Kink tau rows: estimate finite; `NA` (not `NaN`) `std_error` and blank/no-star formatting for STEM and Endogenous Kink; a full finite estimate/SE pair for Hierarchical.
- Bumped `run_endogenous_kink()`'s `expect_length()` from 4 to 5 in `test-calc-endo-kink.R` (grepped for and found no other test asserting its exact return length), plus a finiteness/non-negativity check on the new 5th element.
- Refreshed the pinned summary table in `test-summary-table-characterization.R` with the new row and real computed values.

## Verification

The sandbox had neither R nor any of the package's runtime/dev dependencies installed. I built a full R toolchain from source (R, `box`, `climenu`, `bayesm`, `testthat`, `devtools`, `roxygen2`, `lintr`, `box.linters`, `styler`, etc.) to actually run this repo's own tooling end-to-end, rather than rely on static reading alone:

- `make document` (regenerate-check-manifest + `devtools::document()`): no diff — expected, since this change touches no `box::use()` imports in `R/*.R` and adds no new Imports-only-used-in-`inst/artma` dependency.
- `make lint`: zero new lints on the changed files; confirmed clean under a UTF-8 locale (`.lintr.R`'s `box_usage_linter` false-flags `%||%` under this sandbox's older R, an unrelated environment gap — the 10 flagged lines are all pre-existing, none touched by this diff).
- `make test`: full suite passes, including the new dedicated test, the two updated fixed-shape tests, and the existing `calc-endo-kink`/`calc-stem`/`nonlinear-tests` suites. The ~50 pre-existing failures elsewhere in the suite are unrelated sandbox version gaps (an older `ggplot2` missing `is_ggplot()`, `%||%` unavailable in a couple of interactive-mock test paths outside `box`'s import chain) — none touch the files this PR changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEb3Cz4CQcaLYbzHGscxTH)_