### PR TITLE
fix(bpe): auto-detect factor summary predictors

### DIFF
--- a/inst/artma/econometric/best_practice_estimate.R
+++ b/inst/artma/econometric/best_practice_estimate.R
@@ -217,15 +217,22 @@ compute_bpe_economic_significance <- function(predictors, bma_data, coef_post_me
 
 #' @title Best-Practice Estimate Grouped by Factor Levels
 #' @description
-#' For every predictor flagged via `bpe_sum_stats`/`bpe_equal`/`bpe_gltl` in
-#' the data config, splits the BMA observations into factor-level groups
-#' (mirroring `effect_summary_stats`) and computes the best-practice estimate
-#' for each group, holding every other predictor at its configured/resolved
-#' override.
+#' Splits the BMA observations into factor-level groups (mirroring
+#' `effect_summary_stats`) and computes the best-practice estimate for each
+#' group, holding every other predictor at its configured/resolved override.
+#' A predictor is grouped when it is explicitly flagged via
+#' `bpe_sum_stats`/`bpe_equal`/`bpe_gltl` in the data config, or, when
+#' `auto_detect_factor_vars` is `TRUE`, when it is not explicitly flagged but
+#' still resolves to 2-12 distinct levels (the same bound
+#' `resolve_variable_groups()` applies to its own per-level fallback). Most
+#' moderators in meta-analysis datasets are dummy/category variables, so this
+#' default keeps the table populated without requiring config beforehand;
+#' set `auto_detect_factor_vars = FALSE` to only group explicitly flagged
+#' variables.
 #' @keywords internal
 compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_mean, include_intercept,
                                        vcov_matrix, z_value, overrides, round_to,
-                                       centers = NULL, scales = NULL) {
+                                       centers = NULL, scales = NULL, auto_detect_factor_vars = TRUE) {
   empty <- data.frame(
     scope = character(0),
     study_id = character(0),
@@ -242,12 +249,12 @@ compute_bpe_factor_summary <- function(predictors, config, bma_data, coef_post_m
 
   for (var_name in predictors) {
     config_key <- find_config_key_for_var(var_name, config)
-    if (is.null(config_key)) {
-      next
-    }
+    var_cfg <- if (is.null(config_key)) NULL else config[[config_key]]
 
-    var_cfg <- config[[config_key]]
-    if (!is_bpe_factor_var(var_cfg)) {
+    # Explicit flags always take part; without one, auto-detection still
+    # attempts the variable and relies on resolve_variable_groups()'s own
+    # 2-12 level bound to skip genuinely continuous predictors below.
+    if (!is_bpe_factor_var(var_cfg) && !isTRUE(auto_detect_factor_vars)) {
       next
     }
 

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -72,6 +72,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       constraint_msg = "economic_significance_pip_threshold must be between 0 and 1."
     ),
     include_factor_summary = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
+    factor_summary_auto_detect = opt_spec(default = TRUE, type = "logical", scalar = TRUE),
     round_to = opt_spec(
       default = 3L, type = "numeric", key = "artma.output.number_of_decimals",
       cast = as.integer, scalar = TRUE
@@ -86,6 +87,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   include_economic_significance <- resolved$include_economic_significance
   economic_significance_pip_threshold <- resolved$economic_significance_pip_threshold
   include_factor_summary <- resolved$include_factor_summary
+  factor_summary_auto_detect <- resolved$factor_summary_auto_detect
   round_to <- resolved$round_to
 
   # Cross-option constraint: at least one row scope must remain enabled. Kept
@@ -293,7 +295,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
   }
 
   if (include_factor_summary) {
-    tables$summary_by_factor <- compute_bpe_factor_summary(
+    factor_summary <- compute_bpe_factor_summary(
       predictors = predictors,
       config = config,
       bma_data = bma_data,
@@ -304,8 +306,25 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       overrides = resolved_overrides,
       round_to = round_to,
       centers = scale_centers,
-      scales = scale_scales
+      scales = scale_scales,
+      auto_detect_factor_vars = factor_summary_auto_detect
     )
+
+    if (nrow(factor_summary) > 0) {
+      tables$summary_by_factor <- factor_summary
+    } else if (get_verbosity() >= 3) {
+      # Skip exporting an empty CSV; point at what would populate it instead
+      # of leaving the user to guess why the file came back header-only.
+      cli::cli_alert_info(paste0(
+        "Skipping best-practice estimate factor summary: no BMA predictor ",
+        "resolved to a factor grouping. ",
+        if (factor_summary_auto_detect) {
+          "None of the predictors have 2-12 distinct values for auto-detection to group by."
+        } else {
+          "Set factor_summary_auto_detect to TRUE, or flag variables with bpe_sum_stats/bpe_equal/bpe_gltl in the data config."
+        }
+      ))
+    }
   }
 
   vis <- get_visualization_options()

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -542,8 +542,22 @@ methods:
       default: true
       help: |
         If `TRUE`, include a best-practice estimate summary table grouped by
-        the factor levels of variables flagged with `bpe_sum_stats`,
-        `bpe_equal`, or `bpe_gltl` in the data configuration.
+        factor levels: variables flagged with `bpe_sum_stats`, `bpe_equal`,
+        or `bpe_gltl` in the data configuration, plus, when
+        `factor_summary_auto_detect` is `TRUE`, any other BMA predictor that
+        resolves to 2-12 distinct values. If nothing resolves to a grouping,
+        the table is skipped rather than exported empty.
+
+    factor_summary_auto_detect:
+      type: "logical"
+      default: true
+      help: |
+        If `TRUE`, the best-practice estimate factor summary (see
+        `include_factor_summary`) also groups by BMA predictors that are not
+        explicitly flagged in the data configuration, as long as they resolve
+        to 2-12 distinct values (typical of dummy/category moderators). Set
+        to `FALSE` to only group by variables explicitly flagged with
+        `bpe_sum_stats`, `bpe_equal`, or `bpe_gltl`.
 
   robma:
     chains:

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -314,9 +314,13 @@ test_that("best_practice_estimate groups the factor summary table by bpe_equal/b
   expect_true(any(grepl("^Citations <", factor_summary$study_label)))
 })
 
-test_that("best_practice_estimate returns an empty factor summary table with no flagged variables", {
+test_that("best_practice_estimate auto-detects dummy predictors for the factor summary by default", {
   skip_if_not_installed("BMS")
 
+  # Regression test for #403: on a fully auto-detected data config (no
+  # bpe_sum_stats/bpe_equal/bpe_gltl set anywhere), the factor summary must
+  # still populate for the model's own dummy predictors instead of shipping
+  # header-only.
   df <- make_bpe_demo_data()
 
   local_options(list(
@@ -335,7 +339,36 @@ test_that("best_practice_estimate returns an empty factor summary table with no 
   bma_result <- bma(df)
   result <- best_practice_estimate(df, bma_result = bma_result)
 
-  expect_equal(nrow(result$tables$summary_by_factor), 0L)
+  factor_summary <- result$tables$summary_by_factor
+  expect_true(is.data.frame(factor_summary))
+  expect_gt(nrow(factor_summary), 0L)
+  expect_true(any(grepl("^Top Journal = ", factor_summary$study_label)))
+  expect_true(any(grepl("^First Lag Instrument = ", factor_summary$study_label)))
+})
+
+test_that("best_practice_estimate skips the factor summary table when nothing resolves to a grouping", {
+  skip_if_not_installed("BMS")
+
+  df <- make_bpe_demo_data()
+
+  local_options(list(
+    artma.verbose = 0,
+    artma.autonomy.level = "autonomous",
+    artma.data.columns = make_bpe_demo_config(),
+    artma.visualization.export_graphics = FALSE,
+    artma.methods.bma.burn = 50L,
+    artma.methods.bma.iter = 300L,
+    artma.methods.bma.nmodel = 20L,
+    artma.methods.bma.g = "UIP",
+    artma.methods.bma.mprior = "uniform",
+    artma.methods.bma.mcmc = "bd",
+    artma.methods.best_practice_estimate.factor_summary_auto_detect = FALSE
+  ))
+
+  bma_result <- bma(df)
+  result <- best_practice_estimate(df, bma_result = bma_result)
+
+  expect_false("summary_by_factor" %in% names(result$tables))
 })
 
 test_that("get_bma_data records scaling metadata and keeps NA dummies binary", {


### PR DESCRIPTION
## Diagnosis

`best_practice_estimate_summary_by_factor.csv` exported header-only on every real-dataset run because `compute_bpe_factor_summary()` only grouped predictors explicitly flagged with `bpe_sum_stats`, `bpe_equal`, or `bpe_gltl` in the data config. None of the reported validation runs set those keys (the config was fully auto-detected via `data.columns`), so the table was empty by design, but with no indication of why.

The auto-level fallback needed to populate the table without config already existed in `resolve_variable_groups()` (splitting any variable with 2-12 distinct values into one group per level) but was never reachable, because the config-flag gate short-circuited before it could run.

## Fix

- `compute_bpe_factor_summary()` now groups a predictor when it is explicitly flagged, or, by default, when it resolves to 2-12 distinct values on its own (covers the common case of dummy/category moderators without requiring config upfront). This is controlled by a new option, `artma.methods.best_practice_estimate.factor_summary_auto_detect` (default `TRUE`), so users who want only explicitly flagged variables can turn it off.
- When nothing resolves to a grouping (auto-detect off and nothing flagged, or every predictor is continuous), the method now skips exporting the empty CSV and emits a `cli` message explaining which option/config keys populate it, instead of shipping a silent header-only file.

## Tests

- Extended `tests/testthat/test-best-practice-estimate.R`: a regression test reproducing the reported bug (fully auto-detected config, default options) confirms the factor summary now populates for the fixture's dummy predictors, and a new test confirms `factor_summary_auto_detect = FALSE` restores the old opt-out behavior (table omitted, not exported empty).
- `make lint` and the full `make test` suite pass.

Fixes #403