### PR TITLE
fix(data): stop treating lowercase na/n-a strings as missing

### DIFF
--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -15,8 +15,16 @@ CONST <- list(
     # to a tabular record set or a clear error is raised. dta and rds keep the
     # types their native readers return and pass through NA normalization only.
     TYPES = c("csv", "tsv", "xlsx", "xls", "xlsm", "json", "dta", "rds"),
-    # Strings that should be interpreted as NA when reading data files
-    NA_STRINGS = c("", "NA", "N/A", "na", "n/a", "NULL", "null"),
+    # Strings that should be interpreted as NA when reading data files.
+    # Matching is exact (case-sensitive): only the canonical, R-convention
+    # spellings ("NA", the base R and write.csv default; "N/A", "NULL",
+    # "null") are treated as missing-value sentinels. All-lowercase "na" and
+    # "n/a" were deliberately dropped: "na" in particular is a common
+    # real-world category value (e.g. "no functional form assumed"), and
+    # matching it case-insensitively silently mislabeled genuine data as
+    # missing (see #402). Empty strings and whitespace-only cells are always
+    # treated as missing regardless of this list (normalize_whitespace_to_na).
+    NA_STRINGS = c("", "NA", "N/A", "NULL", "null"),
     # Standard column names the pipeline recognizes. These keys identify the
     # role records in the unified per-column store (`data.columns`); every
     # other record key is a moderator variable. Accessors live in

--- a/tests/testthat/test-data-na-handling.R
+++ b/tests/testthat/test-data-na-handling.R
@@ -279,6 +279,48 @@ test_that("an invalid threshold option aborts with a clear message", {
   )
 })
 
