### PR TITLE
fix(report): split method skip contract into skip_reason and skipped_models

### DIFF
--- a/R/artma.R
+++ b/R/artma.R
@@ -562,9 +562,9 @@ invoke_runtime_methods <- function(methods, df, modules_dir = NULL, ...) {
 
   # Build unified MA table when BMA and/or FMA have produced results. Both
   # methods return the standard contract, so the coefficient frame lives in
-  # `tables$coefficients` and skip reasons under `meta$skipped`.
+  # `tables$coefficients` and skip reasons under `meta$skip_reason`.
   extract_ma_coefficients <- function(result) {
-    if (is.null(result) || !is.list(result) || !is.null(result$meta$skipped)) {
+    if (is.null(result) || !is.list(result) || !is.null(result$meta$skip_reason)) {
       return(NULL)
     }
     coefs <- result$tables$coefficients

--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -643,7 +643,8 @@ run_puniform_star <- function(df, add_significance_marks = TRUE, round_to = 3L, 
 #' and effect size under relaxed exogeneity assumptions.
 #' @param df *[data.frame]* Input data.
 #' @param options *[list]* Options containing iv_instrument, puniform settings, formatting.
-#' @return *[list]* Contains coefficients and formatted summary.
+#' @return *[list]* Contains coefficients and formatted summary. `skipped`
+#'   carries a single string when the whole test suite could not run.
 run_exogeneity_tests <- function(df, options) {
   validate(is.data.frame(df), is.list(options))
 
@@ -660,7 +661,7 @@ run_exogeneity_tests <- function(df, options) {
     return(list(
       coefficients = data.frame(),
       summary = data.frame(),
-      skipped = list(reason = paste("Missing columns:", paste(missing_cols, collapse = ", ")))
+      skipped = paste("Missing columns:", paste(missing_cols, collapse = ", "))
     ))
   }
 

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -101,7 +101,7 @@ bma <- function(df) {
     )
     return(new_method_result(
       tables = list(coefficients = empty_coefs),
-      meta = list(model = NULL, skipped = prepared$skipped)
+      meta = list(model = NULL, skip_reason = prepared$skipped)
     ))
   }
 
@@ -516,8 +516,8 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
 #' callers that pass a previously computed `bma()` result or a hand-built
 #' list are both supported. Returns a list with `model`, `data`, `var_list`,
 #' `params` and `skipped` fields (all `NULL` except `skipped` when
-#' `bma_result` does not carry a usable bundle; `skipped` carries the reason
-#' string when the source `bma()` run was itself skipped).
+#' `bma_result` does not carry a usable bundle; `skipped` carries the
+#' `meta$skip_reason` string when the source `bma()` run was itself skipped).
 #' @param bma_result *\[list, optional\]* Either a `bma()` method result or a
 #'   bare `list(model=, data=, var_list=, params=)`.
 #' @return *\[list\]* `list(model=, data=, var_list=, params=, skipped=)`.
@@ -538,11 +538,11 @@ unwrap_bma_result <- function(bma_result) {
       data = meta$data,
       var_list = meta$var_list,
       params = meta$params,
-      skipped = meta$skipped
+      skipped = meta$skip_reason
     ))
   }
 
-  empty$skipped <- meta$skipped
+  empty$skipped <- meta$skip_reason
   empty
 }
 

--- a/inst/artma/methods/exogeneity_tests.R
+++ b/inst/artma/methods/exogeneity_tests.R
@@ -57,7 +57,7 @@ exogeneity_tests <- function(df) {
     }
 
     if (!is.null(results$skipped) && verbosity >= 2) {
-      cli::cli_alert_warning("Skipped: {results$skipped$reason}")
+      cli::cli_alert_warning("Skipped: {results$skipped}")
     }
 
     if (!is.null(results$iv$error) && verbosity >= 2) {
@@ -78,7 +78,7 @@ exogeneity_tests <- function(df) {
     meta = list(
       iv = results$iv,
       puniform = results$puniform,
-      skipped = results$skipped
+      skip_reason = results$skipped
     )
   ))
 }

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -110,7 +110,7 @@ fma <- function(df, bma_result = NULL) {
       )
       return(new_method_result(
         tables = list(coefficients = empty_coefs),
-        meta = list(weights = numeric(0), model = NULL, skipped = prepared$skipped)
+        meta = list(weights = numeric(0), model = NULL, skip_reason = prepared$skipped)
       ))
     }
 

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -70,7 +70,7 @@ linear_tests <- function(df) {
     tables = list(summary = results$summary),
     meta = list(
       coefficients = results$coefficients,
-      skipped = results$skipped,
+      skipped_models = results$skipped,
       options = results$options
     )
   ))

