### PR TITLE
fix(bma): exclude derived effect/se encodings from auto-selected moderators

### DIFF
--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -56,6 +56,7 @@ CONST <- list(
       BMA = "bma",
       BMA_REFERENCE_VAR = "bma_reference_var",
       BMA_TO_LOG = "bma_to_log",
+      BMA_ALLOW_DERIVED = "bma_allow_derived",
       BPE = "bpe",
       BPE_SUM_STATS = "bpe_sum_stats",
       BPE_EQUAL = "bpe_equal",

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -214,7 +214,7 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
     artma / econometric / bma[get_bma_data, find_optimal_bma_formula],
     artma / libs / core / validation[assert, validate, validate_columns],
     artma / libs / core / utils[get_verbosity],
-    artma / variable / bma[get_bma_priority_variables]
+    artma / variable / bma[flag_derived_bma_candidates, get_bma_priority_variables]
   )
 
   if (is.null(verbosity)) {
@@ -279,6 +279,31 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
 
   if (!length(bma_vars)) {
     return(list(skipped = "No valid BMA variables available"))
+  }
+
+  # Configured moderators are used as-is, but warn when one looks like a
+  # derived encoding of the effect or its standard error (winsorized copy,
+  # t-statistic, inverse SE, ...): configs saved by older versions can carry
+  # such columns, and they silently corrupt the BMA results. Set bma: false on
+  # the column to drop it, or bma_allow_derived: true to keep it and silence
+  # this warning.
+  derived <- flag_derived_bma_candidates(
+    df,
+    setdiff(bma_vars, get_bma_priority_variables()),
+    config = config
+  )
+  if (nrow(derived) && verbosity >= 2) {
+    cli::cli_alert_warning(
+      "{nrow(derived)} configured BMA moderator{?s} look{?s/} like derived encoding{?s} of the effect or its standard error: {.val {derived$var_name}}"
+    )
+    details <- sprintf(
+      "%s: |cor| = %.3f with %s",
+      derived$var_name, derived$correlation, derived$target
+    )
+    cli::cli_bullets(stats::setNames(details, rep("*", length(details))))
+    cli::cli_inform(
+      "Regressing the effect on an encoding of itself hides every genuine moderator and drags the best-practice estimate toward the sample mean. Set {.code bma: false} on {cli::qty(nrow(derived))}{?this/these} column{?s} in the data config, or {.code bma_allow_derived: true} to keep {?it/them} and silence this warning."
+    )
   }
 
   # Only include 'effect' as required (dependent variable)

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -965,7 +965,11 @@ data:
       Besides {.strong source_name}, each record can override analysis fields such as
       var_name_verbose, var_name_description, data_type, group_category,
       variable_summary, effect_sum_stats, equal, gltl, bma, bma_reference_var,
-      bma_to_log, bpe, bpe_sum_stats, bpe_equal, and bpe_gltl.
+      bma_to_log, bma_allow_derived, bpe, bpe_sum_stats, bpe_equal, and bpe_gltl.
+      {.strong bma_allow_derived} keeps a column in the BMA moderator set even when
+      it is detected as a derived encoding of the effect or its standard error
+      (e.g. a winsorized copy, t-statistic, or inverse SE), which is otherwise
+      excluded from automatic selection and warned about when configured explicitly.
       {.strong group_category} sets the display label used to group variables together
       (e.g. in BMA plots); it does not change whether a variable is structurally
       detected as a dummy/categorical/transformation group, which is still inferred

--- a/inst/artma/variable/bma.R
+++ b/inst/artma/variable/bma.R
@@ -1,6 +1,7 @@
 #' @title BMA Variable Suggestion
-#' @description Suggest variables for Bayesian Model Averaging with collinearity
-#'   detection and priority mechanism for important variables.
+#' @description Suggest variables for Bayesian Model Averaging with
+#'   derived-encoding exclusion, collinearity detection, and a priority
+#'   mechanism for important variables.
 
 #' @title Get priority variables for BMA
 #' @description Returns a list of variables that should be prioritized for BMA
@@ -11,6 +12,177 @@ get_bma_priority_variables <- function() {
     "se", # Standard error - critical for meta-analysis
     "study_size" # Sample size - theoretical importance
   )
+}
+
+#' @title Detect derived encodings of the effect or standard error
+#' @description Flags candidate moderators that are near-deterministic
+#'   transforms of the effect or its standard error, such as winsorized
+#'   copies, t-statistics, or inverse standard errors. Meta-analysis datasets
+#'   commonly ship such helper columns (e.g. `<effect>_w`, `tstat`, `invse`);
+#'   letting one into the moderator set makes BMA regress the effect on an
+#'   encoding of itself, which drives the inclusion probability of every
+#'   genuine moderator toward zero and collapses downstream estimates (e.g.
+#'   the best-practice estimate) to roughly the sample mean.
+#'
+#'   A candidate is flagged when its absolute correlation with any target
+#'   series reaches `cor_threshold`. Targets are the effect, the standard
+#'   error, and (when the standard error is available) the derived precision
+#'   (1/se) and t-statistic (effect/se). Two correlation measures are taken
+#'   per target and the larger one wins: Spearman rank correlation, which
+#'   catches any monotone transform (winsorization, log, inverse), and
+#'   Pearson correlation after clipping both series at their 1st and 99th
+#'   percentiles, which catches near-linear copies without letting a few
+#'   outliers mask the relationship.
+#' @param df *\[data.frame\]* The data frame; must contain an `effect` column
+#'   for the effect-based targets and an `se` column for the SE-based ones.
+#' @param var_names *\[character\]* Candidate variable names to test.
+#' @param cor_threshold *\[numeric\]* Absolute correlation at or above which a
+#'   candidate counts as a derived encoding. Defaults to 0.9.
+#' @param min_complete_pairs *\[integer\]* Minimum number of complete pairs
+#'   required before a correlation is computed. Defaults to 10.
+#' @return *\[data.frame\]* One row per flagged candidate, with columns:
+#'   - `var_name` (character) - the flagged candidate
+#'   - `target` (character) - label of the best-matching target series
+#'   - `correlation` (numeric) - the winning absolute correlation
+detect_derived_effect_encodings <- function(
+  df,
+  var_names,
+  cor_threshold = 0.9,
+  min_complete_pairs = 10
+) {
+  box::use(artma / libs / core / validation[validate])
+
+  validate(
+    is.data.frame(df),
+    is.character(var_names),
+    is.numeric(cor_threshold),
+    is.numeric(min_complete_pairs)
+  )
+
+  empty <- data.frame(
+    var_name = character(0),
+    target = character(0),
+    correlation = numeric(0),
+    stringsAsFactors = FALSE
+  )
+
+  var_names <- intersect(var_names, names(df))
+  if (!length(var_names)) {
+    return(empty)
+  }
+
+  targets <- list()
+  if ("effect" %in% names(df) && is.numeric(df$effect)) {
+    effect <- as.numeric(df$effect)
+    targets[["effect"]] <- effect
+  }
+  if ("se" %in% names(df) && is.numeric(df$se)) {
+    se <- as.numeric(df$se)
+    targets[["se"]] <- se
+    safe_se <- se
+    safe_se[!is.finite(safe_se) | safe_se == 0] <- NA_real_
+    targets[["1/se (precision)"]] <- 1 / safe_se
+    if (!is.null(targets[["effect"]])) {
+      targets[["effect/se (t-statistic)"]] <- targets[["effect"]] / safe_se
+    }
+  }
+
+  if (!length(targets)) {
+    return(empty)
+  }
+
+  clip_tails <- function(x) {
+    bounds <- stats::quantile(x, probs = c(0.01, 0.99), names = FALSE, type = 7)
+    pmin(pmax(x, bounds[1]), bounds[2])
+  }
+
+  rows <- lapply(var_names, function(var_name) {
+    x <- df[[var_name]]
+    if (!is.numeric(x)) {
+      return(NULL)
+    }
+    x <- as.numeric(x)
+
+    best_target <- NA_character_
+    best_cor <- -Inf
+
+    for (target_name in names(targets)) {
+      t_vals <- targets[[target_name]]
+      ok <- is.finite(x) & is.finite(t_vals)
+      if (sum(ok) < min_complete_pairs) {
+        next
+      }
+      xs <- x[ok]
+      ts <- t_vals[ok]
+
+      cors <- suppressWarnings(c(
+        stats::cor(clip_tails(xs), clip_tails(ts)),
+        stats::cor(xs, ts, method = "spearman")
+      ))
+      cors <- abs(cors[is.finite(cors)])
+      if (!length(cors)) {
+        next
+      }
+
+      score <- max(cors)
+      if (score > best_cor) {
+        best_cor <- score
+        best_target <- target_name
+      }
+    }
+
+    if (!is.finite(best_cor) || best_cor < cor_threshold) {
+      return(NULL)
+    }
+
+    data.frame(
+      var_name = var_name,
+      target = best_target,
+      correlation = best_cor,
+      stringsAsFactors = FALSE
+    )
+  })
+
+  rows <- Filter(Negate(is.null), rows)
+  if (!length(rows)) {
+    return(empty)
+  }
+
+  do.call(rbind, rows)
+}
+
+#' @title Filter out derived encodings of the effect or standard error
+#' @description Runs `detect_derived_effect_encodings()` on the given
+#'   candidates, honors per-column `bma_allow_derived` overrides from the data
+#'   config, and reports what was flagged. Shared by the automatic suggestion
+#'   path (which drops the flagged candidates) and the config-driven path in
+#'   the bma method (which only warns).
+#' @param df *\[data.frame\]* The data frame
+#' @param var_names *\[character\]* Candidate variable names to test
+#' @param config *\[list, optional\]* Data configuration with per-column
+#'   entries; entries with `bma_allow_derived = TRUE` are never flagged.
+#' @return *\[data.frame\]* The flagged subset, in the shape returned by
+#'   `detect_derived_effect_encodings()`.
+flag_derived_bma_candidates <- function(df, var_names, config = NULL) {
+  box::use(artma / libs / core / utils[get_verbosity])
+
+  derived <- detect_derived_effect_encodings(df, var_names)
+
+  if (nrow(derived) && length(config)) {
+    allowed <- vapply(derived$var_name, function(v) {
+      isTRUE(config[[make.names(v)]]$bma_allow_derived)
+    }, logical(1))
+
+    if (any(allowed) && get_verbosity() >= 3) {
+      cli::cli_inform(
+        "Keeping {.val {derived$var_name[allowed]}} as BMA moderator candidate{?s} despite high correlation with the effect/SE ({.code bma_allow_derived} is set in the data config)."
+      )
+    }
+
+    derived <- derived[!allowed, , drop = FALSE]
+  }
+
+  derived
 }
 
 #' @title Detect perfect collinearity in variable set
