### PR TITLE
fix(data): write mock data to a durable user dir instead of tempfile

### DIFF
--- a/inst/artma/const.R
+++ b/inst/artma/const.R
@@ -107,6 +107,7 @@ CONST <- list(
     DESIRED_VARS = c("effect", "se", "n_obs", "reg_dof")
   ),
   MOCKS = list(
+    DATA_FILE_NAME = "mock-data.csv",
     TMP_DATA_FILE_NAME = "tmp_data.csv",
     TMP_OPTIONS_FILE_NAME = "tmp_options.yaml",
     MOCK_DF_NROWS = 1000,

--- a/inst/artma/data/mock.R
+++ b/inst/artma/data/mock.R
@@ -142,7 +142,8 @@ create_mock_df <- function(
 
   if (with_file_creation) {
     if (is.null(file_path)) {
-      file_path <- CONST$MOCKS$TMP_DATA_FILE_PATH
+      file_path <- mock_data_file_path()
+      dir.create(dirname(file_path), recursive = TRUE, showWarnings = FALSE)
     }
 
     assert(
@@ -163,29 +164,64 @@ create_mock_df <- function(
   data_frame
 }
 
+#' Path of the durable mock dataset file
+#'
+#' @description
+#' The mock dataset lives under `tools::R_user_dir("artma", "data")/mock` with a
+#' stable file name, so a path written into an options file keeps resolving in
+#' later R sessions and repeated `"mock"` uses do not accumulate files. Resolved
+#' on every call rather than at load time, so an `R_USER_DATA_DIR` override
+#' (used by the test suite) is honoured.
+#' @return *\[character\]* Absolute path to the mock CSV file.
+#' @export
+mock_data_file_path <- function() {
+  box::use(artma / const[CONST])
+  file.path(
+    tools::R_user_dir(CONST$PACKAGE_NAME, which = "data"),
+    "mock",
+    CONST$MOCKS$DATA_FILE_NAME
+  )
+}
+
 #' Generate a mock dataset file and return its path
 #'
 #' @description
-#' Backs the `"mock"` data source shortcut: writes a temporary CSV with mock
-#' meta-analysis data and returns its path. Used both by the interactive
-#' source-path prompt and by programmatic `user_input` values.
-#' @return *\[character\]* Path to the generated CSV file.
+#' Backs the `"mock"` data source shortcut: writes a CSV with mock
+#' meta-analysis data to a durable location (see [mock_data_file_path()]) and
+#' returns its path. Used both by the interactive source-path prompt and by
+#' programmatic `user_input` values.
+#'
+#' An existing mock file is reused as is. The dataset is deterministic, so
+#' regenerating it would only churn the file's mtime and needlessly invalidate
+#' the data cache signature. Pass `regenerate = TRUE` to overwrite it.
+#' @param regenerate *\[logical, optional\]* Whether to overwrite an existing
+#'   mock file. Defaults to `FALSE`, reusing the file when it is already there.
+#' @return *\[character\]* Path to the mock CSV file.
 #' @export
-materialize_mock_data_path <- function() {
+materialize_mock_data_path <- function(regenerate = FALSE) {
   box::use(artma / libs / core / utils[get_verbosity])
+
+  file_path <- mock_data_file_path()
+
+  if (!regenerate && file.exists(file_path)) {
+    if (get_verbosity() >= 3) {
+      cli::cli_alert_info("Reusing the mock data in {.path {file_path}}")
+    }
+    return(file_path)
+  }
 
   if (get_verbosity() >= 3) {
     cli::cli_alert_info("Generating mock data...")
   }
 
-  temp_file <- tempfile(pattern = "artma-mock-data-", fileext = ".csv")
-  create_mock_df(with_file_creation = TRUE, file_path = temp_file)
+  dir.create(dirname(file_path), recursive = TRUE, showWarnings = FALSE)
+  create_mock_df(with_file_creation = TRUE, file_path = file_path)
 
   if (get_verbosity() >= 3) {
-    cli::cli_alert_success("Mock data generated and saved to {.path {temp_file}}")
+    cli::cli_alert_success("Mock data generated and saved to {.path {file_path}}")
   }
 
-  temp_file
+  file_path
 }
 
-box::export(create_mock_df, materialize_mock_data_path)
+box::export(create_mock_df, mock_data_file_path, materialize_mock_data_path)

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -924,6 +924,10 @@ data:
       Full path to your dataset source. The special value {.val mock} generates
       a mock dataset and points this option at it; it works both at the
       interactive prompt and when passed programmatically via `user_input`.
+      The mock dataset is written to `mock/mock-data.csv` under
+      `tools::R_user_dir("artma", "data")`, so it survives the R session and the
+      saved path keeps resolving in later runs. An existing mock file is reused
+      rather than regenerated.
 
   na_handling:
     type: "enum: stop|remove|median|mean|interpolate|mice"

--- a/tests/testthat/test-data-mock.R
+++ b/tests/testthat/test-data-mock.R
@@ -1,0 +1,63 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_false,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
+  artma / data / mock[create_mock_df, materialize_mock_data_path, mock_data_file_path]
+)
+
+# The whole point of the mock data path is that it outlives the R session, so
+# the scratch user data directory used here sits *outside* `tempdir()` - a
+# temporary redirect would make the durability assertion vacuous.
+local_user_data_dir <- function(.local_envir = parent.frame()) {
+  dir <- file.path(getwd(), sprintf("mock-user-data-%s", Sys.getpid()))
+  dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  withr::defer(unlink(dir, recursive = TRUE), envir = .local_envir)
+  withr::local_envvar(R_USER_DATA_DIR = dir, .local_envir = .local_envir)
+  normalizePath(dir, winslash = "/")
+}
+
+test_that("materialize_mock_data_path writes a durable file outside tempdir()", {
+  base <- local_user_data_dir()
+  withr::local_options(artma.verbose = 1)
+
+  path <- materialize_mock_data_path()
+
+  expect_true(file.exists(path))
+  expect_equal(path, mock_data_file_path())
+  expect_true(startsWith(normalizePath(path, winslash = "/"), base))
+  expect_false(startsWith(
+    normalizePath(path, winslash = "/"),
+    normalizePath(tempdir(), winslash = "/")
+  ))
+  expect_true(nrow(utils::read.csv(path)) > 0)
+})
+
+test_that("materialize_mock_data_path reuses an existing mock file", {
+  local_user_data_dir()
+  withr::local_options(artma.verbose = 1)
+
+  path <- materialize_mock_data_path()
+  Sys.setFileTime(path, Sys.time() - 3600)
+  mtime_before <- file.mtime(path)
+
+  expect_equal(materialize_mock_data_path(), path)
+  expect_equal(file.mtime(path), mtime_before)
+
+  expect_equal(materialize_mock_data_path(regenerate = TRUE), path)
+  expect_true(file.mtime(path) > mtime_before)
+})
+
+test_that("create_mock_df still writes to an explicit throwaway path", {
+  file_path <- withr::local_tempfile(fileext = ".csv")
+
+  df <- create_mock_df(nrow = 20, n_studies = 3, with_file_creation = TRUE, file_path = file_path)
+
+  expect_true(file.exists(file_path))
+  expect_equal(nrow(utils::read.csv(file_path)), nrow(df))
+})


### PR DESCRIPTION
`materialize_mock_data_path()` now writes the generated dataset to `mock/mock-data.csv` under `tools::R_user_dir("artma", "data")` instead of a `tempfile()`, so an options file created with the `mock` shortcut keeps resolving in later R sessions. An existing mock file is reused as is (the dataset is deterministic, so regenerating would only churn the mtime and invalidate the data cache signature); `regenerate = TRUE` overwrites it. `create_mock_df(with_file_creation = TRUE, file_path = ...)` is unchanged for callers that want a throwaway file, and its previously broken NULL default (which pointed at a non-existent constant) now falls back to the durable path. The `data.source_path` help text says where the file lands.

Closes #413