--- a/inst/artma/methods/maive.R
+++ b/inst/artma/methods/maive.R
@@ -126,7 +126,7 @@ maive_estimator <- function(df) {
       interpretation = result$interpretation,
       first_stage = result$first_stage,
       options = resolved_options,
-      skipped = result$skipped
+      skip_reason = result$skipped
     )
   ))
 }

--- a/inst/artma/methods/nonlinear_tests.R
+++ b/inst/artma/methods/nonlinear_tests.R
@@ -88,7 +88,7 @@ nonlinear_tests <- function(df) {
     ),
     meta = list(
       coefficients = results$coefficients,
-      skipped = results$skipped,
+      skipped_models = results$skipped,
       options = results$options
     )
   ))

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -191,7 +191,7 @@ p_hacking_tests <- function(df) {
       caliper = results$caliper,
       elliott = results$elliott
     ),
-    meta = list(skipped = results$skipped)
+    meta = list(skipped_models = results$skipped)
   ))
 }
 

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -112,7 +112,7 @@ robma <- function(df) {
     }
     return(new_method_result(
       tables = list(summary = empty_robma_table()),
-      meta = list(model = NULL, n_obs = nrow(fit_data), skipped = reason)
+      meta = list(model = NULL, n_obs = nrow(fit_data), skip_reason = reason)
     ))
   }
 

--- a/inst/artma/modules/runtime_methods.R
+++ b/inst/artma/modules/runtime_methods.R
@@ -20,15 +20,45 @@ RUNTIME_METHOD_MARKER <- ".__runtime_method__"
 #' * `meta`: a named list of anything else a downstream consumer needs (the BMA
 #'   model, fit parameters, skip reasons, auxiliary frames, and so on).
 #'
+#' Two `meta` keys are reserved, and they mean different things:
+#'
+#' * `skip_reason`: a single, non-empty string saying why the method as a whole
+#'   did not run (a missing optional package, too few observations). Absent or
+#'   `NULL` means the method ran. Consumers such as the HTML report render the
+#'   whole section as skipped when it is present, so never use it for a partial
+#'   skip.
+#' * `skipped_models`: a named list of sub-models the method could not fit,
+#'   each a `list(label =, reason =)`. The method itself still ran, so this
+#'   never suppresses the section. Use `NULL` or `list()` when nothing was
+#'   skipped.
+#'
 #' @param tables *\[list\]* Named list of `data.frame`s to export.
 #' @param plots *\[list\]* Named list of plot objects.
