### PR TITLE
fix: resolve absolute graphics path in writers and escape literal braces in options help

### DIFF
--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -1081,7 +1081,7 @@ output:
     help: |
       File formats used when exporting result tables. Accepts {.val csv} and
       {.val tex}. Add {.val tex} to also write booktabs LaTeX tables ready to be
-      included in a paper (requires `\usepackage{booktabs}` in your preamble).
+      included in a paper (requires `\usepackage{{booktabs}}` in your preamble).
       Defaults to {.val csv} only.
 
   number_of_decimals:

--- a/inst/artma/options/utils.R
+++ b/inst/artma/options/utils.R
@@ -194,13 +194,23 @@ validate_user_input <- function(user_input) {
 }
 
 #' @title Print options help text
-#' @description Print options help text
+#' @description Print options help text.
+#'
+#' Help strings are run through `cli::format_inline()` so they can use cli
+#' inline markup. That also makes them glue templates, so a literal brace in the
+#' text (`\usepackage{booktabs}`) is interpolated as an R expression and errors.
+#' Braces meant literally must be doubled in the template, but one malformed
+#' entry must not take down `options.help()` for a whole group, so fall back to
+#' the raw text instead of propagating the error.
 #' @param help *\[character\]* The help text to print
 #' @return `NULL`
 #' @export
 print_options_help_text <- function(help) {
   help_key <- cli::format_inline("{.strong Help}: ")
-  help_body <- cli::format_inline(help)
+  help_body <- tryCatch(
+    cli::format_inline(help),
+    error = function(e) paste(help, collapse = "\n")
+  )
   writeLines(paste0(help_key, help_body))
 }
 

