### PR TITLE
ci(release): install git-chglog from a pinned release instead of brew

### DIFF
--- a/.github/actions/composite/updateNews/action.yaml
+++ b/.github/actions/composite/updateNews/action.yaml
@@ -21,14 +21,22 @@ runs:
         ref: master
         token: ${{ inputs.ARTMA_BOT_COMMIT_TOKEN }}
 
-    - name: Set up homebrew
-      uses: 'Homebrew/actions/setup-homebrew@master'
-
-    - name: Install dependencies
+    # Installed from the upstream release tarball rather than Homebrew.
+    # git-chglog only ships via its own tap, and Homebrew now refuses formulae
+    # from untrusted third-party taps, which broke every release build. A
+    # pinned binary also drops the ~40s Homebrew bootstrap.
+    - name: Install git-chglog
       shell: bash
+      env:
+        CHGLOG_VERSION: 0.15.4
       run: |
-        brew tap git-chglog/git-chglog
-        brew install git-chglog
+        set -euo pipefail
+        curl -fsSL -o chglog.tar.gz \
+          "https://github.com/git-chglog/git-chglog/releases/download/v${CHGLOG_VERSION}/git-chglog_${CHGLOG_VERSION}_linux_amd64.tar.gz"
+        tar -xzf chglog.tar.gz git-chglog
+        sudo install -m 755 git-chglog /usr/local/bin/git-chglog
+        rm -f chglog.tar.gz git-chglog
+        git-chglog --version
 
     - name: Setup git for ArtmaBot
       uses: ./.github/actions/composite/setupGitForArtmaBot


### PR DESCRIPTION
## Why

The v0.3.4 release build failed at the `Update NEWS.md` step ([run 31320150284](https://github.com/PetrCala/artma/actions/runs/31320150284)):

```
Refusing to load formula git-chglog/git-chglog/git-chglog from untrusted tap git-chglog/git-chglog.
Run `brew trust --formula git-chglog/git-chglog/git-chglog` or `brew trust git-chglog/git-chglog` to trust it.
```

Homebrew added a trusted-tap policy and now refuses third-party formulae outright. git-chglog only ships via its own tap, so `brew install git-chglog` cannot succeed any more. This blocks every release, not just this one.

The failure left master half-released: the version bump had already pushed `chore: release v0.3.4`, but no NEWS entry, no tag, no GitHub release, and nothing submitted to CRAN.

## What

`.github/actions/composite/updateNews` now installs git-chglog from the upstream release tarball at a pinned version (0.15.4) and drops the Homebrew bootstrap entirely. That removes the dependency on Homebrew's tap policy and saves roughly 40 seconds per release.

Verified out of band: the pinned asset URL returns 200, and the tarball carries `git-chglog` at its root, so the single-member extract is correct.

## Release note

This PR carries `release:next-version` + `v-patch`. Master is already at 0.3.4 from the failed run, so this ships **0.3.5**; 0.3.4 is skipped and was never published anywhere.

0.3.5 is the release that carries the Fedora segfault fix from #410, which is what CRAN is currently failing on.