### PR TITLE
fix(data): only hard-require columns the requested methods need

### DIFF
--- a/R/artma.R
+++ b/R/artma.R
@@ -158,7 +158,7 @@ artma <- function(
 
     # Prepare data: use provided data or load from options
     if (is.null(data)) {
-      df <- prepare_data()
+      df <- prepare_data(methods = methods)
     } else {
       # User provided data directly - still need to preprocess and compute.
       # Mirror prepare_data's phases: decide the NA strategy (configure), run

--- a/inst/artma/data/index.R
+++ b/inst/artma/data/index.R
@@ -20,18 +20,28 @@ box::use(
 # The raw data frame is read exactly once per run (in `prepare_data`) and handed
 # to the cached compute phase through this module-scoped env, so the compute
 # cache key stays keyed only on `build_data_cache_signature()` rather than on the
-# hashed data frame content.
+# hashed data frame content. The requested methods ride along the same env so
+# the compute phase can resolve the same run-specific required-column set as
+# the configure phase, without becoming part of the cache key: the resolved
+# set only ever gates an abort, and that gate always runs afresh in the
+# uncached configure phase below, so cache warmth cannot hide a genuine miss.
 .raw_env <- new.env(parent = emptyenv())
 
 #' @title Prime the raw data frame for the compute phase
-#' @description Store the raw data frame that `compute_data_impl()` reads. Called
-#'   by `prepare_data()` after its single disk read; also usable by tests that
-#'   drive the compute phase in isolation.
+#' @description Store the raw data frame that `compute_data_impl()` reads, plus
+#'   the methods requested for this run (used to narrow the hard-required
+#'   column set; see `artma / data / method_requirements
+#'   [resolve_hard_required_colnames]`). Called by `prepare_data()` after its
+#'   single disk read; also usable by tests that drive the compute phase in
+#'   isolation.
 #' @param df_raw *[data.frame]* Raw data frame with original column names.
+#' @param methods *[character, optional]* The methods requested for this run,
+#'   as passed to `artma()`. Defaults to `NULL` (unresolved selection).
 #' @return `NULL`, invisibly.
 #' @keywords internal
-prime_raw_df <- function(df_raw) {
+prime_raw_df <- function(df_raw, methods = NULL) {
   .raw_env$df_raw <- df_raw
+  .raw_env$methods <- methods
   invisible(NULL)
 }
 
@@ -41,26 +51,40 @@ prime_raw_df <- function(df_raw) {
 #'   before the cached compute phase runs, so compute never prompts and its
 #'   cache key is stable across runs.
 #' @param df_raw *[data.frame]* Raw data frame with original column names.
+#' @param methods *[character, optional]* The methods requested for this run,
+#'   as passed to `artma()`. Narrows the hard-required column set (see
+#'   `artma / data / method_requirements[resolve_hard_required_colnames]`).
+#'   Defaults to `NULL`, which keeps the full historical required set.
 #' @return `NULL`, invisibly.
 #' @keywords internal
-configure_data <- function(df_raw) {
+configure_data <- function(df_raw, methods = NULL) {
   box::use(
     artma / data / utils[standardize_column_names],
+    artma / data / method_requirements[resolve_hard_required_colnames],
     artma / data / schema_reconcile[reconcile_schema],
     artma / data / preprocess[clean_data],
     artma / data / configure[resolve_na_handling, resolve_se_zero_handling]
   )
 
+  # This is the run's hard-required-column gate: it runs on every
+  # prepare_data() call (this phase is never cached), so a method list that
+  # newly needs a column re-evaluates the check even when the compute phase
+  # below would otherwise hit a stale cache.
+  required_colnames <- resolve_hard_required_colnames(methods)
+
   # Detect and resolve any schema drift before column standardization. This may
-  # prompt and updates both in-memory and persisted config.
+  # prompt and updates both in-memory and persisted config. Passing the same
+  # run-specific required set keeps a column no requested method needs (e.g.
+  # n_obs) from forcing schema reconciliation itself to abort or prompt when
+  # it is genuinely absent and was never explicitly mapped.
   mode <- getOption("artma.data.reconcile_mode", "ask")
-  reconcile_schema(df_raw, mode = mode)
+  reconcile_schema(df_raw, mode = mode, required_colnames = required_colnames)
 
   # Decide the missing-value and zero-SE strategies on the cleaned, standardized
   # frame so the compute phase can handle both without prompting. Standardize
   # quietly: this frame is a configure-phase intermediate, and the compute phase
   # standardizes the same raw frame again with messages on.
-  df_std <- standardize_column_names(df_raw, quiet = TRUE)
+  df_std <- standardize_column_names(df_raw, quiet = TRUE, required_colnames = required_colnames)
   df_clean <- clean_data(df_std)
   resolve_na_handling(df_clean)
   resolve_se_zero_handling(df_clean)
@@ -78,6 +102,7 @@ configure_data <- function(df_raw) {
 compute_data_impl <- function() {
   box::use(
     artma / data / utils[standardize_column_names],
+    artma / data / method_requirements[resolve_hard_required_colnames],
     artma / data_config / resolve[prime_df_for_config_cache],
     artma / data / preprocess[preprocess_data],
     artma / data / compute[compute_optional_columns]
@@ -85,8 +110,13 @@ compute_data_impl <- function() {
 
   df_raw <- .raw_env$df_raw
 
-  # Apply colnames map (now updated if drift was reconciled in configure)
-  df <- standardize_column_names(df_raw)
+  # Apply colnames map (now updated if drift was reconciled in configure). The
+  # configure phase already ran this same gate (uncached, always), so this
+  # cannot abort here on a path configure_data() didn't already clear; it is
+  # recomputed rather than cached alongside df_raw purely so this call reports
+  # the same run-specific required set the configure phase used.
+  required_colnames <- resolve_hard_required_colnames(.raw_env$methods)
+  df <- standardize_column_names(df_raw, required_colnames = required_colnames)
 
   prime_df_for_config_cache(df)
   df <- preprocess_data(df)
@@ -119,8 +149,14 @@ persist_data <- function(df) {
 #'   cleaning, and validating the data. Orchestrates the configure, compute, and
 #'   persist phases. Only the compute phase is cached; the configure and persist
 #'   side effects always run, warm or cold cache.
+#' @param methods *[character, optional]* The methods requested for this run,
+#'   as passed to `artma()`. Narrows the raw columns the data pipeline hard-
+#'   requires to just what the compute stage and these methods actually need
+#'   (see `artma / data / method_requirements[resolve_hard_required_colnames]`).
+#'   Defaults to `NULL`, which keeps the full historical required set (used
+#'   when the method selection is not yet resolved, e.g. an interactive menu).
 #' @return *[data.frame]* The prepared data frame.
-prepare_data <- function() {
+prepare_data <- function(methods = NULL) {
   box::use(
     artma / libs / core / utils[get_verbosity],
     artma / data / read[read_data]
@@ -132,9 +168,9 @@ prepare_data <- function() {
 
   # Read raw data once and share it with both the configure and compute phases.
   df_raw <- read_data()
-  prime_raw_df(df_raw)
+  prime_raw_df(df_raw, methods)
 
-  configure_data(df_raw) # interactive, uncached
+  configure_data(df_raw, methods) # interactive, uncached
   df <- compute_data() # pure, cached
   persist_data(df) # idempotent, always runs
 

--- a/inst/artma/data/method_requirements.R
+++ b/inst/artma/data/method_requirements.R
@@ -1,0 +1,95 @@
+#' @title Resolve the raw columns the current run cannot proceed without
+#' @description
+#' `standardize_column_names()` hard-aborts when a hard-required raw column is
+#' absent from the data and has no configured mapping. Historically that set
+#' was the fixed `CONST$DATA$REQUIRED_COLNAMES` (`study_id`, `effect`, `se`,
+#' `n_obs`), regardless of which methods were actually requested, so a dataset
+#' missing only `n_obs` aborted even when every requested method (for example
+#' `effect_summary_stats`) never touches it.
+#'
+#' This resolves a narrower, run-specific hard-required set instead:
+#'
+#' * `study_id`, `effect`, and `se` stay unconditionally required. The compute
+#'   stage (`compute_optional_columns()`) always derives `t_stat` from
+#'   `effect`/`se` and normalizes `study_id`/`study_size` from `study_id`,
+#'   regardless of which methods run, so their absence breaks data preparation
+#'   itself rather than any one method.
+#' * `n_obs` is optional-by-default: `add_reg_dof_column()` and
+#'   `add_precision_column()` degrade to `NA` when it is missing rather than
+#'   aborting. It only re-joins the hard-required set when a requested method
+#'   declares a genuine need for it, directly (`n_obs`, `reg_dof`) or
+#'   indirectly (`precision`, but only when `calc.precision_type` is `"DoF"`;
+#'   the default `"1/SE"` never touches `n_obs`).
+#'
+#' `methods` must be a concrete, already-resolved selection to narrow
+#' anything. `NULL` (interactive selection deferred) and `"all"` fall back to
+#' the full historical set, since narrowing either would either be impossible
+#' (the selection is not known yet) or pointless (every non-opt-in method,
+#' including the ones that need `n_obs`, may run). Unknown method names are
+#' likewise ignored here; `invoke_runtime_methods()` reports those.
+#'
+#' This is called from the uncached configure phase of the data pipeline
+#' (`configure_data()`), which runs on every `prepare_data()` call regardless
+#' of whether the cached compute phase hits or misses. That keeps the abort
+#' decision independent of cache warmth: a method list that newly needs
+#' `n_obs` re-evaluates and aborts even when the underlying data frame would
+#' otherwise be served from cache.
+#' @param methods *\[character, optional\]* The methods requested for this run,
+#'   as passed to `artma()`. `NULL` or `"all"` fall back to the full
+#'   historical required set.
+#' @param modules_dir *\[character, optional\]* Directory to discover runtime
+#'   method modules in. Defaults to `NULL`, in which case the standard package
+#'   methods directory is used. Mainly for dependency injection in tests.
+#' @return *\[character\]* The raw columns this run cannot proceed without.
+resolve_hard_required_colnames <- function(methods = NULL, modules_dir = NULL) {
+  box::use(
+    artma / const[CONST],
+    artma / modules / runtime_methods[get_method_metadata, get_runtime_method_modules],
+    artma / options / typed_accessors[get_precision_type]
+  )
+
+  full_required <- CONST$DATA$REQUIRED_COLNAMES
+  base_required <- c("study_id", "effect", "se")
+
+  if (is.factor(methods)) {
+    methods <- as.character(methods)
+  }
+  if (!is.character(methods) || length(methods) == 0L) {
+    # NULL, or any other non-character input: the selection is not yet
+    # resolved (interactive menu) or not usable here. Keep today's behavior.
+    return(full_required)
+  }
+
+  methods <- unique(trimws(methods[!is.na(methods)]))
+  methods <- methods[nzchar(methods)]
+
+  if (length(methods) == 0L || identical(methods, "all")) {
+    # "all" may run every non-opt-in method, including ones that need n_obs.
+    return(full_required)
+  }
+
+  modules <- tryCatch(
+    if (is.null(modules_dir)) get_runtime_method_modules() else get_runtime_method_modules(modules_dir = modules_dir),
+    error = function(e) NULL
+  )
+  if (is.null(modules)) {
+    return(full_required)
+  }
+
+  known_methods <- intersect(methods, names(modules))
+  if (length(known_methods) == 0L) {
+    # Nothing recognized: let invoke_runtime_methods() report the real error.
+    return(full_required)
+  }
+
+  declared_columns <- unique(unlist(lapply(known_methods, function(name) {
+    get_method_metadata(modules[[name]]$run, name = name)$required_columns
+  })))
+
+  needs_n_obs <- any(c("n_obs", "reg_dof") %in% declared_columns) ||
+    ("precision" %in% declared_columns && identical(get_precision_type(), "DoF"))
+
+  if (needs_n_obs) union(base_required, "n_obs") else base_required
+}
+
+box::export(resolve_hard_required_colnames)

--- a/inst/artma/data/schema_detect.R
+++ b/inst/artma/data/schema_detect.R
@@ -18,6 +18,14 @@ is_valid_colname <- function(x) {
 #' @param columns_store *\[list\]* The unified per-column store
 #'   (from `artma.data.columns`): one record per column, keyed by the standard
 #'   name for role columns and by the column's own name for moderators.
+#' @param required *\[character, optional\]* The raw columns treated as required
+#'   for identity-mapping and drift purposes. Defaults to `NULL`, which uses
+#'   the full `get_required_colnames()` set (the historical behavior). Callers
+#'   that know which methods are actually being run pass a narrower,
+#'   run-specific set here; see `artma / data / method_requirements
+#'   [resolve_hard_required_colnames]`. A column outside this set that goes
+#'   missing is reported as a missing moderator instead of a missing role, so
+#'   it never forces schema reconciliation to abort or prompt.
 #' @return *\[list\]* Drift report with fields: `missing_roles` (named character
 #'   vector, names = standard names, values = the stored source columns that
 #'   vanished), `missing_moderators`, `added`, `conflicts` (named character
@@ -25,7 +33,7 @@ is_valid_colname <- function(x) {
 #'   different raw column of the same name, values = the mapped source
 #'   columns), and `has_drift`.
 #' @keywords internal
-detect_schema_drift <- function(raw_df, columns_store) {
+detect_schema_drift <- function(raw_df, columns_store, required = NULL) {
   box::use(
     artma / data / utils[get_required_colnames, get_standardized_colnames],
     artma / const[CONST]
@@ -33,7 +41,9 @@ detect_schema_drift <- function(raw_df, columns_store) {
 
   df_cols <- make.names(colnames(raw_df))
   std_names <- get_standardized_colnames()
-  required <- get_required_colnames()
+  if (is.null(required)) {
+    required <- get_required_colnames()
+  }
 
   if (!is.list(columns_store)) columns_store <- list()
   store_keys <- names(columns_store)

--- a/inst/artma/data/schema_reconcile.R
+++ b/inst/artma/data/schema_reconcile.R
@@ -40,16 +40,25 @@ emit_reconcile_complete <- function() {
 #' @param raw_df *\[data.frame\]* Raw dataframe with original column names.
 #' @param mode *\[character\]* One of `"ask"`, `"auto"`, or `"strict"`. If `NULL`,
 #'   reads from `artma.data.reconcile_mode` option (default: `"ask"`).
+#' @param required_colnames *\[character, optional\]* The raw columns treated as
+#'   required for this run. Defaults to `NULL`, which uses the full
+#'   `get_required_colnames()` set (the historical behavior). Passed through
+#'   to `detect_schema_drift()`; see `artma / data / method_requirements
+#'   [resolve_hard_required_colnames]` for the run-specific, method-aware set.
 #' @return `NULL` invisibly. Side effects: updates options file and in-memory
 #'   state if drift is detected and resolved.
 #' @keywords internal
-reconcile_schema <- function(raw_df, mode = NULL) {
+reconcile_schema <- function(raw_df, mode = NULL, required_colnames = NULL) {
   box::use(
     artma / libs / core / autonomy[should_prompt_user],
-    artma / libs / core / utils[get_verbosity]
+    artma / libs / core / utils[get_verbosity],
+    artma / data / utils[get_required_colnames]
   )
 
   mode <- mode %||% getOption("artma.data.reconcile_mode", "ask")
+  if (is.null(required_colnames)) {
+    required_colnames <- get_required_colnames()
+  }
   current_schema_cols <- unique(make.names(colnames(raw_df)))
   expected_schema_cols <- normalize_expected_schema_cols(
     getOption("artma.data.expected_schema_columns", NA_character_)
@@ -60,7 +69,7 @@ reconcile_schema <- function(raw_df, mode = NULL) {
   columns_store <- get_columns_store()
 
   # Detect drift
-  drift <- detect_schema_drift(raw_df, columns_store)
+  drift <- detect_schema_drift(raw_df, columns_store, required = required_colnames)
 
   if (first_run) {
     # No baseline schema yet: missing/added comparisons are meaningless, so
@@ -124,13 +133,13 @@ reconcile_schema <- function(raw_df, mode = NULL) {
   # Stored role sources (for display) and "unmatched" columns available for
   # fuzzy matching: everything the store does not already account for.
   box::use(
-    artma / data / utils[get_colnames_map, get_required_colnames, get_standardized_colnames]
+    artma / data / utils[get_colnames_map, get_standardized_colnames]
   )
   role_sources <- as.list(drift$missing_roles)
   matched_role_sources <- character(0)
   full_map <- get_colnames_map()
   # Required roles with no explicit record are tracked as identity mappings
-  for (std in setdiff(get_required_colnames(), names(full_map))) {
+  for (std in setdiff(required_colnames, names(full_map))) {
     full_map[[std]] <- std
   }
   for (std in names(full_map)) {

--- a/inst/artma/data/utils.R
+++ b/inst/artma/data/utils.R
@@ -79,8 +79,14 @@ get_number_of_studies <- function(df) {
 #' @param quiet *\[logical, optional\]* Suppress informational messages. Used by
 #'   callers that standardize an intermediate frame (e.g. the configure phase)
 #'   so a single run does not announce the same action twice. Defaults to `FALSE`.
+#' @param required_colnames *\[character, optional\]* The raw columns that must
+#'   be mapped or present for this call to succeed. Defaults to `NULL`, which
+#'   uses the full `get_required_colnames()` set (the historical behavior).
+#'   Callers that know which methods are actually being run pass a narrower,
+#'   run-specific set here; see `artma / data / method_requirements
+#'   [resolve_hard_required_colnames]`.
 #' @return *\[data.frame\]* The standardized data frame
-standardize_column_names <- function(df, quiet = FALSE) {
+standardize_column_names <- function(df, quiet = FALSE, required_colnames = NULL) {
   box::use(
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[validate, assert]
@@ -92,7 +98,9 @@ standardize_column_names <- function(df, quiet = FALSE) {
 
   # Read the column mapping from the unified per-column store
   map <- lapply(get_colnames_map(), make.names) # Handle non-standard column names
-  required_colnames <- get_required_colnames()
+  if (is.null(required_colnames)) {
+    required_colnames <- get_required_colnames()
+  }
 
   # Check that every required column is either mapped or already present
   missing_required <- base::setdiff(required_colnames, c(names(map), names(df)))

--- a/tests/testthat/test-data-method-requirements.R
+++ b/tests/testthat/test-data-method-requirements.R
@@ -1,0 +1,368 @@
+box::use(
+  testthat[expect_equal, expect_error, expect_false, expect_setequal, expect_true, test_that],
+  withr[defer, local_options, local_tempdir]
+)
+
+# Force artma/paths to load now, while box.path is still whatever the test
+# runner started with. The synthetic-method tests below temporarily prepend a
+# tempdir containing its own "artma/" subtree to box.path; get_pkg_path()
+# resolves PATHS$PACKAGE_PATH by picking the first box.path entry that
+# contains an "artma" directory, and that resolution runs (and its result is
+# cached) only the first time artma/paths loads in the session. Loading it
+# here, before any test touches box.path, guarantees that first resolution
+# lands on the real package tree regardless of what other test files happen
+# to run before this one.
+box::use(artma / paths[PATHS])
+
+# Regression coverage for https://github.com/PetrCala/artma/issues/400:
+# standardize_column_names() used to hard-require n_obs (part of the fixed
+# CONST$DATA$REQUIRED_COLNAMES set) regardless of which methods were actually
+# requested, so a dataset with no per-estimate sample size aborted even when
+# every requested method (e.g. effect_summary_stats, which only declares
+# required_columns = c("effect", "study_size")) never touches it.
+# resolve_hard_required_colnames() narrows the hard-required set to what the
+# compute stage and the requested methods genuinely need.
+
+# -- Unit tests: resolve_hard_required_colnames() against synthetic methods --
+#
+# Synthetic runtime method modules, independent of the real (evolving) method
+# roster, so these tests exercise resolve_hard_required_colnames()'s own
+# logic rather than any particular production method's declared columns.
+
+build_synthetic_methods_dir <- function() {
+  # .local_envir must target the caller's frame (the test_that block), not
+  # this helper's own frame - otherwise the tempdir is cleaned up the instant
+  # this function returns, before the caller ever reads from it.
+  temp_root <- local_tempdir(.local_envir = parent.frame())
+  methods_dir <- file.path(temp_root, "artma", "methods")
+  dir.create(methods_dir, recursive = TRUE, showWarnings = FALSE)
+
+  writeLines(c(
+    "box::use(artma / modules / runtime_methods[register_runtime_method])",
+    "run <- register_runtime_method(",
+    "  function(df, ...) df,",
+    "  stage = 'no_n_obs_needed',",
+    "  required_columns = c('effect', 'study_size')",
+    ")"
+  ), file.path(methods_dir, "no_n_obs_needed.R"))
+
+  writeLines(c(
+    "box::use(artma / modules / runtime_methods[register_runtime_method])",
+    "run <- register_runtime_method(",
+    "  function(df, ...) df,",
+    "  stage = 'needs_n_obs',",
+    "  required_columns = c('effect', 'se', 'n_obs')",
+    ")"
+  ), file.path(methods_dir, "needs_n_obs.R"))
+
+  writeLines(c(
+    "box::use(artma / modules / runtime_methods[register_runtime_method])",
+    "run <- register_runtime_method(",
+    "  function(df, ...) df,",
+    "  stage = 'needs_precision',",
+    "  required_columns = c('effect', 'precision')",
+    ")"
+  ), file.path(methods_dir, "needs_precision.R"))
+
+  defer(
+    {
+      try(box::unload("artma/methods/no_n_obs_needed"), silent = TRUE)
+      try(box::unload("artma/methods/needs_n_obs"), silent = TRUE)
+      try(box::unload("artma/methods/needs_precision"), silent = TRUE)
+    },
+    envir = parent.frame()
+  )
+
+  local_options(list(box.path = c(temp_root, getOption("box.path"))), .local_envir = parent.frame())
+
+  methods_dir
+}
+
+
+test_that("resolve_hard_required_colnames keeps the full set when methods is NULL", {
+  box::use(
+    artma / const[CONST],
+    artma / data / method_requirements[resolve_hard_required_colnames]
+  )
+
+  methods_dir <- build_synthetic_methods_dir()
+  expect_setequal(
+    resolve_hard_required_colnames(NULL, modules_dir = methods_dir),
+    CONST$DATA$REQUIRED_COLNAMES
+  )
+})
+
+test_that("resolve_hard_required_colnames keeps the full set for methods = 'all'", {
+  box::use(
+    artma / const[CONST],
+    artma / data / method_requirements[resolve_hard_required_colnames]
+  )
+
+  methods_dir <- build_synthetic_methods_dir()
+  expect_setequal(
+    resolve_hard_required_colnames("all", modules_dir = methods_dir),
+    CONST$DATA$REQUIRED_COLNAMES
+  )
+})
+
+test_that("resolve_hard_required_colnames drops n_obs when no requested method needs it", {
+  box::use(
+    artma / data / method_requirements[resolve_hard_required_colnames]
+  )
+
+  methods_dir <- build_synthetic_methods_dir()
+  result <- resolve_hard_required_colnames("no_n_obs_needed", modules_dir = methods_dir)
+
+  expect_setequal(result, c("study_id", "effect", "se"))
+  expect_false("n_obs" %in% result)
+})
+
+test_that("resolve_hard_required_colnames keeps n_obs when a requested method needs it", {
+  box::use(
+    artma / data / method_requirements[resolve_hard_required_colnames]
+  )
+
+  methods_dir <- build_synthetic_methods_dir()
+  result <- resolve_hard_required_colnames("needs_n_obs", modules_dir = methods_dir)
+
+  expect_true("n_obs" %in% result)
+})
+
+test_that("resolve_hard_required_colnames unions requirements across every requested method", {
+  box::use(
+    artma / data / method_requirements[resolve_hard_required_colnames]
+  )
+
+  methods_dir <- build_synthetic_methods_dir()
+  result <- resolve_hard_required_colnames(
+    c("no_n_obs_needed", "needs_n_obs"),
+    modules_dir = methods_dir
+  )
+
+  # n_obs is required because at least one requested method needs it, even
+  # though the other requested method does not.
+  expect_true("n_obs" %in% result)
+})
+
+test_that("resolve_hard_required_colnames ignores unknown method names", {
+  box::use(
+    artma / const[CONST],
+    artma / data / method_requirements[resolve_hard_required_colnames]
+  )
+
+  methods_dir <- build_synthetic_methods_dir()
+
+  # Every requested name is unknown: nothing to narrow by, fall back to the
+  # full historical set so invoke_runtime_methods() can report the real error.
+  expect_setequal(
+    resolve_hard_required_colnames("not_a_real_method", modules_dir = methods_dir),
+    CONST$DATA$REQUIRED_COLNAMES
+  )
+
+  # A mix of a known and an unknown name still narrows by the known one.
+  result <- resolve_hard_required_colnames(
+    c("no_n_obs_needed", "not_a_real_method"),
+    modules_dir = methods_dir
+  )
+  expect_false("n_obs" %in% result)
+})
+
+test_that("resolve_hard_required_colnames requires n_obs for precision only under DoF", {
+  box::use(
+    artma / data / method_requirements[resolve_hard_required_colnames]
+  )
+
+  methods_dir <- build_synthetic_methods_dir()
+
+  local_options(list("artma.calc.precision_type" = "1/SE"))
+  result_default <- resolve_hard_required_colnames("needs_precision", modules_dir = methods_dir)
+  expect_false("n_obs" %in% result_default)
+
+  local_options(list("artma.calc.precision_type" = "DoF"))
+  result_dof <- resolve_hard_required_colnames("needs_precision", modules_dir = methods_dir)
+  expect_true("n_obs" %in% result_dof)
+})
+
+# -- Integration tests: the resolved set actually gates standardize_column_names --
+
+test_that("standardize_column_names passes on data missing n_obs when required_colnames omits it", {
+  box::use(artma / data / utils[standardize_column_names])
+
+  mock_df <- data.frame(
+    study_id = 1:5,
+    effect = c(0.1, 0.2, 0.3, 0.4, 0.5),
+    se = c(0.01, 0.02, 0.03, 0.04, 0.05)
+  )
+
+  withr::with_options(list("artma.data.columns" = list()), {
+    expect_error(
+      standardize_column_names(mock_df, required_colnames = c("study_id", "effect", "se")),
+      NA
+    )
+  })
+})
+
+test_that("standardize_column_names still aborts on data missing n_obs when it is required", {
+  box::use(
+    artma / const[CONST],
+    artma / data / utils[standardize_column_names]
+  )
+
+  mock_df <- data.frame(
+    study_id = 1:5,
+    effect = c(0.1, 0.2, 0.3, 0.4, 0.5),
+    se = c(0.01, 0.02, 0.03, 0.04, 0.05)
+  )
+
+  withr::with_options(list("artma.data.columns" = list()), {
+    expect_error(
+      standardize_column_names(mock_df, required_colnames = CONST$DATA$REQUIRED_COLNAMES),
+      "Missing mapping for required columns"
+    )
+  })
+})
+
+# -- End-to-end: prepare_data() with real, production methods --
+#
+# Reproduces the exact issue #400 scenario through the full configure/compute
+# pipeline, using the real effect_summary_stats and maive methods rather than
+# synthetic ones, on a dataset that (like the climate-sensitivity dataset in
+# the issue) has study_id/effect/se but no n_obs.
+#
+# Options are set directly (as in test-data-index.R) rather than via
+# artma::options.create(), which would run this fixture's n_obs-less data
+# through the interactive column-detection workflow; non-interactively, that
+# workflow's "no good candidate" fallback maps the missing n_obs role onto
+# whatever column it lands on first (a pre-existing quirk unrelated to this
+# fix), which is not what these tests are about. Setting the options directly
+# leaves "artma.data.columns" with no n_obs entry at all, exactly the target
+# scenario. Computed-column entries are pre-seeded (as in test-data-index.R)
+# so persist_data() finds nothing new to write and never needs a real options
+# file target (artma.temp.file_name/dir_name).
+precomputed_computed_column_overrides <- list(
+  obs_id = list(var_name = "obs_id", is_computed = TRUE),
+  study_id = list(var_name = "study_id", is_computed = TRUE),
+  study_label = list(var_name = "study_label", is_computed = TRUE),
+  t_stat = list(var_name = "t_stat", is_computed = TRUE),
+  study_size = list(var_name = "study_size", is_computed = TRUE),
+  reg_dof = list(var_name = "reg_dof", is_computed = TRUE),
+  precision = list(var_name = "precision", is_computed = TRUE)
+)
+
+shared_runtime_options <- local({
+  fixture_dir <- withr::local_tempdir(.local_envir = testthat::teardown_env())
+
+  set.seed(400)
+  df <- data.frame(
+    study_id = rep(paste0("study_", 1:5), each = 4),
+    effect = round(stats::rnorm(20, 0.3, 0.1), 4),
+    se = round(stats::runif(20, 0.05, 0.2), 4),
+    stringsAsFactors = FALSE
+  )
+  source_path <- file.path(fixture_dir, "no-n-obs-data.csv")
+  utils::write.csv(df, source_path, row.names = FALSE)
+
+  list(
+    "artma.cache.use_cache" = FALSE,
+    "artma.data.source_path" = source_path,
+    "artma.data.columns" = precomputed_computed_column_overrides,
+    "artma.data.config_setup" = "auto",
+    "artma.data.na_handling" = "remove",
+    "artma.data.reconcile_mode" = "auto",
+    "artma.data.expected_schema_columns" = NA_character_,
+    "artma.calc.se_zero_handling" = "ignore",
+    "artma.verbose" = 1
+  )
+})
+
+test_that("prepare_data succeeds without n_obs when the sole requested method does not need it", {
+  local_options(shared_runtime_options)
+
+  box::use(artma / data / index[prepare_data])
+
+  df <- prepare_data(methods = "effect_summary_stats")
+  expect_false("n_obs" %in% colnames(df))
+  expect_true("study_size" %in% colnames(df))
+})
+
+test_that("prepare_data succeeds a second time, once schema reconciliation has a baseline", {
+  # detect_schema_drift() independently defaults every required role with no
+  # stored mapping to an identity mapping, so a run-specific required set
+  # must reach reconcile_schema() too, not just standardize_column_names():
+  # otherwise the *second* prepare_data() call (once
+  # artma.data.expected_schema_columns holds a baseline, so drift is no
+  # longer unconditionally suppressed) would treat n_obs as a dropped role
+  # and abort during schema reconciliation, before standardize_column_names()
+  # is ever reached.
+  local_options(shared_runtime_options)
+
+  box::use(artma / data / index[prepare_data])
+
+  first <- prepare_data(methods = "effect_summary_stats")
+  expect_false("n_obs" %in% colnames(first))
+
+  second <- prepare_data(methods = "effect_summary_stats")
+  expect_false("n_obs" %in% colnames(second))
+})
+
+test_that("prepare_data errors when the sole requested method needs n_obs and it is absent", {
+  local_options(shared_runtime_options)
+
+  box::use(artma / data / index[prepare_data])
+
+  expect_error(
+    prepare_data(methods = "maive"),
+    "Missing mapping for required columns"
+  )
+})
+
+test_that("prepare_data errors for a method needing n_obs even once a schema baseline exists", {
+  # Same motivation as the "second time" test above, from the opposite
+  # direction: once reconcile_schema() has a baseline, a method that
+  # genuinely needs n_obs must still be caught (now inside schema
+  # reconciliation itself, via auto_decisions()'s "cannot auto-resolve"
+  # error, rather than standardize_column_names()'s "Missing mapping").
+  local_options(shared_runtime_options)
+
+  box::use(artma / data / index[prepare_data])
+
+  prepare_data(methods = "effect_summary_stats") # establishes the baseline
+
+  expect_error(
+    prepare_data(methods = "maive"),
+    "Cannot auto-resolve missing required column"
+  )
+})
+
+test_that("prepare_data unions requirements: n_obs is required if any requested method needs it", {
+  local_options(shared_runtime_options)
+
+  box::use(artma / data / index[prepare_data])
+
+  expect_error(
+    prepare_data(methods = c("effect_summary_stats", "maive")),
+    "Missing mapping for required columns"
+  )
+})
+
+test_that("prepare_data with methods = 'all' keeps the historical strict requirement", {
+  local_options(shared_runtime_options)
+
+  box::use(artma / data / index[prepare_data])
+
+  expect_error(
+    prepare_data(methods = "all"),
+    "Missing mapping for required columns"
+  )
+})
+
+test_that("prepare_data with methods = NULL keeps the historical strict requirement", {
+  local_options(shared_runtime_options)
+
+  box::use(artma / data / index[prepare_data])
+
+  expect_error(
+    prepare_data(),
+    "Missing mapping for required columns"
+  )
+})


### PR DESCRIPTION
## Problem

`standardize_column_names()` hard-aborted whenever any of the fixed
`CONST$DATA$REQUIRED_COLNAMES` (`study_id`, `effect`, `se`, `n_obs`) was
missing from the data, regardless of which methods were actually requested.
A dataset with `effect`/`se`/`study_id` but no per-estimate `n_obs` (e.g. the
Reckova & Irsova 2015 climate-sensitivity dataset) aborted on
`artma::artma(methods = c("effect_summary_stats"))` even though
`effect_summary_stats` only declares `required_columns = c("effect", "study_size")`.
This contradicted the documented contract that methods with missing required
columns are skipped with an explanation, not the whole run aborted.

A second, independent instance of the same bug lived in schema-drift
detection: `detect_schema_drift()` also treated every `REQUIRED_COLNAMES`
entry as mandatory (identity-mapped by default), so once a schema baseline
existed, a *second* run would abort inside `reconcile_schema()` before
`standardize_column_names()` was ever reached.

## Fix

Added `resolve_hard_required_colnames(methods)` (`inst/artma/data/method_requirements.R`),
which computes a run-specific hard-required set:

- `study_id`, `effect`, `se` stay unconditionally required, since the compute
  stage always derives `t_stat`/`study_size`/`study_label` from them
  regardless of which methods run.
- `n_obs` only rejoins the required set when a requested method genuinely
  needs it: directly (`n_obs`, `reg_dof`), or indirectly through `precision`
  when `calc.precision_type` is `"DoF"` (the default `"1/SE"` never touches
  `n_obs`).
- `methods = NULL` (interactive selection not yet resolved) and
  `methods = "all"` keep the full historical set unchanged.

This resolved set now threads through both abort sites:
- `standardize_column_names()` (`required_colnames` param)
- `detect_schema_drift()` / `reconcile_schema()` (`required`/`required_colnames` params)

Both calls happen in the *uncached* configure phase of `prepare_data()`, so
the gate re-evaluates on every run regardless of compute-cache warmth: a
method list that newly needs a column can't hide behind a stale cache hit.

## Testing

- Added `tests/testthat/test-data-method-requirements.R`: unit tests for
  `resolve_hard_required_colnames()` against synthetic methods, plus
  end-to-end `prepare_data()` coverage using the real `effect_summary_stats`
  and `maive` methods, including the second-run/schema-baseline scenario.
- Full suite: `make test` passes (2727 passed, 0 failed, 14 pre-existing
  unrelated skips).
- `make lint` clean on all changed/new files.

Fixes #400