+# -- "na" as a real category value (issue #402) --------------------------------
+
+test_that("detect_missing_values does not flag a character column whose values are the literal 'na' category", {
+  box::use(artma / data / na_handling[detect_missing_values])
+
+  df <- make_df()
+  df$discounting <- c("na", "exponential", "na")
+
+  summary <- detect_missing_values(df)
+
+  expect_false("discounting" %in% names(summary$optional_cols_with_na))
+  expect_false(summary$has_optional_na)
+})
+
+test_that("detect_missing_values still flags real missing values in an optional numeric column", {
+  box::use(artma / data / na_handling[detect_missing_values])
+
+  df <- make_df()
+  df$mod <- c(1, NA, 3)
+
+  summary <- detect_missing_values(df)
+
+  expect_true("mod" %in% names(summary$optional_cols_with_na))
+  expect_equal(unname(summary$optional_cols_with_na["mod"]), 1)
+})
+
+test_that("'stop' does not abort when the only 'missing' values are the 'na' category", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "stop",
+    "artma.verbose" = 1
+  ))
+
+  df <- make_df()
+  df$discounting <- c("na", "exponential", "na")
+
+  result <- handle_missing_values(df)
+
+  expect_equal(result$discounting, c("na", "exponential", "na"))
+})
+
 test_that("'mice' leaves guarded columns unimputed", {
   box::use(artma / data / na_handling[handle_missing_values])
   testthat::skip_if_not_installed("mice")

--- a/tests/testthat/test-data-read.R
+++ b/tests/testthat/test-data-read.R
@@ -2,6 +2,7 @@ box::use(
   testthat[
     expect_equal,
     expect_error,
+    expect_false,
     expect_true,
     skip_if_not_installed,
     test_that
@@ -82,4 +83,54 @@ test_that("read_data and the shared read_file read a file identically", {
   utils::write.csv(raw_text_df(), tmp, row.names = FALSE)
 
   expect_equal(read_data(tmp), read_file(tmp))
+})
+
+
+# -- "na" as a real category value (issue #402) --------------------------------
+# Lowercase "na" is a legitimate category value in some real datasets (e.g. "no
+# functional form assumed"). Only the exact-case conventional spellings ("NA",
+# "N/A", "NULL", "null") are treated as missing-value sentinels; "na" and
+# "n/a" must survive untouched.
+
+test_that("normalize_read_df keeps lowercase 'na' as a literal category value", {
+  df <- data.frame(
+    study_id = c("S1", "S2", "S3"),
+    discounting = c("na", "exponential", "na"),
+    stringsAsFactors = FALSE
+  )
+
+  out <- normalize_read_df(df)
+
+  expect_equal(out$discounting, c("na", "exponential", "na"))
+  expect_false(anyNA(out$discounting))
+})
+
+test_that("normalize_read_df still treats exact-case 'NA' as missing", {
+  df <- data.frame(x = c("NA", "value"), stringsAsFactors = FALSE)
+
+  out <- normalize_read_df(df)
+
+  expect_equal(out$x, c(NA_character_, "value"))
+})
+
+test_that("read_file keeps lowercase 'na' as a category value read from a CSV", {
+  withr::local_options(list(artma.verbose = 0))
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  utils::write.csv(
+    data.frame(
+      study_id = c("S1", "S2", "S3"),
+      effect = c(0.1, 0.2, 0.3),
+      se = c(0.01, 0.02, 0.03),
+      n_obs = c(10L, 20L, 30L),
+      discounting = c("na", "exponential", "na"),
+      stringsAsFactors = FALSE
+    ),
+    tmp,
+    row.names = FALSE
+  )
+
+  out <- read_file(tmp)
+
+  expect_equal(out$discounting, c("na", "exponential", "na"))
+  expect_false(anyNA(out$discounting))
 })


### PR DESCRIPTION
## Bug

A CSV's own reader (`smart_read_csv`) and the shared post-read normalizer (`replace_na_strings`) both matched every string in `CONST$DATA$NA_STRINGS` as missing, and that list included the bare lowercase spellings `"na"` and `"n/a"` alongside the canonical `"NA"`/`"N/A"`. In the Matousek, Havranek and Irsova (2022) discount-rate archive, the `discounting` column legitimately uses `"na"` as a category value ("no discounting functional form assumed"), and 275 of 539 rows were misdetected as missing.

## Root cause

`inst/artma/const.R`'s `NA_STRINGS` constant (consumed by `smart_detection.R`'s CSV readers and `normalize.R`'s `replace_na_strings`, which every input format flows through) matched `"na"`/`"n/a"` case-insensitively alongside `"NA"`/`"N/A"`.

## Policy decision

Matching stays exact-string (not a new configurable option, to keep the fix scoped): only the canonical R/write.csv convention spellings (`"NA"`, `"N/A"`, `"NULL"`, `"null"`) are treated as missing-value sentinels. The all-lowercase `"na"`/`"n/a"` variants are dropped from the default list, since they are common real-world category values and not a standard missing-data convention. Empty and whitespace-only cells are still always treated as missing, independent of this list (`normalize_whitespace_to_na`). This keeps existing behavior for `"NA"`, `"N/A"`, `"NULL"`/`"null"` (already covered by tests) and for numeric columns, where base R's own CSV parsing already turns exact `"NA"` cells into real `NA` at read time.

Excel, JSON, Stata, and RDS readers all flow through the same shared `normalize_read_df` → `replace_na_strings` step, so behavior stays consistent across formats.

## Testing

- New unit tests in `test-data-read.R` and `test-data-na-handling.R`: a character column with `"na"` as a category survives `normalize_read_df`/`read_file`/`detect_missing_values`/`handle_missing_values` un-flagged and un-dropped; a numeric column with real missing values is still detected; exact-case `"NA"` still normalizes to a true `NA`.
- Reproduced the reported scenario end-to-end with a small synthetic CSV (not the archive itself): a `discounting`-like column with `"na"` values is no longer flagged, while a genuinely missing `se` cell still is.
- Full suite: `devtools::test()` green (2716 passed, 0 failed).
- `make lint` clean on changed files.

Fixes #402