@@ -276,8 +448,9 @@ remove_dummy_trap_variables <- function(df, var_names, priority_vars = character
 }
 
 #' @title Suggest variables for BMA with collinearity checking
-#' @description Suggests variables for Bayesian Model Averaging, ensuring no
-#'   perfect collinearity and prioritizing important variables.
+#' @description Suggests variables for Bayesian Model Averaging, excluding
+#'   derived encodings of the effect or its standard error, ensuring no
+#'   perfect collinearity, and prioritizing important variables.
 #' @param df *\[data.frame\]* The data frame
 #' @param config *\[list, optional\]* Data configuration
 #' @param min_obs_per_split *\[numeric\]* Minimum observations for splits
@@ -363,6 +536,37 @@ suggest_variables_for_bma <- function(
     )
   }
 
+  # Step 0: Exclude derived encodings of the effect or its standard error
+  # (winsorized copies, t-statistics, inverse SEs, ...). These pass the type,
+  # variance, and perfect-collinearity filters below, yet keeping one makes
+  # BMA regress the effect on an encoding of itself. Priority variables are
+  # exempt: the se term is included by convention.
+  derived_candidates <- setdiff(
+    base_suggestions$var_name[base_suggestions$suggested],
+    all_priority
+  )
+  derived <- flag_derived_bma_candidates(df, derived_candidates, config = config)
+
+  if (nrow(derived)) {
+    if (get_verbosity() >= 2) {
+      cli::cli_alert_warning(
+        "Excluding {nrow(derived)} candidate moderator{?s} detected as derived encoding{?s} of the effect or its standard error: {.val {derived$var_name}}"
+      )
+      details <- sprintf(
+        "%s: |cor| = %.3f with %s",
+        derived$var_name, derived$correlation, derived$target
+      )
+      cli::cli_bullets(stats::setNames(details, rep("*", length(details))))
+      cli::cli_inform(
+        "Such columns make BMA regress the effect on a transform of itself, hiding every genuine moderator. To keep one anyway, set {.code bma_allow_derived: true} on its data config entry."
+      )
+    }
+    base_suggestions <- base_suggestions[
+      !base_suggestions$var_name %in% derived$var_name, ,
+      drop = FALSE
+    ]
+  }
+
   # Get variable names
   suggested_vars <- base_suggestions$var_name
 
