### PR TITLE
fix: drop LazyData and dead Suggests, honour absolute graphics export path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,9 +44,7 @@ Suggests:
     htmlwidgets (>= 1.6.0),
     jsonlite (>= 1.8.0),
     knitr (>= 1.50),
-    lintr (>= 3.2.0),
     MAIVE (>= 0.2.4),
-    mathjaxr (>= 1.8-0),
     mice (>= 3.16.0),
     NlcOptim (>= 0.6),
     plm (>= 2.6-3),
@@ -55,12 +53,10 @@ Suggests:
     ragg (>= 1.5.0),
     rddensity (>= 2.5),
     readxl (>= 1.4.0),
-    rex (>= 1.2.1),
     RhpcBLASctl (>= 0.23-42),
     rjags (>= 4.15),
     rmarkdown (>= 2.30),
     RoBMA (>= 4.0.0),
-    roxygen2 (>= 7.3.3),
     testthat (>= 3.2.3),
     writexl (>= 1.4.0)
 VignetteBuilder:
@@ -75,6 +71,5 @@ Config/testthat/edition: 3
 Config/testthat/parallel: TRUE
 Config/testthat/start-first: github-actions, release
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     htmlwidgets (>= 1.6.0),
     jsonlite (>= 1.8.0),
     knitr (>= 1.50),
+    lintr (>= 3.2.0),
     MAIVE (>= 0.2.4),
     mice (>= 3.16.0),
     NlcOptim (>= 0.6),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
 
+<a name="unreleased"></a>
+
+## Unreleased
+
+### Bug Fixes
+
+* An absolute `visualization.export_path` is now used as-is instead of being joined onto the output directory. Runs made before this fix may have left a stray nested `var/folders/...` (or similar) directory tree inside an existing results directory; those can be deleted by hand, the package does not clean them up.
+
 <a name="v0.3.5"></a>
 
 ## [v0.3.5](https://github.com/PetrCala/artma/compare/v0.3.3...v0.3.5)

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -105,6 +105,7 @@ visualization:
     default: "graphics"
     help: |
       Subdirectory (relative to output.dir) for exporting graphics.
+      An absolute path is also accepted and is used as-is.
       Only used if export_graphics is `TRUE`.
 
   graph_scale:

--- a/inst/artma/output/export.R
+++ b/inst/artma/output/export.R
@@ -49,16 +49,37 @@ resolve_output_dir <- function() {
   output_dir
 }
 
+#' Check whether a path is absolute
+#'
+#' @description
+#' Recognises POSIX roots (`/foo`), Windows drive letters (`C:\\foo`, `C:/foo`)
+#' and UNC paths (`\\\\server\\share`).
+#'
+#' @param path *\[character\]* The path to test.
+#' @return *\[logical\]* `TRUE` when the path is absolute.
+#' @keywords internal
+is_absolute_path <- function(path) {
+  if (length(path) != 1L || is.na(path) || !nzchar(path)) {
+    return(FALSE)
+  }
+  grepl("^(?:[A-Za-z]:[/\\\\]|[/\\\\])", path)
+}
+
 #' Resolve the graphics subdirectory path
 #'
 #' @description
 #' Reads the `artma.visualization.export_path` option (default: `"graphics"`)
-#' and resolves it relative to the given output directory.
+#' and resolves it relative to the given output directory. An absolute
+#' `export_path` is returned as-is; joining it to `output_dir` would otherwise
+#' produce a nested copy of the whole absolute path under the results directory.
 #'
 #' @param output_dir *\[character\]* The base output directory.
 #' @return *\[character\]* The resolved graphics directory path.
 resolve_graphics_dir <- function(output_dir) {
   export_path <- getOption("artma.visualization.export_path", "graphics")
+  if (is_absolute_path(export_path)) {
+    return(export_path)
+  }
   file.path(output_dir, export_path)
 }
 

--- a/tests/testthat/test-output-export.R
+++ b/tests/testthat/test-output-export.R
@@ -72,9 +72,28 @@ test_that("resolve_output_dir returns an explicit path unchanged", {
 
 # resolve_graphics_dir ------------------------------------------------------
 
-test_that("resolve_graphics_dir joins the export subdirectory", {
+test_that("resolve_graphics_dir joins a relative export subdirectory", {
   local_options(artma.visualization.export_path = "graphics")
   expect_equal(resolve_graphics_dir("/base"), file.path("/base", "graphics"))
+})
+
+test_that("resolve_graphics_dir returns an absolute export path as-is", {
+  local_options(artma.visualization.export_path = "/tmp/artma-graphics")
+  expect_equal(resolve_graphics_dir("/base"), "/tmp/artma-graphics")
+})
+
+test_that("ensure_output_dirs honours an absolute export path", {
+  base <- local_tempdir()
+  graphics <- file.path(local_tempdir(), "elsewhere")
+  local_options(
+    artma.output.dir = base,
+    artma.visualization.export_path = graphics
+  )
+
+  ensure_output_dirs(base)
+
+  expect_true(dir.exists(graphics))
+  expect_false(dir.exists(file.path(base, graphics)))
 })
 
 # ensure_output_dirs --------------------------------------------------------


### PR DESCRIPTION
Three small independent fixes from the usability audit: `LazyData: true` is gone (there is no `data/` directory, so it was a standing R CMD check NOTE), `roxygen2`, `rex`, `mathjaxr`, and `lintr` are dropped from Suggests (all unreferenced in `R/`, `inst/`, and `tests/`, or already covered by the `Config/Needs/*` fields), and `resolve_graphics_dir()` now returns an absolute `visualization.export_path` as-is instead of joining it onto the output directory and producing a nested `<output_dir>//var/folders/...` tree. The option help text and NEWS.md note the behaviour; existing stray directories are left for the user to delete by hand.

Closes #415