### PR TITLE
feat(output): add an unrounded tidy estimates slot to the method contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,13 +95,24 @@ Methods are auto-discovered by scanning `inst/artma/methods/`; `artma::methods.l
 
 #### Return contract
 
-Every method returns `new_method_result()`, a list with three slots:
+Every method returns `new_method_result()`, a list with four slots:
 
-- `tables`: named list of `data.frame`s exported as CSV by `export_method_result` (`inst/artma/output/export.R`). Keys `summary`/`coefficients`/`table` (or a key equal to the method name) export as `<method>.csv`; any other key as `<method>_<key>.csv`.
+- `tables`: named list of `data.frame`s exported by `export_method_result` (`inst/artma/output/export.R`). These are the display artifacts: rounded, formatted, laid out for a human. Keys `summary`/`coefficients`/`table` (or a key equal to the method name) export as `<method>.csv`; any other key as `<method>_<key>.csv`.
+- `estimates`: a single long-format `data.frame` of the method's unrounded numbers, built with `new_estimates()`. This is the machine-readable artifact.
 - `plots`: named list of plot objects for programmatic access and printing. Graphics files are written by each method during execution, not by the exporter.
 - `meta`: anything else downstream consumers need (models, fit params, skip reasons, auxiliary frames).
 
 Methods with a custom print method pass `class =` to `new_method_result()` and read their fields from `meta`/`plots` in `R/print.R`.
+
+#### Estimates schema
+
+`new_estimates()` (`inst/artma/modules/runtime_methods.R`) normalises a method's numbers into one schema shared by every method, so results bind across methods without knowing which produced them. The columns are fixed; unknown ones are an error, and anything outside the schema belongs in `meta`:
+
+`method`, `model`, `term`, `estimate`, `std_error`, `statistic`, `p_value`, `conf_low`, `conf_high`, `n_obs`, `n_clusters`, `note`
+
+Columns a method does not fill come back as typed `NA`s. `linear_tests` (`linear_tests_estimates()`) is the reference implementation.
+
+Rounding is a display concern: nothing on the `estimates` path may call `format_number()` or read `artma.output.number_of_decimals`. When a result carries an `estimates` frame, it takes the `<method>.csv` name and the display table moves to `<method>_display.csv`. LaTeX output stays driven by the display table under its original `<method>.tex` name, since it is inherently presentational.
 
 ### Options System
 

--- a/README.md
+++ b/README.md
@@ -246,12 +246,13 @@ Runtime methods live in `inst/artma/methods/`, one file per method, and are disc
 
 ```r
 box::use(
-  artma / modules / runtime_methods[new_method_result, register_runtime_method]
+  artma / modules / runtime_methods[new_estimates, new_method_result, register_runtime_method]
 )
 
 my_method <- function(df, ...) {
   new_method_result(
     tables = list(summary = my_summary_df),
+    estimates = new_estimates(my_tidy_df),
     plots = list(),
     meta = list()
   )
@@ -265,6 +266,8 @@ run <- register_runtime_method(
 
 box::export(my_method, run)
 ```
+
+The `tables` slot holds the display artifacts (rounded, formatted for a human reader); `estimates` holds the same numbers unrounded, in a long format shared by every method (`method`, `model`, `term`, `estimate`, `std_error`, `statistic`, `p_value`, `conf_low`, `conf_high`, `n_obs`, `n_clusters`, `note`), and is what a downstream pipeline reads from `<method>.csv`.
 
 Method parameters beyond the data frame come from the options system, so custom methods are configured the same way as built-in ones. See [README-dev.md](README-dev.md) for the full developer setup.
 

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -68,11 +68,51 @@ linear_tests <- function(df) {
 
   invisible(new_method_result(
     tables = list(summary = results$summary),
+    estimates = linear_tests_estimates(results$coefficients),
     meta = list(
       coefficients = results$coefficients,
       skipped_models = results$skipped,
       options = results$options
     )
+  ))
+}
+
+#' @title Tidy estimates for the linear tests
+#' @description
+#' Map the per-model coefficient frame onto the shared `estimates` schema. The
+#' numbers are carried over verbatim: the rounded and formatted columns that sit
+#' alongside them in `coefficients` belong to the display table only.
+#' @param coefficients *\[data.frame\]* The coefficient frame from
+#'   `run_linear_models()`.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+linear_tests_estimates <- function(coefficients) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.data.frame(coefficients) || nrow(coefficients) == 0L) {
+    return(new_estimates())
+  }
+
+  # The display table marks these rows with a dagger; the note carries the same
+  # warning for a consumer that never sees the formatted table.
+  conflict <- coefficients$ci_conflict %||% rep(NA, nrow(coefficients))
+  note <- rep(NA_character_, nrow(coefficients))
+  note[!is.na(conflict) & conflict] <- "Bootstrap confidence interval and analytic significance disagree"
+
+  new_estimates(data.frame(
+    method = "linear_tests",
+    model = coefficients$model,
+    term = coefficients$term,
+    estimate = coefficients$estimate,
+    std_error = coefficients$std_error,
+    statistic = coefficients$statistic,
+    p_value = coefficients$p_value,
+    conf_low = coefficients$bootstrap_lower,
+    conf_high = coefficients$bootstrap_upper,
+    n_obs = coefficients$n_obs,
+    note = note,
+    stringsAsFactors = FALSE
   ))
 }
 
@@ -123,4 +163,4 @@ run <- register_runtime_method(
   required_columns = c("effect", "se", "study_id")
 )
 
-box::export(linear_tests, resolve_linear_tests_options, run)
+box::export(linear_tests, linear_tests_estimates, resolve_linear_tests_options, run)

--- a/inst/artma/modules/runtime_methods.R
+++ b/inst/artma/modules/runtime_methods.R
@@ -7,13 +7,103 @@ box::use(
 # Modules can opt out of runtime registration by setting this flag to FALSE.
 RUNTIME_METHOD_MARKER <- ".__runtime_method__"
 
+#' @title Estimates schema
+#' @description
+#' The fixed column set of the `estimates` slot, in export order. Every runtime
+#' method that reports numbers uses this one schema, so a downstream consumer
+#' can bind results across methods without knowing which method produced them.
+ESTIMATES_COLUMNS <- c(
+  "method", "model", "term", "estimate", "std_error", "statistic",
+  "p_value", "conf_low", "conf_high", "n_obs", "n_clusters", "note"
+)
+
+# The cast applied to each schema column, which doubles as the source of its
+# typed `NA` when a method does not fill the column.
+ESTIMATES_CASTS <- list(
+  method = as.character,
+  model = as.character,
+  term = as.character,
+  estimate = as.numeric,
+  std_error = as.numeric,
+  statistic = as.numeric,
+  p_value = as.numeric,
+  conf_low = as.numeric,
+  conf_high = as.numeric,
+  n_obs = as.integer,
+  n_clusters = as.integer,
+  note = as.character
+)
+
+#' @title Build a tidy estimates frame
+#' @description
+#' Normalise a method's numeric results into the shared long-format schema of
+#' the `estimates` slot. Columns a method does not fill are added as typed
+#' `NA`s, and the columns come back in the canonical order.
+#'
+#' The schema is:
+#'
+#' * `method`: the runtime method name (`"linear_tests"`).
+#' * `model`: the sub-model within the method (`"ols"`, `"fixed_effects"`), or
+#'   `NA` for a method with a single model.
+#' * `term`: what is being estimated (`"effect"`, `"publication_bias"`).
+#' * `estimate`, `std_error`, `statistic`, `p_value`: the point estimate and
+#'   its inference, all unrounded.
+#' * `conf_low`, `conf_high`: the confidence interval bounds, unrounded.
+#' * `n_obs`, `n_clusters`: the observation and cluster counts behind the row.
+#' * `note`: a short free-text caveat (`NA` when there is nothing to flag).
+#'
+#' Values are never rounded or formatted here: rounding is a display concern
+#' and belongs to the `tables` slot alone.
+#'
+#' @param ... Either a single `data.frame` holding a subset of the schema
+#'   columns, or named vectors passed as `data.frame()` arguments (scalars are
+#'   recycled). Columns outside the schema are an error; put method-specific
+#'   extras in `meta`.
+#' @return *\[data.frame\]* A frame with exactly the schema columns, in order.
+new_estimates <- function(...) {
+  args <- list(...)
+
+  if (length(args) == 0L) {
+    df <- data.frame()
+  } else if (length(args) == 1L && is.data.frame(args[[1L]])) {
+    df <- args[[1L]]
+  } else {
+    df <- data.frame(..., stringsAsFactors = FALSE)
+  }
+
+  unknown <- setdiff(names(df), ESTIMATES_COLUMNS)
+  if (length(unknown) > 0L) {
+    cli::cli_abort(c(
+      "Unknown column{?s} in an {.field estimates} frame: {.val {unknown}}.",
+      "i" = "The schema is fixed: {.val {ESTIMATES_COLUMNS}}.",
+      "i" = "Anything outside it belongs in {.field meta}."
+    ))
+  }
+
+  n_rows <- nrow(df)
+  columns <- lapply(ESTIMATES_COLUMNS, function(column) {
+    cast <- ESTIMATES_CASTS[[column]]
+    values <- df[[column]]
+    if (is.null(values)) rep(cast(NA), n_rows) else cast(values)
+  })
+  names(columns) <- ESTIMATES_COLUMNS
+
+  as.data.frame(columns, stringsAsFactors = FALSE, row.names = NULL)
+}
+
 #' @title Standard runtime method return contract
 #' @description
-#' Build the value every runtime method returns. The contract has three slots:
+#' Build the value every runtime method returns. The contract has four slots:
 #'
-#' * `tables`: a named list of `data.frame`s destined for CSV export. The
+#' * `tables`: a named list of `data.frame`s destined for export. These are the
+#'   display artifacts: rounded, formatted, laid out for a human reader. The
 #'   exporter walks this list; keys become filename suffixes (see
 #'   `export_method_result`).
+#' * `estimates`: a single long-format `data.frame` of the method's unrounded
+#'   numbers, in the shared schema built by `new_estimates()`. This is the
+#'   machine-readable artifact, exported as `<method>.csv`; whatever is passed
+#'   here is normalised through `new_estimates()`. `NULL` for a method that
+#'   reports no estimates (a plot-only method).
 #' * `plots`: a named list of plot objects (for example `ggplot`s) for
 #'   programmatic access and printing. Graphics files are written by the method
 #'   during execution, not by this contract.
@@ -36,12 +126,26 @@ RUNTIME_METHOD_MARKER <- ".__runtime_method__"
 #' @param plots *\[list\]* Named list of plot objects.
 #' @param meta *\[list\]* Named list of method-specific extras. `skip_reason`
 #'   and `skipped_models`, when present, must follow the shapes above.
+#' @param estimates *\[data.frame, optional\]* The method's unrounded numbers in
+#'   the shared schema (see `new_estimates()`), or `NULL`.
 #' @param class *\[character, optional\]* Extra S3 class(es) to prepend, used by
 #'   methods that ship a bespoke print method.
-#' @return *\[list\]* A list with `tables`, `plots`, and `meta` elements.
-new_method_result <- function(tables = list(), plots = list(), meta = list(), class = NULL) {
+#' @return *\[list\]* A list with `tables`, `estimates`, `plots`, and `meta`
+#'   elements.
+new_method_result <- function(tables = list(), plots = list(), meta = list(),
+                              estimates = NULL, class = NULL) {
   if (!is.list(tables) || !is.list(plots) || !is.list(meta)) {
     cli::cli_abort("`tables`, `plots`, and `meta` must all be lists.")
+  }
+
+  if (!is.null(estimates)) {
+    if (!is.data.frame(estimates)) {
+      cli::cli_abort(c(
+        "`estimates` must be a {.cls data.frame} in the shared schema, or `NULL`.",
+        "i" = "Build it with {.fn new_estimates}."
+      ))
+    }
+    estimates <- new_estimates(estimates)
   }
 
   skip_reason <- meta$skip_reason
@@ -61,7 +165,7 @@ new_method_result <- function(tables = list(), plots = list(), meta = list(), cl
     ))
   }
 
-  result <- list(tables = tables, plots = plots, meta = meta)
+  result <- list(tables = tables, estimates = estimates, plots = plots, meta = meta)
 
   if (!is.null(class)) {
     class(result) <- c(class, class(result))
@@ -363,12 +467,14 @@ get_runtime_method_modules <- function(
 }
 
 box::export(
+  ESTIMATES_COLUMNS,
   get_method_metadata,
   get_runtime_method_modules,
   METHOD_META_ATTR,
   missing_required_columns,
   missing_suggested_packages,
   module_should_be_runtime_method,
+  new_estimates,
   new_method_result,
   register_runtime_method,
   RUNTIME_METHOD_MARKER,

--- a/inst/artma/output/export.R
+++ b/inst/artma/output/export.R
@@ -183,9 +183,9 @@ save_table <- function(df, name, output_dir, formats = resolve_table_formats()) 
 #'
 #' @description
 #' Iterates over a named list of method results and exports each method's
-#' tabular data (the `tables` slot of the standard return contract) as CSV
-#' files. Graphics are written by each method during execution, so plot-only
-#' methods simply contribute no tables here.
+#' tabular data (the `estimates` and `tables` slots of the standard return
+#' contract). Graphics are written by each method during execution, so
+#' plot-only methods simply contribute no tables here.
 #'
 #' @param results *\[list\]* Named list of method results from `invoke_runtime_methods()`.
 #' @param output_dir *\[character\]* The base output directory.
@@ -232,12 +232,19 @@ resolve_table_basename <- function(method_name, key) {
 #' Export a single method's result
 #'
 #' @description
-#' A generic walk over the standard return contract. Every `data.frame` in the
-#' result's `tables` slot is written in each configured table format (see
-#' `resolve_table_formats()`); everything else (`plots`, `meta`) is ignored
-#' here. There are no per-method branches.
+#' A generic walk over the standard return contract. When the result carries an
+#' `estimates` frame, that frame is the machine-readable artifact and takes the
+#' `<method_name>.csv` name: it is written unrounded, exactly as the method
+#' produced it, and the display table that would otherwise own that name moves
+#' to `<method_name>_display.csv`. LaTeX output is inherently presentational, so
+#' it stays driven by the display tables under their original names and the
+#' `estimates` frame is never written as `.tex`.
 #'
-#' @param result The method's return value (a `list` with a `tables` slot).
+#' Everything else (`plots`, `meta`) is ignored here. There are no per-method
+#' branches.
+#'
+#' @param result The method's return value (a `list` with `tables` and
+#'   `estimates` slots).
 #' @param method_name *\[character\]* The method name.
 #' @param output_dir *\[character\]* The base output directory.
 #' @keywords internal
@@ -246,18 +253,40 @@ export_method_result <- function(result, method_name, output_dir) {
     return(invisible())
   }
 
+  formats <- resolve_table_formats()
+  write_csv <- "csv" %in% formats
+  write_tex <- "tex" %in% formats
+
+  estimates <- result$estimates
+  has_estimates <- is.data.frame(estimates)
+  if (has_estimates && write_csv) {
+    save_table(estimates, method_name, output_dir, formats = "csv")
+  }
+
   tables <- result$tables
   if (!is.list(tables) || length(tables) == 0L) {
     return(invisible())
   }
 
-  formats <- resolve_table_formats()
   table_names <- names(tables)
   for (i in seq_along(tables)) {
     tbl <- tables[[i]]
     if (!is.data.frame(tbl)) next
     key <- if (is.null(table_names)) NULL else table_names[[i]]
-    save_table(tbl, resolve_table_basename(method_name, key), output_dir, formats = formats)
+    table_basename <- resolve_table_basename(method_name, key)
+
+    if (write_csv) {
+      csv_basename <- if (has_estimates && identical(table_basename, method_name)) {
+        paste0(method_name, "_display")
+      } else {
+        table_basename
+      }
+      save_table(tbl, csv_basename, output_dir, formats = "csv")
+    }
+
+    if (write_tex) {
+      save_table(tbl, table_basename, output_dir, formats = "tex")
+    }
   }
 
   invisible()

--- a/tests/testthat/test-best-practice-estimate.R
+++ b/tests/testthat/test-best-practice-estimate.R
@@ -93,7 +93,7 @@ test_that("best_practice_estimate uses provided BMA result and returns structure
   bma_result <- bma(df)
   result <- best_practice_estimate(df, bma_result = bma_result)
 
-  expect_named(result, c("tables", "plots", "meta"))
+  expect_named(result, c("tables", "estimates", "plots", "meta"))
   expect_named(
     result$tables,
     c("summary", "economic_significance", "summary_by_factor"),
@@ -517,7 +517,7 @@ test_that("best_practice_estimate pins its full table/meta/plot contract on fixt
   bma_result <- bma(df)
   result <- best_practice_estimate(df, bma_result = bma_result)
 
-  expect_named(result, c("tables", "plots", "meta"))
+  expect_named(result, c("tables", "estimates", "plots", "meta"))
   expect_setequal(names(result$tables), c("summary", "economic_significance", "summary_by_factor"))
   expect_setequal(
     names(result$meta),

--- a/tests/testthat/test-funnel-plot.R
+++ b/tests/testthat/test-funnel-plot.R
@@ -57,7 +57,7 @@ test_that("funnel_plot creates a plot with required columns", {
   result <- funnel_plot(df)
 
   expect_s3_class(result, "artma_funnel_plot")
-  expect_named(result, c("tables", "plots", "meta"))
+  expect_named(result, c("tables", "estimates", "plots", "meta"))
   expect_named(result$plots, "funnel_plot")
   expect_named(
     result$meta,

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -3,6 +3,7 @@ box::use(
     expect_equal,
     expect_false,
     expect_gt,
+    expect_match,
     expect_message,
     expect_named,
     expect_no_message,
@@ -190,7 +191,7 @@ test_that("linear tests return tidy coefficients and summary", {
 
   res <- linear_tests(df)
 
-  expect_named(res, c("tables", "plots", "meta"))
+  expect_named(res, c("tables", "estimates", "plots", "meta"))
   expect_named(res$tables, "summary")
   expect_named(
     res$meta,
@@ -836,4 +837,70 @@ test_that("panel models are skipped with a clear message when plm is unavailable
   expect_true(all(grepl("install.packages", reasons, fixed = TRUE)))
 
   expect_true("ols" %in% res$coefficients$model)
+})
+
+test_that("linear tests return unrounded estimates in the shared schema", {
+  skip_if_not_installed("plm")
+
+  box::use(
+    artma / modules / runtime_methods[ESTIMATES_COLUMNS]
+  )
+
+  df <- make_demo_data()
+
+  local_options(
+    "artma.methods.add_significance_marks" = TRUE,
+    "artma.methods.linear_tests.bootstrap_replications" = 10L,
+    "artma.methods.linear_tests.conf_level" = 0.9,
+    "artma.output.number_of_decimals" = 2,
+    "artma.verbose" = 1
+  )
+
+  res <- linear_tests(df)
+  estimates <- res$estimates
+
+  expect_named(estimates, ESTIMATES_COLUMNS)
+  expect_equal(nrow(estimates), nrow(res$meta$coefficients))
+  expect_equal(unique(estimates$method), "linear_tests")
+  expect_equal(sort(unique(estimates$term)), c("effect", "publication_bias"))
+
+  expect_true(is.numeric(estimates$estimate))
+  expect_true(is.numeric(estimates$std_error))
+  expect_true(is.numeric(estimates$p_value))
+  expect_true(is.integer(estimates$n_obs))
+
+  # The numbers come straight from the model, untouched by the display
+  # rounding that `artma.output.number_of_decimals` drives.
+  expect_equal(estimates$estimate, res$meta$coefficients$estimate)
+  expect_equal(estimates$std_error, res$meta$coefficients$std_error)
+  expect_false(all(estimates$estimate == round(estimates$estimate, 2)))
+})
+
+test_that("linear_tests_estimates flags CI conflicts and handles an empty frame", {
+  box::use(
+    artma / methods / linear_tests[linear_tests_estimates]
+  )
+
+  coefficients <- data.frame(
+    model = c("ols", "fe"),
+    term = c("effect", "effect"),
+    estimate = c(0.1, 0.2),
+    std_error = c(0.01, 0.02),
+    statistic = c(10, 10),
+    p_value = c(0.001, 0.2),
+    bootstrap_lower = c(0.05, -0.1),
+    bootstrap_upper = c(0.15, 0.3),
+    n_obs = c(30L, 30L),
+    ci_conflict = c(FALSE, TRUE),
+    stringsAsFactors = FALSE
+  )
+
+  estimates <- linear_tests_estimates(coefficients)
+  expect_true(is.na(estimates$note[1]))
+  expect_match(estimates$note[2], "disagree")
+  expect_equal(estimates$conf_low, coefficients$bootstrap_lower)
+
+  empty <- linear_tests_estimates(data.frame())
+  expect_equal(nrow(empty), 0L)
+  expect_true(is.numeric(empty$estimate))
 })

--- a/tests/testthat/test-nonlinear-tests.R
+++ b/tests/testthat/test-nonlinear-tests.R
@@ -60,7 +60,7 @@ test_that("nonlinear tests return tidy coefficients and summary", {
 
   res <- suppressWarnings(nonlinear_tests(df))
 
-  expect_named(res, c("tables", "plots", "meta"))
+  expect_named(res, c("tables", "estimates", "plots", "meta"))
   expect_named(res$tables, "summary")
   expect_named(res$plots, c("stem_funnel", "stem_mse"))
   expect_s3_class(res$plots$stem_funnel, "recordedplot")

--- a/tests/testthat/test-output-export.R
+++ b/tests/testthat/test-output-export.R
@@ -314,3 +314,92 @@ test_that("export_results skips non-data-frame entries in the tables slot", {
   expect_true(file.exists(file.path(dir, "tables", "m.csv")))
   expect_false(file.exists(file.path(dir, "tables", "m_junk.csv")))
 })
+
+# estimates slot ------------------------------------------------------------
+
+make_estimates <- function() {
+  box::use(artma / modules / runtime_methods[new_estimates])
+  new_estimates(data.frame(
+    method = "linear_tests",
+    model = c("ols", "fixed_effects"),
+    term = "publication_bias",
+    estimate = c(-0.1294827361, -0.1281193744),
+    std_error = c(0.0451927364, 0.0483112947),
+    p_value = c(0.0042719384, 0.0081264739),
+    stringsAsFactors = FALSE
+  ))
+}
+
+test_that("export_results writes estimates as <method>.csv and moves the display table", {
+  dir <- setup_output_dir()
+  display <- data.frame(Metric = "Publication Bias", OLS = "-0.129***")
+
+  export_results(
+    list(linear_tests = list(tables = list(summary = display), estimates = make_estimates())),
+    dir
+  )
+
+  expect_true(file.exists(file.path(dir, "tables", "linear_tests.csv")))
+  expect_true(file.exists(file.path(dir, "tables", "linear_tests_display.csv")))
+
+  written_display <- utils::read.csv(file.path(dir, "tables", "linear_tests_display.csv"), stringsAsFactors = FALSE)
+  expect_equal(written_display$OLS, "-0.129***")
+})
+
+test_that("exported estimates round-trip as unrounded numerics", {
+  dir <- setup_output_dir()
+  local_options(artma.output.number_of_decimals = 3)
+  estimates <- make_estimates()
+
+  export_results(list(linear_tests = list(tables = list(summary = data.frame(a = 1)), estimates = estimates)), dir)
+
+  written <- utils::read.csv(file.path(dir, "tables", "linear_tests.csv"), stringsAsFactors = FALSE)
+  expect_true(is.numeric(written$estimate))
+  expect_true(is.numeric(written$std_error))
+  expect_true(is.numeric(written$p_value))
+  expect_equal(written$estimate, estimates$estimate)
+  # Display precision must not leak into the machine-readable artifact.
+  expect_false(any(written$estimate == round(written$estimate, 3)))
+})
+
+test_that("export_results keeps sub-table names when estimates are present", {
+  dir <- setup_output_dir()
+
+  export_results(
+    list(p_hacking_tests = list(
+      tables = list(summary = data.frame(a = 1), caliper = data.frame(x = 1)),
+      estimates = make_estimates()
+    )),
+    dir
+  )
+
+  files <- list.files(file.path(dir, "tables"))
+  expect_true(all(c(
+    "p_hacking_tests.csv", "p_hacking_tests_display.csv", "p_hacking_tests_caliper.csv"
+  ) %in% files))
+})
+
+test_that("export_results leaves display names alone without an estimates slot", {
+  dir <- setup_output_dir()
+
+  export_results(list(bma = list(tables = list(summary = data.frame(a = 1)))), dir)
+
+  expect_equal(list.files(file.path(dir, "tables")), "bma.csv")
+})
+
+test_that("estimates are never written as LaTeX and the display table keeps <method>.tex", {
+  dir <- setup_output_dir()
+  local_options(artma.output.table_formats = c("csv", "tex"))
+
+  export_results(
+    list(linear_tests = list(
+      tables = list(summary = data.frame(Metric = "Publication Bias", OLS = "-0.129***")),
+      estimates = make_estimates()
+    )),
+    dir
+  )
+
+  contents <- readLines(file.path(dir, "tables", "linear_tests.tex"))
+  expect_true(any(grepl("-0.129", contents, fixed = TRUE)))
+  expect_false(file.exists(file.path(dir, "tables", "linear_tests_display.tex")))
+})

--- a/tests/testthat/test-runtime-methods.R
+++ b/tests/testthat/test-runtime-methods.R
@@ -240,3 +240,76 @@ test_that("new_method_result enforces the two skip shapes", {
     "must be a named list"
   )
 })
+
+test_that("new_estimates fills the whole schema with typed NAs", {
+  box::use(
+    artma / modules / runtime_methods[ESTIMATES_COLUMNS, new_estimates]
+  )
+
+  estimates <- new_estimates(data.frame(
+    method = "linear_tests",
+    term = c("effect", "publication_bias"),
+    estimate = c(0.0571234, -0.1289876),
+    stringsAsFactors = FALSE
+  ))
+
+  expect_named(estimates, ESTIMATES_COLUMNS)
+  expect_equal(nrow(estimates), 2L)
+  expect_equal(estimates$method, rep("linear_tests", 2L))
+  # Unfilled columns are typed NAs, not dropped and not characters.
+  expect_true(is.numeric(estimates$std_error))
+  expect_true(all(is.na(estimates$std_error)))
+  expect_true(is.integer(estimates$n_clusters))
+  expect_true(is.character(estimates$note))
+  # Values pass through untouched: no rounding anywhere on this path.
+  expect_equal(estimates$estimate, c(0.0571234, -0.1289876))
+})
+
+test_that("new_estimates returns an empty typed frame with no input", {
+  box::use(
+    artma / modules / runtime_methods[ESTIMATES_COLUMNS, new_estimates]
+  )
+
+  estimates <- new_estimates()
+
+  expect_named(estimates, ESTIMATES_COLUMNS)
+  expect_equal(nrow(estimates), 0L)
+  expect_true(is.numeric(estimates$p_value))
+  expect_true(is.character(estimates$model))
+})
+
+test_that("new_estimates coerces column types and rejects unknown columns", {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  estimates <- new_estimates(data.frame(
+    model = factor("ols"),
+    n_obs = 1000,
+    stringsAsFactors = FALSE
+  ))
+  expect_equal(estimates$model, "ols")
+  expect_true(is.integer(estimates$n_obs))
+
+  expect_error(
+    new_estimates(data.frame(term = "effect", bootstrap_lower = 0.1)),
+    "Unknown column"
+  )
+})
+
+test_that("new_method_result normalises the estimates slot", {
+  box::use(
+    artma / modules / runtime_methods[ESTIMATES_COLUMNS, new_method_result]
+  )
+
+  result <- new_method_result(
+    tables = list(summary = data.frame(a = 1)),
+    estimates = data.frame(term = "effect", estimate = 0.25)
+  )
+
+  expect_named(result$estimates, ESTIMATES_COLUMNS)
+  expect_equal(result$estimates$estimate, 0.25)
+
+  expect_equal(new_method_result()$estimates, NULL)
+  expect_error(new_method_result(estimates = "not a frame"), "must be a")
+})

--- a/tests/testthat/test-t-stat-histogram.R
+++ b/tests/testthat/test-t-stat-histogram.R
@@ -62,7 +62,7 @@ test_that("t_stat_histogram creates both plots with defaults", {
   result <- t_stat_histogram(df)
 
   expect_s3_class(result, "artma_t_stat_histogram")
-  expect_named(result, c("tables", "plots", "meta"))
+  expect_named(result, c("tables", "estimates", "plots", "meta"))
   expect_named(result$plots, c("plot_main", "plot_close_up"))
   expect_named(result$meta, c(
     "n_observations", "n_outliers_main", "n_outliers_close_up",


### PR DESCRIPTION
Adds a fourth slot to the runtime method return contract: `estimates`, a single long-format data frame of unrounded numbers in a schema shared by every method (`method`, `model`, `term`, `estimate`, `std_error`, `statistic`, `p_value`, `conf_low`, `conf_high`, `n_obs`, `n_clusters`, `note`), built by the new `new_estimates()` helper. When a result carries one, the exporter writes it as the primary `<method>.csv` and moves the display table to `<method>_display.csv`; LaTeX stays driven by the display table under its original `<method>.tex` name, since it is presentational. Nothing on the estimates path rounds or formats. `linear_tests` is the reference implementation (its `meta$coefficients` was already the right shape); the rollout to the remaining methods is #417, and `tables` is untouched so existing consumers and `R/print.R` keep working.

Closes #416