@@ -411,8 +615,10 @@ suggest_variables_for_bma <- function(
 
 box::export(
   suggest_variables_for_bma,
+  detect_derived_effect_encodings,
   detect_perfect_collinearity,
   detect_dummy_traps,
+  flag_derived_bma_candidates,
   remove_collinear_variables,
   remove_dummy_trap_variables,
   get_bma_priority_variables

--- a/tests/testthat/test-bma-derived-encodings.R
+++ b/tests/testthat/test-bma-derived-encodings.R
@@ -1,0 +1,226 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_message,
+    expect_true,
+    test_that
+  ],
+  withr[local_options]
+)
+
+box::use(
+  artma / methods / bma[prepare_bma_inputs],
+  artma / variable / bma[
+    detect_derived_effect_encodings,
+    flag_derived_bma_candidates,
+    suggest_variables_for_bma
+  ]
+)
+
+#' Tests for derived-encoding detection in BMA moderator selection
+#'
+#' Published meta-analysis datasets commonly ship helper columns derived from
+#' the effect or its standard error (winsorized copies, t-statistics, inverse
+#' SEs). These must never enter the BMA moderator set automatically: the model
+#' would regress the effect on an encoding of itself, zeroing out every
+#' genuine moderator and collapsing the best-practice estimate to the sample
+#' mean. Column names mirror a real case (armel_w, se_w, tstats, invse in the
+#' Armington dataset) and deliberately dodge the name-based group heuristics,
+#' so only the correlation-based detection can catch them.
+
+winsorize_at <- function(x, level = 0.025) {
+  bounds <- stats::quantile(x, probs = c(level, 1 - level), names = FALSE)
+  pmin(pmax(x, bounds[1]), bounds[2])
+}
+
+make_derived_encodings_data <- function() {
+  set.seed(2024)
+  n <- 120L
+  effect <- rnorm(n, mean = 1.5, sd = 1.2)
+  se <- runif(n, min = 0.1, max = 1.5)
+
+  data.frame(
+    study_id = rep(paste0("S", seq_len(20L)), each = 6L),
+    effect = effect,
+    se = se,
+    # Derived encodings that ship with many published datasets
+    effect_w = winsorize_at(effect),
+    se_w = winsorize_at(se),
+    tstats = effect / se,
+    invse = 1 / se,
+    # Genuine moderators
+    noise = rnorm(n, mean = 10, sd = 3),
+    dummy_us = sample(c(0, 1), n, replace = TRUE),
+    stringsAsFactors = FALSE
+  )
+}
+
+make_derived_encodings_config <- function() {
+  vars <- c(
+    "effect", "se", "effect_w", "se_w", "tstats", "invse", "noise", "dummy_us"
+  )
+  types <- c(
+    effect = "float", se = "float", effect_w = "float", se_w = "float",
+    tstats = "float", invse = "float", noise = "float", dummy_us = "dummy"
+  )
+  stats::setNames(
+    lapply(vars, function(v) {
+      list(var_name = v, data_type = types[[v]], bma = NA)
+    }),
+    vars
+  )
+}
+
+
+# Detection -------------------------------------------------------------------
+
+test_that("detect_derived_effect_encodings flags transforms of effect and se", {
+  df <- make_derived_encodings_data()
+
+  flagged <- detect_derived_effect_encodings(
+    df,
+    c("effect_w", "se_w", "tstats", "invse", "noise", "dummy_us")
+  )
+
+  expect_true(all(c("effect_w", "se_w", "tstats", "invse") %in% flagged$var_name))
+  expect_false("noise" %in% flagged$var_name)
+  expect_false("dummy_us" %in% flagged$var_name)
+  expect_true(all(flagged$correlation >= 0.9))
+  expect_true(all(!is.na(flagged$target)))
+})
+
+test_that("detect_derived_effect_encodings works without an se column", {
+  df <- make_derived_encodings_data()
+  df <- df[, c("effect", "effect_w", "noise")]
+
+  flagged <- detect_derived_effect_encodings(df, c("effect_w", "noise"))
+
+  expect_true("effect_w" %in% flagged$var_name)
+  expect_false("noise" %in% flagged$var_name)
+})
+
+test_that("detect_derived_effect_encodings skips non-numeric and sparse columns", {
+  df <- make_derived_encodings_data()
+  df$label <- sample(letters, nrow(df), replace = TRUE)
+  df$sparse_copy <- df$effect
+  df$sparse_copy[seq_len(nrow(df) - 5L)] <- NA_real_
+
+  flagged <- detect_derived_effect_encodings(df, c("label", "sparse_copy"))
+
+  expect_equal(nrow(flagged), 0L)
+})
+
+test_that("detect_derived_effect_encodings returns empty for empty candidates", {
+  df <- make_derived_encodings_data()
+
+  flagged <- detect_derived_effect_encodings(df, character(0))
+
+  expect_equal(nrow(flagged), 0L)
+  expect_equal(names(flagged), c("var_name", "target", "correlation"))
+})
+
+test_that("flag_derived_bma_candidates honors the bma_allow_derived override", {
+  local_options(list(artma.verbose = 0))
+  df <- make_derived_encodings_data()
+
+  flagged_all <- flag_derived_bma_candidates(
+    df, c("effect_w", "tstats"),
+    config = NULL
+  )
+  expect_true(all(c("effect_w", "tstats") %in% flagged_all$var_name))
+
+  config <- list(
+    effect_w = list(var_name = "effect_w", bma_allow_derived = TRUE)
+  )
+  flagged <- flag_derived_bma_candidates(
+    df, c("effect_w", "tstats"),
+    config = config
+  )
+  expect_false("effect_w" %in% flagged$var_name)
+  expect_true("tstats" %in% flagged$var_name)
+})
+
+
+# Suggestion integration ------------------------------------------------------
+
+test_that("suggest_variables_for_bma excludes derived encodings and warns", {
+  local_options(list(artma.verbose = 3))
+  df <- make_derived_encodings_data()
+  config <- make_derived_encodings_config()
+
+  suggestions <- NULL
+  expect_message(
+    suggestions <- suggest_variables_for_bma(df, config = config),
+    "derived encoding"
+  )
+
+  suggested <- suggestions$var_name[suggestions$suggested]
+
+  expect_false(any(c("effect_w", "se_w", "tstats", "invse") %in% suggested))
+  expect_true("noise" %in% suggested)
+  expect_true("se" %in% suggested) # priority variable stays by convention
+})
+
+test_that("suggest_variables_for_bma keeps a whitelisted derived column", {
+  local_options(list(artma.verbose = 0))
+  df <- make_derived_encodings_data()
+  config <- make_derived_encodings_config()
+  config$effect_w$bma_allow_derived <- TRUE
+
+  suggestions <- suggest_variables_for_bma(df, config = config)
+  suggested <- suggestions$var_name[suggestions$suggested]
+
+  expect_true("effect_w" %in% suggested)
+  expect_false(any(c("se_w", "tstats", "invse") %in% suggested))
+})
+
+
+# Configured moderators (prepare_bma_inputs) ----------------------------------
+
+test_that("prepare_bma_inputs warns about configured derived moderators but keeps them", {
+  local_options(list(artma.verbose = 1))
+  df <- make_derived_encodings_data()
+  config <- list(
+    se = list(var_name = "se", bma = TRUE),
+    noise = list(var_name = "noise", bma = TRUE),
+    effect_w = list(var_name = "effect_w", bma = TRUE)
+  )
+
+  prepared <- NULL
+  expect_message(
+    prepared <- prepare_bma_inputs(
+      df, config,
+      use_vif_optimization = FALSE,
+      max_groups_to_remove = 3,
+      verbosity = 2
+    ),
+    "derived encoding"
+  )
+
+  # Explicit configuration wins: the column stays in the model data
+  expect_true("effect_w" %in% colnames(prepared$bma_data))
+})
+
+test_that("prepare_bma_inputs stays quiet when the derived moderator is whitelisted", {
+  local_options(list(artma.verbose = 1))
+  df <- make_derived_encodings_data()
+  config <- list(
+    se = list(var_name = "se", bma = TRUE),
+    noise = list(var_name = "noise", bma = TRUE),
+    effect_w = list(
+      var_name = "effect_w", bma = TRUE, bma_allow_derived = TRUE
+    )
+  )
+
+  msgs <- testthat::capture_messages(
+    prepare_bma_inputs(
+      df, config,
+      use_vif_optimization = FALSE,
+      max_groups_to_remove = 3,
+      verbosity = 2
+    )
+  )
+
+  expect_false(any(grepl("derived encoding", msgs)))
+})

