### PR TITLE
fix(data): stop strategy no longer aborts on optional-column NAs

### DIFF
--- a/inst/artma/data/configure.R
+++ b/inst/artma/data/configure.R
@@ -4,9 +4,13 @@
 #'   a no-op. Otherwise, if the (already cleaned) data frame has missing values
 #'   in optional columns, it prompts the user interactively (and offers to save
 #'   the choice) or falls back to the deterministic `"stop"` strategy in a
-#'   non-interactive session. This is intentionally separate from
-#'   `handle_missing_values()` (the pure compute-phase step) so that no prompt
-#'   or option write ever happens inside the cached pipeline.
+#'   non-interactive session. That default is safe to fall back to
+#'   unattended: `"stop"` only requires required columns to be complete (see
+#'   `handle_missing_values()`), so a non-interactive run never aborts merely
+#'   because an optional/unmapped column has gaps (issue #401). This is
+#'   intentionally separate from `handle_missing_values()` (the pure
+#'   compute-phase step) so that no prompt or option write ever happens
+#'   inside the cached pipeline.
 #' @param df *\[data.frame\]* The cleaned data frame used to detect optional
 #'   missing values (as produced by `clean_data()`).
 #' @return `NULL`, invisibly.
@@ -52,9 +56,12 @@ resolve_na_handling <- function(df) {
       respect_autonomy = FALSE
     )
   } else {
-    # Non-interactive mode: default to "stop"
+    # Non-interactive mode: default to "stop". Optional columns with missing
+    # values are left as-is and reported by handle_missing_values(); required
+    # columns still abort, so this does not run the risk of silently altering
+    # data (issue #401).
     if (get_verbosity() >= 2) {
-      cli::cli_warn("Running in non-interactive mode with missing values. Defaulting to 'stop' strategy.")
+      cli::cli_warn("Running in non-interactive mode with missing values in optional columns. Defaulting to the 'stop' strategy (required columns must still be complete).")
     }
     options(artma.data.na_handling = NA_HANDLING_DEFAULT)
   }