--- a/inst/artma/output/export.R
+++ b/inst/artma/output/export.R
@@ -71,14 +71,25 @@ is_absolute_path <- function(path) {
 #'
 #' @description
 #' Reads the `artma.visualization.export_path` option (default: `"graphics"`)
-#' and resolves it relative to the given output directory. An absolute
+#' and resolves it relative to the given output directory. A `~` is expanded
+#' first, so `~/figures` is treated as the absolute path it denotes. An absolute
 #' `export_path` is returned as-is; joining it to `output_dir` would otherwise
 #' produce a nested copy of the whole absolute path under the results directory.
 #'
+#' This is the single place graphics paths are resolved. Every caller that needs
+#' the directory plots are written to must route through it, otherwise the
+#' directory that gets created and the directory that gets written to drift
+#' apart for absolute paths.
+#'
 #' @param output_dir *\[character\]* The base output directory.
+#' @param export_path *\[character, optional\]* The configured export path.
+#'   Defaults to the `artma.visualization.export_path` option.
 #' @return *\[character\]* The resolved graphics directory path.
-resolve_graphics_dir <- function(output_dir) {
-  export_path <- getOption("artma.visualization.export_path", "graphics")
+resolve_graphics_dir <- function(output_dir, export_path = NULL) {
+  export_path <- export_path %||% getOption("artma.visualization.export_path", "graphics")
+  if (length(export_path) == 1L && !is.na(export_path) && nzchar(export_path)) {
+    export_path <- path.expand(export_path)
+  }
   if (is_absolute_path(export_path)) {
     return(export_path)
   }

--- a/inst/artma/visualization/options.R
+++ b/inst/artma/visualization/options.R
@@ -42,12 +42,15 @@ get_visualization_options <- function() {
   assert(is.character(export_path), "export_path must be a character string")
   assert(is.numeric(graph_scale) && graph_scale > 0, "graph_scale must be a positive number")
 
-  # Resolve export_path relative to the unified output directory
+  # Resolve export_path against the unified output directory. This must go
+  # through resolve_graphics_dir(), the same helper ensure_output_dirs() and the
+  # report renderer use: joining an absolute export_path to the output directory
+  # here would write plots into a nested <output_dir>/<absolute path> copy while
+  # the rest of the package looked for them at the absolute path itself.
   save_results <- getOption("artma.output.save_results", TRUE)
   if (isTRUE(save_results)) {
-    box::use(artma / output / export[resolve_output_dir])
-    output_dir <- resolve_output_dir()
-    export_path <- file.path(output_dir, export_path)
+    box::use(artma / output / export[resolve_graphics_dir, resolve_output_dir])
+    export_path <- resolve_graphics_dir(resolve_output_dir(), export_path)
   }
 
   list(

--- a/tests/testthat/test-options-inspect.R
+++ b/tests/testthat/test-options-inspect.R
@@ -1,4 +1,4 @@
-box::use(testthat[test_that, expect_equal, expect_true, expect_false, expect_null, expect_setequal, expect_length, expect_identical, expect_named, expect_s3_class])
+box::use(testthat[test_that, expect_equal, expect_true, expect_false, expect_null, expect_setequal, expect_length, expect_identical, expect_named, expect_output, expect_s3_class])
 
 # A small template that mirrors the shape of the real one: several top-level
 # sections, a required option with no default, and a list-typed leaf.
@@ -290,4 +290,35 @@ test_that("value comparison tolerates YAML type noise but not missing keys", {
   expect_true(values_equal(NULL, NULL))
   expect_false(values_equal(NULL, NA))
   expect_false(values_equal("10", 10))
+})
+
+# Help strings are rendered through cli::format_inline(), which also makes them
+# glue templates: a literal brace (e.g. `\usepackage{booktabs}`) is evaluated as
+# an R expression and aborts. That took out `options.help("output")` entirely, so
+# guard both the template content and the renderer.
+test_that("every template help string renders without a glue error", {
+  box::use(artma / options / template[get_option_defs])
+
+  broken <- Filter(
+    function(def) {
+      txt <- def$help
+      if (is.null(txt) || !is.character(txt)) {
+        return(FALSE)
+      }
+      inherits(tryCatch(cli::format_inline(txt), error = function(e) e), "error")
+    },
+    get_option_defs()
+  )
+
+  expect_equal(vapply(broken, function(def) def$name, character(1)), character(0))
+})
+
+test_that("print_options_help_text falls back to raw text on a malformed help string", {
+  box::use(artma / options / utils[print_options_help_text])
+
+  expect_output(
+    print_options_help_text("requires \\usepackage{booktabs} in your preamble"),
+    "booktabs",
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-output-export.R
+++ b/tests/testthat/test-output-export.R
@@ -82,6 +82,48 @@ test_that("resolve_graphics_dir returns an absolute export path as-is", {
   expect_equal(resolve_graphics_dir("/base"), "/tmp/artma-graphics")
 })
 
+test_that("resolve_graphics_dir expands a tilde before testing for absoluteness", {
+  local_options(artma.visualization.export_path = "~/artma-graphics")
+  expect_equal(resolve_graphics_dir("/base"), path.expand("~/artma-graphics"))
+})
+
+test_that("resolve_graphics_dir accepts an explicit export path over the option", {
+  local_options(artma.visualization.export_path = "graphics")
+  expect_equal(resolve_graphics_dir("/base", "figs"), file.path("/base", "figs"))
+  expect_equal(resolve_graphics_dir("/base", "/tmp/figs"), "/tmp/figs")
+})
+
+# The writers read their target directory from get_visualization_options(),
+# not from resolve_graphics_dir() directly. When those two disagreed, an
+# absolute export path was created in one place and written to in another.
+test_that("get_visualization_options resolves the same directory as ensure_output_dirs", {
+  base <- local_tempdir()
+  graphics <- file.path(local_tempdir(), "elsewhere")
+  local_options(
+    artma.output.dir = base,
+    artma.output.save_results = TRUE,
+    artma.visualization.export_path = graphics
+  )
+
+  box::use(artma / visualization / options[get_visualization_options])
+
+  expect_equal(get_visualization_options()$export_path, resolve_graphics_dir(base))
+  expect_equal(get_visualization_options()$export_path, graphics)
+})
+
+test_that("get_visualization_options joins a relative export path to the output dir", {
+  base <- local_tempdir()
+  local_options(
+    artma.output.dir = base,
+    artma.output.save_results = TRUE,
+    artma.visualization.export_path = "graphics"
+  )
+
+  box::use(artma / visualization / options[get_visualization_options])
+
+  expect_equal(get_visualization_options()$export_path, file.path(base, "graphics"))
+})
+
 test_that("ensure_output_dirs honours an absolute export path", {
   base <- local_tempdir()
   graphics <- file.path(local_tempdir(), "elsewhere")


### PR DESCRIPTION
Round 1 verification of the usability audit (#423) found two defects. Both were caught by running the package, not by reading the diffs.

## 1. Absolute graphics export path was only half-fixed (#415)

c85b6bc added `resolve_graphics_dir()` so an absolute `artma.visualization.export_path` is not joined to the output directory. But that helper is only used by `ensure_output_dirs()` and the report renderer. The plot **writers** read their target from `get_visualization_options()`, which still did an unconditional `file.path(output_dir, export_path)`.

The result: the absolute directory got created and the report looked for images there, while the PNGs were written to a nested copy underneath the output dir. Before this change, with `visualization.export_path` set to an absolute path:

```
FILES_IN_ABS=0
OUTPUT_DIR_TREE:
  <out>/private/tmp/claude-501/.../scratchpad/v7/elsewhere/figs
  <out>/tables
```

After:

```
FILES_IN_ABS=3 -> funnel_plot_effect_precision.png, t_stat_histogram_close_up.png, t_stat_histogram_full_range.png
NESTED_ABS_PATH_UNDER_OUTPUT=0
```

`get_visualization_options()` now routes through `resolve_graphics_dir()`, so creation, writing, and report lookup all agree. `resolve_graphics_dir()` also gained an optional `export_path` argument and expands `~` before testing for absoluteness, so `~/figures` no longer produces a literal `~` directory under the output dir.

## 2. `options.help("output")` aborted on a literal brace (#420)

Help strings are rendered with `cli::format_inline()`, which makes them glue templates. `output.table_formats` documents `\usepackage{booktabs}`, and cli tried to evaluate `{booktabs}` as R:

```
! Could not evaluate cli `{}` expression: `booktabs`.
Caused by error in `eval(expr, envir = envir)`:
! object 'booktabs' not found
```

That took out `artma::options.help("output")` and `artma::options.help("output.table_formats")` entirely. The brace is now doubled in the template, and `print_options_help_text()` falls back to the raw text instead of propagating the error, so one malformed entry cannot take down help for a whole group. A scan of all 127 template help strings found this as the only occurrence; a test now keeps it that way.

## Verification

- `make test`: 0 failures, 2920 passing (2912 before, 8 new).
- `make lint`: no lints.
- `make check`: 0 errors, 0 notes. The remaining warning is the Apple clang `-Wfixed-enum-extension` toolchain warning from R's own headers, present before these changes.
- Both branches of the graphics path re-tested end to end: relative writes 3 PNGs into `<out>/graphics` with 3 images embedded in the report; absolute writes 3 PNGs to the absolute directory with nothing nested under the output dir.

Everything else in Round 1 (#413, #414, and the packaging half of #415) verified clean and is unchanged here.