--- a/tests/testthat/test-data-config-defaults.R
+++ b/tests/testthat/test-data-config-defaults.R
@@ -84,7 +84,8 @@ test_that("build_default_config_entry: entry has all expected fields", {
     "var_name", "var_name_verbose", "var_name_description",
     "data_type", "group_category", "variable_summary",
     "effect_sum_stats", "equal", "gltl", "bma", "bma_reference_var",
-    "bma_to_log", "bpe", "bpe_sum_stats", "bpe_equal", "bpe_gltl"
+    "bma_to_log", "bma_allow_derived", "bpe", "bpe_sum_stats",
+    "bpe_equal", "bpe_gltl"
   )
   expect_equal(sort(names(entry)), sort(expected_fields))
 })

--- a/vignettes/methods-overview.Rmd
+++ b/vignettes/methods-overview.Rmd
@@ -73,6 +73,17 @@ variables; the standard-error term acts as a publication-bias control inside
 BMA by convention. They show up in the Model Averaging results alongside your
 own moderators, and a note is printed during variable selection.
 
+Automatic selection also excludes columns detected as derived encodings of
+the effect or its standard error, such as winsorized copies of the effect,
+t-statistics, or inverse standard errors, which many published datasets ship
+alongside the raw variables. Keeping one would make BMA regress the effect on
+a transform of itself, hiding every genuine moderator. Detection is based on
+rank and outlier-clipped correlations with the effect, the SE, 1/se, and
+effect/se (threshold 0.9); excluded columns are listed in a warning. If such
+a column is configured explicitly (`bma: true`), it is kept but warned about.
+To keep one on purpose without warnings, set `bma_allow_derived: true` on its
+entry in the data config.
+
 `robma` needs the `RoBMA` package, which in turn requires a working JAGS
 installation (via `rjags`). On Windows, CRAN's RoBMA source can fail to
 compile against JAGS 4.3.1; if RoBMA is not installed, the method is skipped