--- a/inst/artma/data/na_handling.R
+++ b/inst/artma/data/na_handling.R
@@ -395,7 +395,12 @@ identify_unimputable_columns <- function(df, threshold) {
 #' This function handles missing values differently for required vs optional columns:
 #' - Non-numeric required columns (e.g., study_id) must be complete and will cause an error if missing
 #' - Numeric required columns (e.g., effect, se, n_obs) can be imputed if a non-"stop" strategy is selected
-#' - Optional columns are handled according to the selected strategy
+#' - Optional columns are handled according to the selected strategy, except that
+#'   the "stop" strategy never aborts over them: since required columns are
+#'   already guaranteed complete by the time "stop" is reached, missing values
+#'   in optional columns are left as-is and reported, not treated as fatal
+#'   (issue #401). A column no method actually needs should not be able to
+#'   halt the whole run.
 #'
 #' Imputation strategies skip optional numeric columns whose missingness ratio
 #' exceeds `artma.data.max_imputation_missingness`; those columns keep their
@@ -521,13 +526,21 @@ handle_missing_values <- function(df) {
 
   # Apply the selected strategy
   df_processed <- switch(na_handling,
+    # By this point required columns are guaranteed complete: a numeric or
+    # non-numeric required NA would already have aborted above. So "stop"
+    # only has optional-column NAs left to deal with, and those are not
+    # worth failing the whole run over (issue #401) - they are left as-is.
     "stop" = {
-      optional_cols_msg <- format_cols_with_counts(na_summary$optional_cols_with_na)
-      cli::cli_abort(c(
-        "x" = "Missing values found in optional columns: {optional_cols_msg}",
-        "i" = "Current strategy is {.val stop}. Change {.field artma.data.na_handling} to handle missing values automatically.",
-        "i" = "Available strategies: {.val stop}, {.val remove}, {.val median}, {.val mean}, {.val interpolate}, {.val mice}"
-      ))
+      optional_cols_msg <- format_cols_with_counts(label_with_source_names(na_summary$optional_cols_with_na))
+      if (get_verbosity() >= 2) {
+        cli::cli_alert_warning(
+          "Leaving missing values in optional columns as-is (not used by every method): {optional_cols_msg}"
+        )
+        cli::cli_alert_info(
+          "The {.val stop} strategy only requires required columns to be complete. Set {.field artma.data.na_handling} to {.val remove}, {.val median}, {.val mean}, {.val interpolate}, or {.val mice} to handle these values automatically."
+        )
+      }
+      df
     },
     "remove" = handle_na_remove(df),
     "median" = handle_na_median(df, exclude_cols = skip_cols),

--- a/inst/artma/options/prompts.R
+++ b/inst/artma/options/prompts.R
@@ -37,7 +37,7 @@ prompt_na_handling <- function(opt, ...) {
   box::use(artma / const[CONST])
 
   choices <- c(
-    "Stop (abort if missing values found)" = "stop",
+    "Stop (leave optional columns as-is; required columns must be complete)" = "stop",
     "Remove rows (listwise deletion)" = "remove",
     "Median imputation (replace with column median)" = "median",
     "Mean imputation (replace with column mean)" = "mean",
@@ -52,7 +52,7 @@ prompt_na_handling <- function(opt, ...) {
 
   cli::cli_h3("Available strategies:")
   cli::cli_ul(c(
-    "{.strong stop}: Abort analysis if any missing values are found (safest, ensures data quality)",
+    "{.strong stop}: Leave missing values in these columns as-is and report them (safest, does not touch your data). Required columns must always be complete regardless of this setting.",
     "{.strong remove}: Remove entire rows with any missing values (listwise deletion)",
     "{.strong median}: Replace missing values with the variable's median (robust to outliers)",
     "{.strong mean}: Replace missing values with the variable's mean (assumes normality)",

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -920,7 +920,7 @@ data:
     suppress_help_in_prompt: true
     help: |
       How to handle missing values:
-        {cli::symbol$bullet} {.strong stop}: Abort if any missing values are found (safest, default)
+        {cli::symbol$bullet} {.strong stop}: Abort if required columns have missing values (safest, default). Optional columns with missing values are left as-is and reported instead of aborting the run.
         {cli::symbol$bullet} {.strong remove}: Remove entire rows with any missing values (listwise deletion)
         {cli::symbol$bullet} {.strong median}: Replace missing values with the variable's median (robust to outliers)
         {cli::symbol$bullet} {.strong mean}: Replace missing values with the variable's mean (assumes normality)

--- a/tests/testthat/test-data-configure.R
+++ b/tests/testthat/test-data-configure.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_no_error,
     expect_null,
     expect_warning,
     test_that
@@ -10,8 +11,41 @@ box::use(
 
 test_that <- getFromNamespace("test_that", "testthat")
 expect_equal <- getFromNamespace("expect_equal", "testthat")
+expect_no_error <- getFromNamespace("expect_no_error", "testthat")
 expect_null <- getFromNamespace("expect_null", "testthat")
 expect_warning <- getFromNamespace("expect_warning", "testthat")
+
+# -- resolve_na_handling ------------------------------------------------------
+
+test_that("resolve_na_handling defaults to 'stop' in a non-interactive session without aborting", {
+  # issue #401: the non-interactive default must not be able to halt the run
+  # by itself; handle_missing_values() is what decides whether missing
+  # optional values are actually fatal (they are not).
+  box::use(
+    artma / data / configure[resolve_na_handling],
+    artma / data / na_handling[handle_missing_values]
+  )
+
+  withr::local_options(list(
+    "artma.data.na_handling" = NULL,
+    "artma.verbose" = 1
+  ))
+
+  df <- data.frame(
+    study_id = c("a", "b", "c"),
+    effect = c(0.1, 0.2, 0.3),
+    se = c(0.01, 0.02, 0.03),
+    n_obs = c(10L, 20L, 30L),
+    moderator = c(1, NA, 3),
+    stringsAsFactors = FALSE
+  )
+
+  resolve_na_handling(df)
+  expect_equal(getOption("artma.data.na_handling"), "stop")
+
+  expect_no_error(result <- handle_missing_values(df))
+  expect_equal(nrow(result), 3)
+})
 
 # -- resolve_se_zero_handling ------------------------------------------------------
 

--- a/tests/testthat/test-data-na-handling.R
+++ b/tests/testthat/test-data-na-handling.R
@@ -4,6 +4,7 @@ box::use(
     expect_error,
     expect_false,
     expect_message,
+    expect_no_error,
     expect_true,
     test_that
   ],
@@ -14,6 +15,7 @@ test_that <- getFromNamespace("test_that", "testthat")
 expect_equal <- getFromNamespace("expect_equal", "testthat")
 expect_error <- getFromNamespace("expect_error", "testthat")
 expect_true <- getFromNamespace("expect_true", "testthat")
+expect_no_error <- getFromNamespace("expect_no_error", "testthat")
 
 # Required columns are study_id, effect, se, n_obs (CONST$DATA$REQUIRED_COLNAMES).
 make_df <- function(study_id = c("a", "b", "c")) {
@@ -141,6 +143,53 @@ test_that("'stop' aborts on NAs in numeric required columns", {
   df <- make_df()
   df$effect[2] <- NA_real_
   expect_error(handle_missing_values(df), "required columns")
+})
+
+test_that("'stop' leaves NAs in optional columns as-is instead of aborting", {
+  # issue #401: a missing value in a column no method needs must not halt a
+  # non-interactive run.
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "stop",
+    "artma.verbose" = 1
+  ))
+
+  df <- make_df()
+  df$moderator <- c(1, NA, 3)
+
+  expect_no_error(result <- handle_missing_values(df))
+  expect_equal(nrow(result), 3)
+  expect_true(is.na(result$moderator[2]))
+})
+
+test_that("'stop' still aborts on NAs in required columns alongside optional NAs", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "stop",
+    "artma.verbose" = 1
+  ))
+
+  df <- make_df()
+  df$effect[2] <- NA_real_
+  df$moderator <- c(1, NA, 3)
+
+  expect_error(handle_missing_values(df), "required columns")
+})
+
+test_that("'stop' names the affected optional columns in its message", {
+  box::use(artma / data / na_handling[handle_missing_values])
+
+  local_options(list(
+    "artma.data.na_handling" = "stop",
+    "artma.verbose" = 2
+  ))
+
+  df <- make_df()
+  df$moderator <- c(1, NA, 3)
+
+  expect_message(handle_missing_values(df), "moderator")
 })
 
 test_that("'median' imputes NAs in numeric required columns", {


### PR DESCRIPTION
## Problem

Non-interactive sessions can't be prompted for `artma.data.na_handling`, so they resolve to the `"stop"` default. Any missing value in *any* optional column then hard-aborted the whole run, even when the sparse column was never mapped to a required role and no requested method used it. In a validation pass this fired on 3 of 4 real published meta-analysis datasets, every time on incidental gaps in secondary moderator columns.

## Fix

`handle_missing_values()` (`inst/artma/data/na_handling.R`) now scopes the `"stop"` strategy to required columns only. By the time its switch statement is reached, required columns are already guaranteed complete (a required-column NA aborts earlier, unconditionally). So `"stop"` on optional-column NAs now leaves those columns untouched and reports the affected columns and counts via `cli`, instead of aborting.

Required columns keep their strict behavior unchanged:
- non-numeric required columns (e.g. `study_id`) still can't be missing under `"stop"`
- numeric required columns (e.g. `effect`, `se`) still abort under `"stop"`

This makes the non-interactive default in `resolve_na_handling()` (`inst/artma/data/configure.R`) safe to fall back to unattended, since it no longer risks halting a run over a column no method needs. Updated the option template help text and the interactive prompt's strategy descriptions to match, since the docs already described `"stop"` as governing "non-required columns" but the implementation didn't honor that.

Scoped to the non-interactive policy for optional columns only; does not touch #402 (treating the literal string `"na"` as missing) or #400 (the global required-column gate).

## Tests

- `'stop' leaves NAs in optional columns as-is instead of aborting`
- `'stop' still aborts on NAs in required columns alongside optional NAs`
- `'stop' names the affected optional columns in its message`
- `resolve_na_handling defaults to 'stop' in a non-interactive session without aborting`

Full suite: 2714 passed, 0 failed (14 pre-existing skips unrelated to this change, e.g. forking unavailable).

Fixes #401