### PR TITLE
fix(e2e): shell-quote CLI args so the Rscript subprocess starts under sh

### DIFF
--- a/tests/E2E/test-cli.R
+++ b/tests/E2E/test-cli.R
@@ -34,19 +34,34 @@ artma::options.create(
 stdout_file <- tempfile("artma-cli-stdout-", fileext = ".txt")
 stderr_file <- tempfile("artma-cli-stderr-", fileext = ".txt")
 
+# `system2()` shell-quotes the command but pastes `args` in verbatim, so every
+# argument carrying shell metacharacters has to be quoted here. Without this the
+# parentheses in the `-e` expression abort the run under `sh` before Rscript is
+# ever reached ("Syntax error: \"(\" unexpected").
 cli_args <- c(
-  "-e", "quit(save = 'no', status = artma::cli.run())",
+  "-e", shQuote("quit(save = 'no', status = artma::cli.run())"),
   "run",
   "--options", "cli.yaml",
-  "--options-dir", options_dir,
+  "--options-dir", shQuote(options_dir),
   "--methods", "funnel_plot,effect_summary_stats",
   "--json"
 )
 
-status <- system2("Rscript", cli_args, stdout = stdout_file, stderr = stderr_file)
+rscript <- file.path(R.home("bin"), "Rscript")
+status <- system2(rscript, cli_args, stdout = stdout_file, stderr = stderr_file)
 
-stdout_txt <- paste(readLines(stdout_file, warn = FALSE), collapse = "\n")
-stderr_txt <- paste(readLines(stderr_file, warn = FALSE), collapse = "\n")
+# A subprocess that never starts leaves the redirect files uncreated; read
+# defensively so the abort below reports the real failure rather than an
+# unrelated "cannot open the connection" from readLines().
+read_capture <- function(path) {
+  if (!file.exists(path)) {
+    return("")
+  }
+  paste(readLines(path, warn = FALSE), collapse = "\n")
+}
+
+stdout_txt <- read_capture(stdout_file)
+stderr_txt <- read_capture(stderr_file)
 
 if (!identical(as.integer(status), 0L)) {
   cli::cli_abort(c(


### PR DESCRIPTION
Fixes the nightly E2E failure reported in #383.

## The failure

`tests/E2E/test-cli.R` (added with the CLI in 72d5603) has never passed on Linux CI. The first nightly run after it landed failed with:

```
sh: 1: Syntax error: "(" unexpected
Error in file(con, "r") : cannot open the connection
  cannot open file '/tmp/.../artma-cli-stdout-....txt': No such file or directory
```

## Cause

`system2()` shell-quotes only the command, never `args`:

```r
command <- paste(c(shQuote(command), env, args), collapse = " ")
```

So the parentheses in `-e "quit(save = 'no', status = artma::cli.run())"` reached `sh` unquoted and the subprocess died at parse time, before Rscript ran. The `readLines()` failure on the never-created stdout file was a knock-on effect that hid the real error.

## Changes

- `shQuote()` the `-e` expression and the `--options-dir` path.
- Invoke `file.path(R.home("bin"), "Rscript")` rather than relying on `Rscript` being on `PATH`, matching the existing pattern in `tests/testthat/test-robma.R`.
- Read the stdout/stderr capture files defensively, so a subprocess that never starts reports its real failure instead of an unrelated "cannot open the connection".

## Verification

- Reproduced the parse error directly: `sh -c "... quit(save = 'no', ...) ..."` fails identically.
- Full `make test-e2e` suite (`test-cli.R`, `test-smoke.R`, `test-installation.R`) passes locally, exit 0.
- `styler` clean, `lintr` reports no lints.