### PR TITLE
fix(preview): skip utils::View() when no data viewer is available

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,6 +21,7 @@
 ^doc$
 ^Meta$
 ^cran-comments\.md$
+^manual_cran_comments\.md$
 ^CRAN-SUBMISSION$
 ^assets\.txt$
 ^metadata\.json$

--- a/R/data_preview.R
+++ b/R/data_preview.R
@@ -20,7 +20,9 @@
 #'   options-dependent standardization or preprocessing.
 #'
 #' @return Invisible \code{NULL}. Opens the data in the standard R viewer
-#'   (\code{utils::View()}).
+#'   (\code{utils::View()}). When no viewer is available (a non-interactive
+#'   session, or a Unix session with no reachable display), the first rows are
+#'   printed instead.
 #'
 #' @details
 #' Three data sources are supported:
@@ -75,6 +77,7 @@ data.preview <- function(
     artma / data / index[prepare_data],
     artma / data / preprocess[preprocess_data],
     artma / data / compute[compute_optional_columns],
+    artma / libs / core / utils[data_viewer_available, get_verbosity],
     artma / libs / core / validation[assert]
   )
 
@@ -99,6 +102,18 @@ data.preview <- function(
   )
 
   view_if_available <- function(x, title) {
+    if (!data_viewer_available()) {
+      if (get_verbosity() >= 3) {
+        cli::cli_inform(c(
+          "!" = "No data viewer is available in this session, printing the first rows instead.",
+          "i" = "{title}: {nrow(x)} row{?s}, {ncol(x)} column{?s}."
+        ))
+        cli::cli_verbatim(
+          utils::capture.output(print(utils::head(x, 10L))) # nolint: undesirable_function_linter.
+        )
+      }
+      return(invisible(NULL))
+    }
     tryCatch(
       utils::View(x, title = title),
       error = function(e) invisible(NULL)
@@ -121,8 +136,6 @@ data.preview <- function(
 
   # All other cases: need runtime_setup (options), then resolve df and optionally preprocess
   main <- function() {
-    box::use(artma / libs / core / utils[get_verbosity])
-
     if (is.null(data)) {
       if (isFALSE(preprocess)) {
         df <- read_data()

--- a/R/generated_check_manifest.R
+++ b/R/generated_check_manifest.R
@@ -33,6 +33,7 @@ utils::globalVariables(c(
   "core",
   "data",
   "data_config",
+  "data_viewer_available",
   "display_ma_table",
   "editor",
   "editor_mod",

--- a/inst/artma/libs/core/utils.R
+++ b/inst/artma/libs/core/utils.R
@@ -7,6 +7,33 @@ get_verbosity <- function() {
   getOption("artma.verbose", CONST$DEFAULT_VERBOSITY)
 }
 
+#' @title Check whether R's data viewer can be opened
+#' @description `utils::View()` hands the data off to the front-end's spreadsheet
+#'   window. In a non-interactive session, or on a Unix system whose only viewer
+#'   is the X11 data entry window and where no display is reachable, there is no
+#'   window to attach to and R aborts the session instead of failing gracefully.
+#'   Call this before `utils::View()` and fall back to printing when it is
+#'   `FALSE`.
+#' @return *\[logical\]* `TRUE` when `utils::View()` is safe to call.
+#' @export
+data_viewer_available <- function() {
+  if (!interactive()) {
+    return(FALSE)
+  }
+  if (identical(.Platform$OS.type, "windows")) {
+    return(TRUE)
+  }
+  # Front-ends such as RStudio and Positron install their own viewer and never
+  # reach the X11 data entry window.
+  if (!identical(Sys.getenv("RSTUDIO"), "") || !identical(Sys.getenv("POSITRON"), "")) {
+    return(TRUE)
+  }
+  if (identical(.Platform$GUI, "AQUA")) {
+    return(TRUE)
+  }
+  isTRUE(unname(capabilities("X11"))) && !identical(Sys.getenv("DISPLAY"), "")
+}
+
 #' @title Get an option, treating NULL and scalar NA as unset
 #' @description `getOption()` wrapper for options whose template default is
 #'   `.na` (`allow_na`): those are loaded into `options()` as a literal `NA`,

--- a/man/data.preview.Rd
+++ b/man/data.preview.Rd
@@ -32,7 +32,9 @@ options-dependent standardization or preprocessing.}
 }
 \value{
 Invisible \code{NULL}. Opens the data in the standard R viewer
-(\code{utils::View()}).
+(\code{utils::View()}). When no viewer is available (a non-interactive
+session, or a Unix session with no reachable display), the first rows are
+printed instead.
 }
 \description{
 Open a data frame in R's viewer. Data can be supplied as a file path, a data

--- a/manual_cran_comments.md
+++ b/manual_cran_comments.md
@@ -1,0 +1,9 @@
+* This release fixes the segmentation fault reported on
+  r-devel-linux-x86_64-fedora-clang and r-devel-linux-x86_64-fedora-gcc.
+
+  `data.preview()` called `utils::View()` unconditionally. On a Unix build
+  whose only viewer is the X11 data entry window, with no display reachable,
+  that path aborts the session; the clang-ASAN run traces it to a null
+  dereference in `initwin` (dataentry.c:1973). The call is now gated on an
+  interactive session with a usable viewer and falls back to printing the
+  first rows, so the check no longer reaches it.

--- a/tests/testthat/test-data-preview.R
+++ b/tests/testthat/test-data-preview.R
@@ -2,9 +2,12 @@ box::use(
   testthat[
     expect_equal,
     expect_error,
+    expect_false,
     expect_invisible,
+    expect_match,
     expect_null,
     expect_true,
+    skip_if,
     test_that
   ],
   withr[local_options]
@@ -64,6 +67,34 @@ test_that("data.preview rejects invalid data", {
     artma::data.preview(1L, preprocess = FALSE),
     "NULL, a file path"
   )
+})
+
+test_that("the data viewer is never opened in a non-interactive session", {
+  box::use(artma / libs / core / utils[data_viewer_available])
+
+  skip_if(interactive(), "Only meaningful in a non-interactive session")
+
+  # utils::View() aborts the R session on Unix builds whose only viewer is the
+  # X11 data entry window, so data.preview() must not reach it here.
+  expect_false(data_viewer_available())
+})
+
+test_that("data.preview prints a preview when no viewer is available", {
+  box::use(artma / libs / core / utils[data_viewer_available])
+
+  skip_if(data_viewer_available(), "A data viewer is available in this session")
+
+  withr::local_options(list(artma.verbose = 3))
+
+  df <- data.frame(study_id = c("A", "B"), effect = c(0.5, 0.3))
+
+  emitted <- paste(
+    testthat::capture_messages(artma::data.preview(df, preprocess = FALSE)),
+    collapse = ""
+  )
+
+  expect_match(emitted, "No data viewer")
+  expect_match(emitted, "study_id")
 })
 
 test_that("read_data returns data frame without standardizing column names", {


### PR DESCRIPTION
## Problem

artma 0.3.3 fails its CRAN checks on `r-devel-linux-x86_64-fedora-clang` and `r-devel-linux-x86_64-fedora-gcc` with a segfault:

```
*** caught segfault ***
address (nil), cause 'memory not mapped'
1: utils::View(x, title = title)
```

The clang-ASAN run pins it down exactly: a null dereference inside R's own X11 module, `initwin` at `dataentry.c:1973`. `utils::View()` hands the data to the front-end's spreadsheet window; on a Unix build whose only viewer is the X11 data entry window, with no reachable display, that window has nothing to attach to and R aborts the session rather than failing gracefully.

`data.preview()` wrapped the call in `tryCatch()`, but a segfault is not an R condition, so nothing was caught. The other 11 CRAN flavors are OK.

## Fix

Gate the call on a new `data_viewer_available()` helper (`inst/artma/libs/core/utils.R`), which requires an interactive session and, on Unix, either a front-end that supplies its own viewer (RStudio, Positron, R.app) or X11 capability plus a non-empty `DISPLAY`. R CMD check runs non-interactively, so the crashing path is now unreachable there.

When no viewer is available, `data.preview()` prints the first rows through `cli` instead of silently doing nothing. That also makes the function useful over SSH on a headless Linux box, which previously got an unhelpful no-op at best.

## Tests

Two tests added to `tests/testthat/test-data-preview.R`: one asserting the viewer is never considered available in a non-interactive session, one covering the printed fallback.

Local gates: `devtools::check(vignettes = FALSE, manual = FALSE)` gives 0 errors, 0 warnings, 2 NOTEs (Suggests unavailable locally, unable to verify current time). Full suite passes, lint clean on the changed files.

No version bump here; that is the release workflow's job.