-#' @param meta *\[list\]* Named list of method-specific extras.
+#' @param meta *\[list\]* Named list of method-specific extras. `skip_reason`
+#'   and `skipped_models`, when present, must follow the shapes above.
 #' @param class *\[character, optional\]* Extra S3 class(es) to prepend, used by
 #'   methods that ship a bespoke print method.
 #' @return *\[list\]* A list with `tables`, `plots`, and `meta` elements.
 new_method_result <- function(tables = list(), plots = list(), meta = list(), class = NULL) {
   if (!is.list(tables) || !is.list(plots) || !is.list(meta)) {
     cli::cli_abort("`tables`, `plots`, and `meta` must all be lists.")
+  }
+
+  skip_reason <- meta$skip_reason
+  if (!is.null(skip_reason) &&
+    (!is.character(skip_reason) || length(skip_reason) != 1L || is.na(skip_reason))) {
+    cli::cli_abort(c(
+      "`meta$skip_reason` must be a single string, or `NULL` when the method ran.",
+      "i" = "Use `meta$skipped_models` for a named list of skipped sub-models."
+    ))
+  }
+
+  skipped_models <- meta$skipped_models
+  if (!is.null(skipped_models) && !is.list(skipped_models)) {
+    cli::cli_abort(c(
+      "`meta$skipped_models` must be a named list of `list(label =, reason =)`, or `NULL`.",
+      "i" = "Use `meta$skip_reason` for a scalar reason the whole method was skipped."
+    ))
   }
 
   result <- list(tables = tables, plots = plots, meta = meta)

--- a/inst/artma/report/render.R
+++ b/inst/artma/report/render.R
@@ -248,6 +248,25 @@ count_plots <- function(result) {
   sum(!vapply(plots, is.null, logical(1)))
 }
 
+#' Coerce a `meta$skip_reason` value to the single string the report renders.
+#' @description The report must survive a method that writes something other
+#'   than a scalar string (an empty list, a named list of skipped sub-models,
+#'   `NA`), so anything that is not a usable single string counts as
+#'   "not skipped" instead of aborting the render.
+#' @param value *\[any\]* The raw `meta$skip_reason` value.
+#' @return *\[character or NULL\]* The reason, or `NULL` when not skipped.
+#' @keywords internal
+scalar_skip_reason <- function(value) {
+  if (is.null(value) || !is.atomic(value) || length(value) != 1L || is.na(value)) {
+    return(NULL)
+  }
+  reason <- as.character(value)
+  if (!nzchar(reason)) {
+    return(NULL)
+  }
+  reason
+}
+
 #' Build the inner HTML of a method section.
 #' @param result *\[list\]* A `new_method_result`-shaped list.
 #' @param method_name *\[character\]* The method name.
@@ -256,12 +275,14 @@ count_plots <- function(result) {
 #' @return *\[character\]* The section body HTML.
 #' @keywords internal
 build_section_body <- function(result, method_name, graphics_dir, round_to) {
-  # A method that ran but skipped itself records the reason under meta$skipped.
-  skip_reason <- result$meta$skipped
-  if (!is.null(skip_reason) && nzchar(as.character(skip_reason)[[1]])) {
+  # A method that ran but skipped itself records the reason under
+  # meta$skip_reason. meta$skipped_models (partial skips) does not suppress the
+  # section, so it is deliberately not read here.
+  skip_reason <- scalar_skip_reason(result$meta$skip_reason)
+  if (!is.null(skip_reason)) {
     return(paste0(
       "<div class=\"report-skip\">This method was skipped: ",
-      html_escape(as.character(skip_reason)[[1]]), "</div>"
+      html_escape(skip_reason), "</div>"
     ))
   }
 

--- a/tests/testthat/test-bma-result-unwrap.R
+++ b/tests/testthat/test-bma-result-unwrap.R
@@ -223,7 +223,7 @@ test_that("fma skips gracefully instead of crashing when only one moderator is a
 
   expect_equal(nrow(result$tables$coefficients), 0)
   expect_null(result$meta$model)
-  expect_match(result$meta$skipped, "at least 2 candidate moderator variables")
+  expect_match(result$meta$skip_reason, "at least 2 candidate moderator variables")
 })
 
 test_that("resolve_bma_input_for_bpe surfaces the BMA skip reason when BMA cannot run", {

--- a/tests/testthat/test-bma.R
+++ b/tests/testthat/test-bma.R
@@ -367,7 +367,7 @@ test_that("bma skips with an explanatory reason instead of crashing on a single 
 
   expect_equal(nrow(result$tables$coefficients), 0)
   expect_true(is.null(result$meta$model))
-  expect_match(result$meta$skipped, "at least 2 candidate moderator variables")
+  expect_match(result$meta$skip_reason, "at least 2 candidate moderator variables")
 })
 
 test_that("prepare_bma_inputs excludes constant moderators before scaling", {

--- a/tests/testthat/test-econometric-exogeneity.R
+++ b/tests/testthat/test-econometric-exogeneity.R
@@ -412,7 +412,7 @@ test_that("run_exogeneity_tests skips gracefully when columns are missing", {
   res <- run_exogeneity_tests(data.frame(effect = 1:3, se = rep(1, 3)), default_exogeneity_options())
 
   expect_true(!is.null(res$skipped))
-  expect_true(grepl("study_id", res$skipped$reason))
+  expect_true(grepl("study_id", res$skipped))
 })
 
 test_that("run_exogeneity_tests aborts when a required package is absent", {

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -194,7 +194,7 @@ test_that("linear tests return tidy coefficients and summary", {
   expect_named(res$tables, "summary")
   expect_named(
     res$meta,
-    c("coefficients", "skipped", "options"),
+    c("coefficients", "skipped_models", "options"),
     ignore.order = TRUE
   )
 
@@ -245,8 +245,8 @@ test_that("linear tests gracefully skip models with missing columns", {
   res <- linear_tests(df)
 
   expect_false("ols_precision_weighted" %in% res$meta$coefficients$model)
-  expect_true("ols_precision_weighted" %in% names(res$meta$skipped))
-  expect_true(grepl("Missing required columns", res$meta$skipped$ols_precision_weighted$reason))
+  expect_true("ols_precision_weighted" %in% names(res$meta$skipped_models))
+  expect_true(grepl("Missing required columns", res$meta$skipped_models$ols_precision_weighted$reason))
 })
 
 test_that("bootstrap CIs are deterministic and seed-identical to the tidy-path implementation", {

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -158,8 +158,8 @@ test_that("p_hacking_tests surfaces the Cox-Shi skip reason in output and meta",
   expect_true(all(grepl("NA", cox_rows$`P-value`)))
 
   # The reason lands in meta for programmatic consumers.
-  expect_match(result$meta$skipped$cox_shi_005$reason, "singular")
-  expect_equal(result$meta$skipped$cox_shi_005$label, "Cox-Shi [0, 0.05]")
+  expect_match(result$meta$skipped_models$cox_shi_005$reason, "singular")
+  expect_equal(result$meta$skipped_models$cox_shi_005$label, "Cox-Shi [0, 0.05]")
 
   # And it is printed after the summary table instead of a bare NA.
   expect_true(any(grepl("singular", messages)))

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -67,7 +67,7 @@ test_that("nonlinear tests return tidy coefficients and summary", {
   expect_s3_class(res$plots$stem_mse, "recordedplot")
   expect_named(
     res$meta,
-    c("coefficients", "skipped", "options"),
+    c("coefficients", "skipped_models", "options"),
     ignore.order = TRUE
   )
 
@@ -154,7 +154,7 @@ test_that("selection model runs with negative and zero cutoffs and restructured 
 
   res <- suppressWarnings(suppressMessages(nonlinear_tests(df)))
 
-  expect_false("selection" %in% names(res$meta$skipped))
+  expect_false("selection" %in% names(res$meta$skipped_models))
   selection <- res$meta$coefficients[res$meta$coefficients$model == "selection", , drop = FALSE]
   expect_setequal(
     selection$term,
@@ -243,7 +243,7 @@ test_that("selection model runs with a single zero cutoff (sign selection)", {
 
   res <- suppressWarnings(suppressMessages(nonlinear_tests(df)))
 
-  expect_false("selection" %in% names(res$meta$skipped))
+  expect_false("selection" %in% names(res$meta$skipped_models))
   selection <- res$meta$coefficients[res$meta$coefficients$model == "selection", , drop = FALSE]
   expect_true("pub_prob_1" %in% selection$term)
   expect_true("Rel. Pub. Probability (-Inf, 0]" %in% selection$term_label)

--- a/tests/testthat/test-report-integration.R
+++ b/tests/testthat/test-report-integration.R
@@ -5,6 +5,7 @@ box::use(
     skip_on_cran,
     test_that
   ],
+  testing / mocks / index[MOCKS],
   withr[local_options, local_tempdir]
 )
 
@@ -59,4 +60,59 @@ test_that("artma() writes report.html when output.report is enabled", {
   expect_true(grepl("Effect Summary Stats", contents) || grepl("Funnel Plot", contents))
   # Plots the run wrote must be embedded, never linked.
   expect_true(grepl("data:image/png;base64,", contents, fixed = TRUE))
+})
+
+# Golden end-to-end: a realistic method set on mock data must produce a report
+# with one section per method. `linear_tests` is the important one: it records
+# partial skips as a named list, and the renderer used to abort on that shape,
+# which only surfaced as a warning in the middle of a long run (issue #414).
+test_that("artma() renders one report section per method for a real method set", {
+  skip_on_cran()
+
+  work <- local_tempdir()
+  data_path <- file.path(work, "mock.csv")
+  MOCKS$create_mock_df(with_file_creation = TRUE, file_path = data_path, seed = 414)
+
+  options_dir <- file.path(work, "options")
+  dir.create(options_dir)
+  output_dir <- file.path(work, "out")
+  dir.create(output_dir)
+
+  artma::options.create(
+    options_file_name = "golden_report.yaml",
+    options_dir = options_dir,
+    user_input = list(
+      data = list(source_path = data_path),
+      general = list(parallel = FALSE),
+      output = list(dir = output_dir, save_results = TRUE, report = TRUE)
+    )
+  )
+
+  local_options(artma.verbose = 1)
+
+  methods <- c("effect_summary_stats", "linear_tests", "funnel_plot")
+  suppressWarnings(artma::artma(
+    methods = methods,
+    options = "golden_report.yaml",
+    options_dir = options_dir
+  ))
+
+  report_path <- file.path(output_dir, "report.html")
+  expect_true(file.exists(report_path))
+
+  contents <- paste(readLines(report_path, warn = FALSE), collapse = "\n")
+  expect_gt(nchar(contents), 1000)
+
+  for (method_name in methods) {
+    anchor <- paste0("id=\"section-", gsub("_", "-", method_name), "\"")
+    expect_true(grepl(anchor, contents, fixed = TRUE))
+  }
+
+  # linear_tests ran, so its section must carry its results rather than a
+  # blanket "this method was skipped" body.
+  linear_section <- sub(
+    ".*id=\"section-linear-tests\"", "", contents
+  )
+  linear_section <- sub("id=\"section-.*", "", linear_section)
+  expect_true(!grepl("This method was skipped", linear_section, fixed = TRUE))
 })

--- a/tests/testthat/test-report-render.R
+++ b/tests/testthat/test-report-render.R
@@ -37,7 +37,7 @@ make_results <- function() {
     bma = list(
       tables = list(),
       plots = list(),
-      meta = list(skipped = "package BMS is not installed")
+      meta = list(skip_reason = "package BMS is not installed")
     )
   )
   attr(results, "skipped_methods") <- c(fma = "missing required column: se")
@@ -101,12 +101,43 @@ test_that("build_report_html passes significance marks through untouched", {
 
 test_that("build_report_html renders skip-reason sections, not silent drops", {
   html <- build_report_html(make_results(), round_to = 3)
-  # Self-skipped method (meta$skipped)
+  # Self-skipped method (meta$skip_reason)
   expect_match(html, "package BMS is not installed", fixed = TRUE)
   # Gate-skipped method (skipped_methods attribute)
   expect_match(html, "missing required column: se", fixed = TRUE)
   # Failed method (failed_methods attribute)
   expect_match(html, "instrument was too weak", fixed = TRUE)
+})
+
+test_that("build_report_html survives malformed skip reasons", {
+  # A method writing something other than a scalar string must not take the
+  # whole report down (issue #414: `as.character(list())[[1]]` errored).
+  for (bad in list(list(), list(fe = list(label = "FE", reason = "no clusters")), character(0), NA_character_, "")) {
+    results <- list(
+      linear_tests = list(
+        tables = list(summary = data.frame(model = "ols", estimate = 0.5)),
+        plots = list(),
+        meta = list(skip_reason = bad)
+      )
+    )
+    html <- build_report_html(results, round_to = 3)
+    expect_no_match(html, "This method was skipped", fixed = TRUE)
+    expect_match(html, "ols", fixed = TRUE)
+  }
+})
+
+test_that("build_report_html ignores skipped_models, which are partial skips", {
+  results <- list(
+    linear_tests = list(
+      tables = list(summary = data.frame(model = "ols", estimate = 0.5)),
+      plots = list(),
+      meta = list(skipped_models = list(fe = list(label = "FE", reason = "no clusters")))
+    )
+  )
+  html <- build_report_html(results, round_to = 3)
+
+  expect_no_match(html, "This method was skipped", fixed = TRUE)
+  expect_match(html, "ols", fixed = TRUE)
 })
 
 test_that("resolve_method_pngs matches by method name and alias", {

--- a/tests/testthat/test-robma.R
+++ b/tests/testthat/test-robma.R
@@ -64,7 +64,7 @@ test_that("robma skips when too few usable observations remain", {
 
   expect_equal(result$meta$n_obs, 1L)
   expect_null(result$meta$model)
-  expect_true(nzchar(result$meta$skipped))
+  expect_true(nzchar(result$meta$skip_reason))
   expect_s3_class(result$tables$summary, "data.frame")
   expect_equal(nrow(result$tables$summary), 0L)
 })
@@ -90,7 +90,7 @@ test_that("robma fits the ensemble and returns estimates and components", {
   # convergence checks, which is expected here.
   result <- suppressWarnings(robma(df))
 
-  expect_false(isTRUE(nzchar(result$meta$skipped)))
+  expect_false(isTRUE(nzchar(result$meta$skip_reason)))
   expect_equal(result$meta$n_obs, nrow(df))
   expect_true(!is.null(result$meta$model))
 

--- a/tests/testthat/test-runtime-methods.R
+++ b/tests/testthat/test-runtime-methods.R
@@ -205,3 +205,38 @@ test_that("get_runtime_method_modules ignores helper modules", {
   modules <- get_runtime_method_modules(modules_dir = methods_dir)
   expect_named(modules, "valid_method")
 })
+
+test_that("new_method_result enforces the two skip shapes", {
+  box::use(
+    artma / modules / runtime_methods[new_method_result]
+  )
+
+  expect_equal(
+    new_method_result(meta = list(skip_reason = "package BMS is not installed"))$meta$skip_reason,
+    "package BMS is not installed"
+  )
+  expect_equal(
+    new_method_result(meta = list(skipped_models = list(fe = list(label = "FE", reason = "no clusters"))))$meta$skipped_models$fe$reason,
+    "no clusters"
+  )
+  expect_equal(new_method_result(meta = list(skipped_models = list()))$meta$skipped_models, list())
+
+  # A named list of skipped sub-models belongs under `skipped_models`; passing
+  # it as the scalar reason is what broke the HTML report (issue #414).
+  expect_error(
+    new_method_result(meta = list(skip_reason = list())),
+    "must be a single string"
+  )
+  expect_error(
+    new_method_result(meta = list(skip_reason = list(fe = list(reason = "no clusters")))),
+    "must be a single string"
+  )
+  expect_error(
+    new_method_result(meta = list(skip_reason = c("a", "b"))),
+    "must be a single string"
+  )
+  expect_error(
+    new_method_result(meta = list(skipped_models = "no clusters")),
+    "must be a named list"
+  )
+})


### PR DESCRIPTION
`meta$skipped` carried three incompatible shapes across the method suite, and the HTML report assumed only one of them, so any run containing `linear_tests` or `nonlinear_tests` lost its report to a "subscript out of bounds" warning. The contract is now split: `meta$skip_reason` is the scalar reason the whole method did not run (bma, robma, maive, fma, exogeneity_tests), and `meta$skipped_models` is the named list of sub-models a method could not fit (linear_tests, nonlinear_tests, p_hacking_tests). `new_method_result()` documents and validates both shapes, and consumers (`build_section_body()`, `extract_ma_coefficients()`, `unwrap_bma_result()`) read the scalar key only. The renderer is defensive regardless: anything that is not a usable single string counts as "not skipped" rather than aborting the render. `exogeneity.R` now returns its skip reason as a plain string instead of `list(reason = ...)`.

Tests: a golden end-to-end run (effect_summary_stats + linear_tests + funnel_plot on mock data) asserts the report file exists and carries one section per method, so a render failure is now a hard test failure even though it stays a warning at runtime, which is still the right behavior mid-run. Plus contract tests on `new_method_result()` and renderer coverage for the malformed shapes.

Closes #414