### PR DESCRIPTION
## Problem

BMA moderator auto-selection includes derived encodings of the effect or its standard error when the dataset ships them: winsorized copies, t-statistics, inverse SEs. The existing filters (type, variance, dummy traps, perfect collinearity) don't catch them because a winsorized copy is not perfectly collinear with anything.

Confirmed on the Armington dataset (Bajzik, Havranek, Irsova, Schwarz 2020, JIE; 3,524 rows): the auto-selected set included armel_w (PIP 1.000, post mean 0.94: the model regresses the effect on its own winsorized copy), plus tstats, invse, invse_w, tstats_w, and se_w. Every genuine moderator then gets near-zero PIP and the best-practice estimate collapses to roughly the sample mean. Datasets on meta-analysis.cz commonly ship such columns, and the inclusion was silent at default verbosity.

## Fix

- New `detect_derived_effect_encodings()` in `inst/artma/variable/bma.R`: flags candidates whose absolute correlation with the effect, the SE, 1/se, or effect/se reaches 0.9. Per target it takes the larger of Spearman rank correlation (catches any monotone transform: winsorization, log, inverse) and Pearson after clipping both series at the 1st/99th percentiles (catches near-linear copies without outliers masking them). Name patterns are not used, so it works regardless of how the columns are labeled.
- `suggest_variables_for_bma()` drops flagged candidates before the dummy-trap and collinearity steps and warns at default verbosity, listing each column with its winning correlation and matched target. Priority variables (`se`, `study_size`) are exempt since the SE term is included by convention.
- `prepare_bma_inputs()` warns (but keeps the column) when an explicitly configured moderator (`bma: true`, e.g. saved by an older run of the auto-selector) looks derived, so existing corrupted configs get a loud signal with fix instructions.
- New per-column data-config field `bma_allow_derived: true` whitelists a column back in and silences both paths, for the rare case a user genuinely wants it.

## Verification

On the real Armington CSV, the new logic excludes all seven derived columns (armel_w |cor|=1.000 with effect, se_w and invse_w 1.000 with se, invse 1.000 with 1/se, tstats 0.981 and tstats_w 0.980 with effect/se, se_lrun 0.907 with se) while keeping 58 genuine moderators including `se`.

Regression tests in `tests/testthat/test-bma-derived-encodings.R` use column names mirroring the real case, chosen to dodge the name-based group heuristics so only the correlation detection can catch them. Full suite: 2,728 passing, 0 failures.