### PR TITLE
feat(output): roll the estimates slot out across the remaining runtime methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,11 @@ Methods with a custom print method pass `class =` to `new_method_result()` and r
 
 `method`, `model`, `term`, `estimate`, `std_error`, `statistic`, `p_value`, `conf_low`, `conf_high`, `n_obs`, `n_clusters`, `note`
 
-Columns a method does not fill come back as typed `NA`s. `linear_tests` (`linear_tests_estimates()`) is the reference implementation.
+Columns a method does not fill come back as typed `NA`s. `linear_tests` (`linear_tests_estimates()`) is the reference implementation. Every method builds its frame in a standalone `*_estimates()` function that takes the method's own numeric results and returns the shared schema, so the mapping is unit-testable without running the method.
 
-Rounding is a display concern: nothing on the `estimates` path may call `format_number()` or read `artma.output.number_of_decimals`. When a result carries an `estimates` frame, it takes the `<method>.csv` name and the display table moves to `<method>_display.csv`. LaTeX output stays driven by the display table under its original `<method>.tex` name, since it is inherently presentational.
+Every method that reports numbers must fill the slot: `tests/testthat/test-method-estimates-contract.R` walks each discovered method's parse tree and fails when `new_method_result()` is called without an `estimates` argument. Plot-only methods (`funnel_plot`, `box_plot`, `t_stat_histogram`, `prima_facie_graphs`) are listed there as the explicit exception.
+
+Rounding is a display concern: nothing on the `estimates` path may call `format_number()` or read `artma.output.number_of_decimals`. When a result carries a non-empty `estimates` frame, it takes the `<method>.csv` name and the display table moves to `<method>_display.csv`; an empty frame is treated as no estimates at all, so no header-only CSV is written. LaTeX output stays driven by the display table under its original `<method>.tex` name, since it is inherently presentational.
 
 ### Options System
 

--- a/R/artma.R
+++ b/R/artma.R
@@ -561,29 +561,29 @@ invoke_runtime_methods <- function(methods, df, modules_dir = NULL, ...) {
   }
 
   # Build unified MA table when BMA and/or FMA have produced results. Both
-  # methods return the standard contract, so the coefficient frame lives in
-  # `tables$coefficients` and skip reasons under `meta$skip_reason`.
-  extract_ma_coefficients <- function(result) {
+  # methods return the standard contract, so the unrounded numbers live in the
+  # `estimates` slot and skip reasons under `meta$skip_reason`.
+  extract_ma_estimates <- function(result) {
     if (is.null(result) || !is.list(result) || !is.null(result$meta$skip_reason)) {
       return(NULL)
     }
-    coefs <- result$tables$coefficients
-    if (is.null(coefs) || !is.data.frame(coefs) || nrow(coefs) == 0) {
+    estimates <- result$estimates
+    if (is.null(estimates) || !is.data.frame(estimates) || nrow(estimates) == 0) {
       return(NULL)
     }
-    coefs
+    estimates
   }
 
-  bma_coefs <- extract_ma_coefficients(results[["bma"]])
-  fma_coefs <- extract_ma_coefficients(results[["fma"]])
+  bma_estimates <- extract_ma_estimates(results[["bma"]])
+  fma_estimates <- extract_ma_estimates(results[["fma"]])
 
-  if (!is.null(bma_coefs) || !is.null(fma_coefs)) {
+  if (!is.null(bma_estimates) || !is.null(fma_estimates)) {
     box::use(artma / output / ma_table[build_ma_table, display_ma_table])
 
     round_to <- as.integer(getOption("artma.output.number_of_decimals", 3))
     ma_table <- build_ma_table(
-      bma_coefficients = bma_coefs,
-      fma_coefficients = fma_coefs,
+      bma_estimates = bma_estimates,
+      fma_estimates = fma_estimates,
       round_to = round_to
     )
 

--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -48,6 +48,13 @@ support_label <- function(p_max) {
   format(p_max, nsmall = 2)
 }
 
+#' @title Interval label for an Elliott support upper bound
+#' @param p_max *[numeric]* Support upper bound, e.g. `0.05`.
+#' @return *[character]* Label such as `"[0, 0.05]"`.
+support_interval_label <- function(p_max) {
+  paste0("[0, ", support_label(p_max), "]")
+}
+
 # Caliper tests (Gerber & Malhotra, 2008) ---------------------------------
 
 CALIPER_TAILS <- c("auto", "positive", "negative", "absolute")
@@ -249,7 +256,10 @@ run_single_caliper <- function(t_stats, threshold = 1.96, width = 0.05,
 #' @param add_significance_marks *[logical]* Whether to add significance marks.
 #' @param round_to *[integer]* Number of decimal places.
 #' @param show_progress *[logical]* Whether to show progress indicator.
-#' @return *[data.frame]* Caliper test results.
+#' @return *[list]* One entry per threshold-width pair. `share_above` and
+#'   `p_value` hold the unrounded numbers; `share_above_formatted` and
+#'   `p_value_formatted` hold the rounded, starred strings the summary table
+#'   prints.
 run_caliper_tests <- function(t_stats, thresholds = c(1.645, 1.96, 2.58),
                               widths = c(0.05, 0.1, 0.2), study_id = NULL,
                               tail = "auto",
@@ -310,8 +320,10 @@ run_caliper_tests <- function(t_stats, thresholds = c(1.645, 1.96, 2.58),
       results[[length(results) + 1]] <- list(
         threshold = thresh,
         width = w,
-        share_above = share_formatted,
-        p_value = p_value_formatted,
+        share_above = res$share_above,
+        p_value = res$p_value,
+        share_above_formatted = share_formatted,
+        p_value_formatted = p_value_formatted,
         n_above = res$n_above,
         n_below = res$n_below,
         n_studies = res$n_studies,
@@ -375,9 +387,9 @@ build_caliper_summary <- function(caliper_results, options) {
         vapply(caliper_results, function(x) x$width == w && x$threshold == thresh, logical(1))
       )]]
 
-      result[row_idx, col_idx + 1] <- res$share_above
+      result[row_idx, col_idx + 1] <- res$share_above_formatted
       result[row_idx + 1, col_idx + 1] <- caliper_direction_label(res$direction)
-      result[row_idx + 2, col_idx + 1] <- res$p_value
+      result[row_idx + 2, col_idx + 1] <- res$p_value_formatted
       # Display ratio or total based on option
       counts <- if (display_ratios) {
         paste0(res$n_above, "/", res$n_below)
@@ -663,6 +675,9 @@ run_p_hacking_tests <- function(df, options) {
       }
     )
     output$caliper <- build_caliper_summary(caliper_results, list(display_ratios = options$caliper_display_ratios))
+    # The summary table is a display grid of formatted strings; the raw
+    # per-pair results ride along so the method can build its estimates frame.
+    output$caliper_results <- caliper_results
   }
 
   # 2. Elliott Tests
@@ -689,6 +704,8 @@ run_p_hacking_tests <- function(df, options) {
     for (p_max in supports) {
       elliott_tests[[paste0("binomial_", support_key(p_max))]] <- list(
         test = paste0("Binomial [0, ", support_label(p_max), "]"),
+        family = "binomial",
+        support = support_interval_label(p_max),
         p_value = run_binomial(pvalues, 0, p_max, type = "c")
       )
     }
@@ -703,6 +720,8 @@ run_p_hacking_tests <- function(df, options) {
     for (p_max in supports) {
       elliott_tests[[paste0("lcm_", support_key(p_max))]] <- list(
         test = paste0("LCM [0, ", support_label(p_max), "]"),
+        family = "lcm",
+        support = support_interval_label(p_max),
         p_value = lcm_skip %||% run_lcm(pvalues, 0, p_max, cdfs)
       )
     }
@@ -711,6 +730,8 @@ run_p_hacking_tests <- function(df, options) {
     for (p_max in supports) {
       elliott_tests[[paste0("fisher_", support_key(p_max))]] <- list(
         test = paste0("Fisher [0, ", support_label(p_max), "]"),
+        family = "fisher",
+        support = support_interval_label(p_max),
         p_value = run_fisher(pvalues, 0, p_max)
       )
     }
@@ -719,6 +740,8 @@ run_p_hacking_tests <- function(df, options) {
     if (options$include_discontinuity) {
       elliott_tests$discontinuity <- list(
         test = "Discontinuity at 0.05",
+        family = "discontinuity",
+        support = "at 0.05",
         p_value = run_discontinuity(pvalues, cutoff = 0.05, bandwidth = options$discontinuity_bandwidth)
       )
     }
@@ -728,6 +751,8 @@ run_p_hacking_tests <- function(df, options) {
       for (p_max in supports) {
         elliott_tests[[paste0("cox_shi_", support_key(p_max))]] <- list(
           test = paste0("Cox-Shi [0, ", support_label(p_max), "]"),
+          family = "cox_shi",
+          support = support_interval_label(p_max),
           p_value = run_cox_shi(
             pvalues, study_id, 0, p_max,
             n_bins = options$cox_shi_bins,
@@ -743,6 +768,7 @@ run_p_hacking_tests <- function(df, options) {
     }
 
     output$elliott <- build_elliott_summary(elliott_tests, pvalues, options)
+    output$elliott_results <- elliott_tests
   }
 
   output$n_pvalues <- length(pvalues)

--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -238,7 +238,11 @@ best_practice_estimate <- function(df, bma_result = NULL) {
     rows <- c(rows, study_rows)
   }
 
-  summary <- do.call(rbind, rows)
+  # Keep the unrounded rows: `summary` is rounded in place for display, and the
+  # estimates slot must carry the numbers as computed.
+  raw_rows <- do.call(rbind, rows)
+
+  summary <- raw_rows
   summary$estimate <- round_if_finite(summary$estimate, round_to)
   summary$standard_error <- round_if_finite(summary$standard_error, round_to)
   summary$ci_lower <- round_if_finite(summary$ci_lower, round_to)
@@ -361,6 +365,7 @@ best_practice_estimate <- function(df, bma_result = NULL) {
 
   invisible(new_method_result(
     tables = tables,
+    estimates = bpe_estimates(raw_rows, n_clusters = n_clusters),
     plots = plots,
     meta = list(
       formula = formula,
@@ -369,6 +374,45 @@ best_practice_estimate <- function(df, bma_result = NULL) {
       bma_source = resolved_bma$source,
       autonomy_level = autonomy_level
     )
+  ))
+}
+
+#' @title Tidy estimates for the best-practice estimate
+#' @description
+#' Map the per-scope rows onto the shared `estimates` schema. Each row is a
+#' linear combination of the BMA posterior means evaluated at one set of
+#' predictor values, so `model` is the scope (`"author"` for the reference
+#' specification, `"study"` for a per-study prediction) and `term` is the study
+#' label the prediction belongs to (`"Author"` for the reference row).
+#'
+#' Standard errors are study-clustered, so every row carries the same
+#' `n_clusters`; the confidence bounds are the t-based ones the display table
+#' shows, taken before rounding.
+#' @param rows *\[data.frame\]* The unrounded best-practice rows
+#'   (`scope`, `study_label`, `estimate`, `standard_error`, `ci_lower`,
+#'   `ci_upper`).
+#' @param n_clusters *\[integer, optional\]* Number of study clusters behind the
+#'   standard errors.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+bpe_estimates <- function(rows, n_clusters = NA_integer_) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.data.frame(rows) || nrow(rows) == 0L) {
+    return(new_estimates())
+  }
+
+  new_estimates(data.frame(
+    method = "best_practice_estimate",
+    model = rows$scope,
+    term = rows$study_label,
+    estimate = rows$estimate,
+    std_error = rows$standard_error,
+    conf_low = rows$ci_lower,
+    conf_high = rows$ci_upper,
+    n_clusters = n_clusters,
+    stringsAsFactors = FALSE
   ))
 }
 
@@ -685,5 +729,5 @@ run <- register_runtime_method(
 )
 
 box::export(
-  best_practice_estimate, run, resolve_bma_input_for_bpe
+  best_practice_estimate, bpe_estimates, run, resolve_bma_input_for_bpe
 )

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -196,6 +196,7 @@ bma <- function(df) {
   primary <- results[[1]]
   invisible(new_method_result(
     tables = list(coefficients = primary$coefficients),
+    estimates = bma_estimates(primary$coefficients, nrow(primary$data)),
     meta = list(
       model = primary$model,
       data = primary$data,
@@ -204,6 +205,44 @@ bma <- function(df) {
       skipped = NULL,
       all = results
     )
+  ))
+}
+
+#' @title Tidy estimates for BMA
+#' @description
+#' Map the posterior coefficient frame onto the shared `estimates` schema, one
+#' row per moderator.
+#'
+#' BMA reports a posterior, not a sampling distribution, so the inferential
+#' columns are read Bayesian: `estimate` is the posterior mean, `std_error` the
+#' posterior standard deviation, and `statistic` the posterior inclusion
+#' probability (PIP). There is no frequentist test statistic or p-value to put
+#' there instead, and PIP is the number every downstream consumer of a BMA run
+#' wants next to the mean, so it takes the `statistic` slot and each row carries
+#' a `note` saying so. `cond_pos_sign` has no schema column and stays in the
+#' display table.
+#' @param coefficients *\[data.frame\]* The BMA coefficient frame
+#'   (`variable`, `pip`, `post_mean`, `post_sd`).
+#' @param n_obs *\[integer, optional\]* Observations the BMA was fitted on.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+bma_estimates <- function(coefficients, n_obs = NA_integer_) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.data.frame(coefficients) || nrow(coefficients) == 0L) {
+    return(new_estimates())
+  }
+
+  new_estimates(data.frame(
+    method = "bma",
+    term = coefficients$variable,
+    estimate = coefficients$post_mean,
+    std_error = coefficients$post_sd,
+    statistic = coefficients$pip,
+    n_obs = n_obs,
+    note = "statistic is the posterior inclusion probability (PIP)",
+    stringsAsFactors = FALSE
   ))
 }
 
@@ -909,4 +948,4 @@ run <- register_runtime_method(
 
 # prepare_bma_inputs and unwrap_bma_result are exported because the fma and
 # best_practice_estimate methods reuse them directly.
-box::export(bma, run, prepare_bma_inputs, unwrap_bma_result)
+box::export(bma, bma_estimates, run, prepare_bma_inputs, unwrap_bma_result)

--- a/inst/artma/methods/effect_summary_stats.R
+++ b/inst/artma/methods/effect_summary_stats.R
@@ -197,11 +197,21 @@ effect_summary_stats <- function(df) {
       stringsAsFactors = FALSE
     )
     assign("rows", c(rows_env$rows, list(new_row)), envir = rows_env)
+    # The display row is rounded; keep the raw statistics for the estimates slot.
+    assign(
+      "raw_rows",
+      c(rows_env$raw_rows, stats::setNames(
+        list(list(label = label, unweighted = unweighted, weighted = weighted)),
+        label
+      )),
+      envir = rows_env
+    )
 
     TRUE
   }
 
   rows <- list()
+  raw_rows <- list()
   missing_vars <- character()
 
   for (var_name in effect_vars) {
@@ -266,6 +276,7 @@ effect_summary_stats <- function(df) {
     all_idx <- which(out$`Var Name` == "All Data")
     if (length(all_idx) && all_idx[1] != 1) {
       out <- rbind(out[all_idx[1], , drop = FALSE], out[-all_idx[1], , drop = FALSE])
+      raw_rows <- c(raw_rows[all_idx[1]], raw_rows[-all_idx[1]])
     }
   }
   rownames(out) <- NULL
@@ -286,7 +297,59 @@ effect_summary_stats <- function(df) {
     print_summary_table(out)
   }
 
-  invisible(new_method_result(tables = list(summary = out)))
+  invisible(new_method_result(
+    tables = list(summary = out),
+    estimates = effect_summary_stats_estimates(raw_rows)
+  ))
+}
+
+#' @title Tidy estimates for the effect summary statistics
+#' @description
+#' Flatten the summary table into the shared `estimates` schema. The method is
+#' descriptive rather than inferential, so the mapping is a judgement call:
+#' each row of the display table is one data subset and each of its columns one
+#' statistic, so in the long schema `model` is the subset label (`"All Data"`,
+#' or a variable group such as `"Study year > 2000"`) and `term` names the
+#' statistic (`"mean"`, `"weighted_mean"`, `"median"`, `"min"`, `"max"`,
+#' `"sd"`). `estimate` holds the statistic itself, and there is no test
+#' statistic or p-value to fill.
+#'
+#' The two means carry the confidence bounds that belong to them in `conf_low`
+#' and `conf_high`; the remaining statistics leave those `NA` rather than
+#' borrowing the mean's interval. `n_obs` is the number of finite estimates in
+#' the subset, and is repeated on every statistic of that subset.
+#' @param raw_rows *\[list\]* Per-subset unrounded statistics, each a list with
+#'   `label`, `unweighted`, and `weighted` elements.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+effect_summary_stats_estimates <- function(raw_rows) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.list(raw_rows) || length(raw_rows) == 0L) {
+    return(new_estimates())
+  }
+
+  rows <- lapply(raw_rows, function(entry) {
+    unweighted <- entry$unweighted
+    weighted <- entry$weighted
+
+    data.frame(
+      method = "effect_summary_stats",
+      model = entry$label,
+      term = c("mean", "weighted_mean", "median", "min", "max", "sd"),
+      estimate = c(
+        unweighted$mean, weighted$mean, unweighted$median,
+        unweighted$min, unweighted$max, unweighted$sd
+      ),
+      conf_low = c(unweighted$ci[1], weighted$ci[1], NA_real_, NA_real_, NA_real_, NA_real_),
+      conf_high = c(unweighted$ci[2], weighted$ci[2], NA_real_, NA_real_, NA_real_, NA_real_),
+      n_obs = as.integer(unweighted$obs),
+      stringsAsFactors = FALSE
+    )
+  })
+
+  new_estimates(do.call(rbind, rows))
 }
 
 box::use(
@@ -299,4 +362,4 @@ run <- register_runtime_method(
   required_columns = c("effect", "study_size")
 )
 
-box::export(effect_summary_stats, run)
+box::export(effect_summary_stats, effect_summary_stats_estimates, run)

--- a/inst/artma/methods/exogeneity_tests.R
+++ b/inst/artma/methods/exogeneity_tests.R
@@ -75,12 +75,68 @@ exogeneity_tests <- function(df) {
 
   invisible(new_method_result(
     tables = list(summary = results$summary),
+    estimates = exogeneity_tests_estimates(results),
     meta = list(
       iv = results$iv,
       puniform = results$puniform,
       skip_reason = results$skipped
     )
   ))
+}
+
+#' @title Tidy estimates for the exogeneity tests
+#' @description
+#' Map the IV and p-uniform* coefficient frames onto the shared `estimates`
+#' schema. Both estimators contribute their own `model` (`"iv"`,
+#' `"puniform"`), and their `term` values carry over unchanged. The numbers are
+#' taken verbatim: the formatted columns sitting alongside them belong to the
+#' display table only.
+#'
+#' The two diagnostics that are not coefficients ride along as notes rather
+#' than rows: a weak first stage on the IV rows, and the p-uniform*
+#' convergence/fallback note on its rows.
+#' @param results *\[list\]* The value returned by `run_exogeneity_tests()`.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+exogeneity_tests_estimates <- function(results) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  as_rows <- function(coefficients, model, note) {
+    if (!is.data.frame(coefficients) || nrow(coefficients) == 0L) {
+      return(NULL)
+    }
+    data.frame(
+      method = "exogeneity_tests",
+      model = model,
+      term = coefficients$term,
+      estimate = coefficients$estimate,
+      std_error = coefficients$std_error,
+      statistic = coefficients$statistic,
+      p_value = coefficients$p_value,
+      n_obs = coefficients$n_obs,
+      note = note %||% NA_character_,
+      stringsAsFactors = FALSE
+    )
+  }
+
+  iv <- results$iv
+  iv_note <- if (isTRUE(iv$weak_instrument)) {
+    "First-stage F below 10; the instrument is weak"
+  } else {
+    NA_character_
+  }
+
+  rows <- Filter(Negate(is.null), list(
+    as_rows(iv$coefficients, "iv", iv_note),
+    as_rows(results$puniform$coefficients, "puniform", results$puniform$note)
+  ))
+
+  if (length(rows) == 0L) {
+    return(new_estimates())
+  }
+
+  new_estimates(do.call(rbind, rows))
 }
 
 box::use(
@@ -94,4 +150,4 @@ run <- register_runtime_method(
   suggests = "AER"
 )
 
-box::export(exogeneity_tests, run)
+box::export(exogeneity_tests, exogeneity_tests_estimates, run)

--- a/inst/artma/methods/fma.R
+++ b/inst/artma/methods/fma.R
@@ -138,6 +138,11 @@ fma <- function(df, bma_result = NULL) {
 
   new_method_result(
     tables = list(coefficients = fma_results$coefficients),
+    estimates = fma_estimates(
+      fma_results$coefficients,
+      n_obs = nrow(bma_data),
+      n_clusters = if (is.null(cluster_ids)) NA_integer_ else length(unique(cluster_ids))
+    ),
     meta = list(
       weights = fma_results$weights,
       model = bma_model,
@@ -147,6 +152,39 @@ fma <- function(df, bma_result = NULL) {
       clustered = !is.null(cluster_ids)
     )
   )
+}
+
+#' @title Tidy estimates for FMA
+#' @description
+#' Map the model-averaged coefficient frame onto the shared `estimates` schema,
+#' one row per moderator. The averaged coefficient, its standard error, and the
+#' Wald p-value carry over unrounded; `n_clusters` is filled only when the
+#' standard errors are clustered, so an `NA` there means iid inference.
+#' @param coefficients *\[data.frame\]* The FMA coefficient frame
+#'   (`variable`, `coefficient`, `se`, `p_value`).
+#' @param n_obs *\[integer, optional\]* Observations the FMA was fitted on.
+#' @param n_clusters *\[integer, optional\]* Number of clusters behind the
+#'   standard errors, or `NA` when they are not clustered.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+fma_estimates <- function(coefficients, n_obs = NA_integer_, n_clusters = NA_integer_) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.data.frame(coefficients) || nrow(coefficients) == 0L) {
+    return(new_estimates())
+  }
+
+  new_estimates(data.frame(
+    method = "fma",
+    term = coefficients$variable,
+    estimate = coefficients$coefficient,
+    std_error = coefficients$se,
+    p_value = coefficients$p_value,
+    n_obs = n_obs,
+    n_clusters = n_clusters,
+    stringsAsFactors = FALSE
+  ))
 }
 
 #' Align `study_id` cluster IDs with the prepared BMA frame
@@ -204,4 +242,4 @@ run <- register_runtime_method(
   suggests = c("BMS", "quadprog")
 )
 
-box::export(fma, resolve_fma_cluster_ids, run)
+box::export(fma, fma_estimates, resolve_fma_cluster_ids, run)

--- a/inst/artma/methods/maive.R
+++ b/inst/artma/methods/maive.R
@@ -121,6 +121,7 @@ maive_estimator <- function(df) {
 
   invisible(new_method_result(
     tables = list(summary = result$summary),
+    estimates = maive_estimates(result$raw, nrow(df)),
     meta = list(
       maive = result$raw,
       interpretation = result$interpretation,
@@ -129,6 +130,117 @@ maive_estimator <- function(df) {
       skip_reason = result$skipped
     )
   ))
+}
+
+#' @title Tidy estimates for the MAIVE estimator
+#' @description
+#' Map the raw MAIVE output onto the shared `estimates` schema. The sectioned
+#' display table mixes coefficients, specification labels, and diagnostics in a
+#' single `Statistic`/`Value` pair, so only the numeric coefficients cross over,
+#' split across two models:
+#'
+#' * `model = "maive"`: the instrumented estimator, with `term = "effect"` (the
+#'   corrected mean), `term = "publication_bias"` (the Egger coefficient), and
+#'   `term = "se_squared"` (the PEESE variance term) when the specification
+#'   reports one. The first-stage F rides along as `term = "first_stage_f"`,
+#'   which fills `statistic` only, since it is a diagnostic rather than an
+#'   estimate.
+#' * `model = "unadjusted"`: the same funnel model without the IV correction,
+#'   reported by MAIVE for comparison.
+#'
+#' Confidence intervals are the normal-approximation ones MAIVE's own summary
+#' shows; the Egger interval uses the bootstrap bounds when the specification
+#' produced them. Anderson-Rubin intervals, the Hausman test, and the
+#' specification labels stay in `meta$maive`.
+#' @param maive_output *\[list, optional\]* The raw output of `maive()`, or
+#'   `NULL` when the estimator was skipped.
+#' @param n_obs *\[integer, optional\]* Observations the estimator ran on.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+maive_estimates <- function(maive_output, n_obs = NA_integer_) {
+  box::use(
+    artma / econometric / maive[maive_ci, maive_first_stage_f, maive_p_from_coef],
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.list(maive_output)) {
+    return(new_estimates())
+  }
+
+  numeric_or_na <- function(x) {
+    if (is.numeric(x) && length(x) == 1L && is.finite(x)) as.numeric(x) else NA_real_
+  }
+
+  row <- function(model, term, estimate, std_error = NA_real_, statistic = NA_real_,
+                  p_value = NA_real_, conf = c(NA_real_, NA_real_)) {
+    data.frame(
+      method = "maive",
+      model = model,
+      term = term,
+      estimate = estimate,
+      std_error = std_error,
+      statistic = statistic,
+      p_value = p_value,
+      conf_low = conf[[1L]],
+      conf_high = conf[[2L]],
+      n_obs = n_obs,
+      stringsAsFactors = FALSE
+    )
+  }
+
+  rows <- list()
+
+  beta <- numeric_or_na(maive_output$beta)
+  beta_se <- numeric_or_na(maive_output$SE)
+  rows[[length(rows) + 1L]] <- row(
+    "maive", "effect", beta,
+    std_error = beta_se,
+    p_value = maive_p_from_coef(beta, beta_se),
+    conf = maive_ci(beta, beta_se)
+  )
+
+  egger <- numeric_or_na(maive_output$egger_coef)
+  egger_se <- numeric_or_na(maive_output$egger_se)
+  boot_ci <- maive_output$egger_boot_ci
+  egger_conf <- if (is.numeric(boot_ci) && length(boot_ci) == 2L && all(is.finite(boot_ci))) {
+    as.numeric(boot_ci)
+  } else {
+    maive_ci(egger, egger_se)
+  }
+  rows[[length(rows) + 1L]] <- row(
+    "maive", "publication_bias", egger,
+    std_error = egger_se,
+    p_value = numeric_or_na(maive_output$`pub bias p-value`),
+    conf = egger_conf
+  )
+
+  peese_coef <- numeric_or_na(maive_output$peese_se2_coef)
+  if (!is.na(peese_coef)) {
+    peese_se <- numeric_or_na(maive_output$peese_se2_se)
+    rows[[length(rows) + 1L]] <- row(
+      "maive", "se_squared", peese_coef,
+      std_error = peese_se,
+      p_value = maive_p_from_coef(peese_coef, peese_se),
+      conf = maive_ci(peese_coef, peese_se)
+    )
+  }
+
+  f_stat <- maive_first_stage_f(maive_output)
+  if (!is.na(f_stat)) {
+    rows[[length(rows) + 1L]] <- row("maive", "first_stage_f", NA_real_, statistic = f_stat)
+  }
+
+  beta_standard <- numeric_or_na(maive_output$beta_standard)
+  if (!is.na(beta_standard)) {
+    se_standard <- numeric_or_na(maive_output$SE_standard)
+    rows[[length(rows) + 1L]] <- row(
+      "unadjusted", "effect", beta_standard,
+      std_error = se_standard,
+      p_value = maive_p_from_coef(beta_standard, se_standard),
+      conf = maive_ci(beta_standard, se_standard)
+    )
+  }
+
+  new_estimates(do.call(rbind, rows))
 }
 
 box::use(
@@ -142,4 +254,4 @@ run <- register_runtime_method(
   suggests = "MAIVE"
 )
 
-box::export(maive_estimator, run)
+box::export(maive_estimator, maive_estimates, run)

--- a/inst/artma/methods/nonlinear_tests.R
+++ b/inst/artma/methods/nonlinear_tests.R
@@ -82,6 +82,7 @@ nonlinear_tests <- function(df) {
 
   invisible(new_method_result(
     tables = list(summary = results$summary),
+    estimates = nonlinear_tests_estimates(results$coefficients),
     plots = list(
       stem_funnel = stem_plots$stem_funnel,
       stem_mse = stem_plots$stem_mse
@@ -91,6 +92,41 @@ nonlinear_tests <- function(df) {
       skipped_models = results$skipped,
       options = results$options
     )
+  ))
+}
+
+#' @title Tidy estimates for the non-linear tests
+#' @description
+#' Map the per-model coefficient frame onto the shared `estimates` schema. Each
+#' non-linear estimator is a `model` and contributes an `effect` and a
+#' `publication_bias` row, plus whatever extra terms it reports (the selection
+#' model's publication probabilities, the endogenous kink's heterogeneity).
+#' `n_obs` is the count the model actually fitted on, which can be below the
+#' sample size for estimators that subset (WAAP, Top 10).
+#'
+#' The numbers are carried over verbatim; the formatted columns alongside them
+#' belong to the display table only.
+#' @param coefficients *\[data.frame\]* The coefficient frame from
+#'   `run_nonlinear_methods()`.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+nonlinear_tests_estimates <- function(coefficients) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.data.frame(coefficients) || nrow(coefficients) == 0L) {
+    return(new_estimates())
+  }
+
+  new_estimates(data.frame(
+    method = "nonlinear_tests",
+    model = coefficients$model,
+    term = coefficients$term,
+    estimate = coefficients$estimate,
+    std_error = coefficients$std_error,
+    p_value = coefficients$p_value,
+    n_obs = coefficients$n_obs_model,
+    stringsAsFactors = FALSE
   ))
 }
 
@@ -104,4 +140,4 @@ run <- register_runtime_method(
   required_columns = c("effect", "se", "study_id")
 )
 
-box::export(nonlinear_tests, run)
+box::export(nonlinear_tests, nonlinear_tests_estimates, run)

--- a/inst/artma/methods/p_hacking_tests.R
+++ b/inst/artma/methods/p_hacking_tests.R
@@ -191,8 +191,99 @@ p_hacking_tests <- function(df) {
       caliper = results$caliper,
       elliott = results$elliott
     ),
+    estimates = p_hacking_tests_estimates(results),
     meta = list(skipped_models = results$skipped)
   ))
+}
+
+#' @title Tidy estimates for the p-hacking tests
+#' @description
+#' Flatten the caliper grid and the Elliott test battery into the shared
+#' `estimates` schema. Neither display table is a coefficient table, so the
+#' dimension mapping is a judgement call rather than a rename:
+#'
+#' * Caliper. The display table is a grid: one column per t-statistic
+#'   threshold, four stacked rows per caliper width, with cells such as
+#'   `"3/6 (6 studies)"`. In the long schema each threshold-width pair is one
+#'   row, `model` is the threshold (`"threshold_1.96"`) and `term` is the
+#'   caliper width (`"width_0.05"`). `estimate` is the share of the window
+#'   above the threshold, `p_value` its test p-value, `n_obs` the number of
+#'   estimates inside the window, and `n_clusters` the number of studies they
+#'   come from. The above/below split is not a separate column: `n_above` is
+#'   `estimate * n_obs`, and the direction (which side carries the excess) is
+#'   in `note` together with the tail inspected.
+#' * Elliott. Each test is one row, `model` is the test family (`"binomial"`,
+#'   `"lcm"`, `"fisher"`, `"discontinuity"`, `"cox_shi"`) and `term` the
+#'   p-value support it was run on (`"[0, 0.05]"`). These tests report a
+#'   p-value and nothing else, so only `p_value` is filled; a test that could
+#'   not run keeps its `NA` and carries the reason in `note`.
+#'
+#' The observation counts printed at the foot of the Elliott table are sample
+#' descriptions rather than test results, and stay in the display table.
+#' @param results *\[list\]* The value returned by `run_p_hacking_tests()`.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+p_hacking_tests_estimates <- function(results) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  caliper_rows <- function(caliper_results) {
+    if (!is.list(caliper_results) || length(caliper_results) == 0L) {
+      return(NULL)
+    }
+
+    do.call(rbind, lapply(caliper_results, function(res) {
+      direction <- res$direction
+      note <- paste0(
+        "tail: ", res$tail %||% NA_character_,
+        "; direction: ", if (is.null(direction) || is.na(direction)) "unknown" else direction
+      )
+      n_studies <- res$n_studies
+      data.frame(
+        method = "p_hacking_tests",
+        model = paste0("threshold_", res$threshold),
+        term = paste0("width_", res$width),
+        estimate = as.numeric(res$share_above),
+        p_value = as.numeric(res$p_value),
+        n_obs = res$n_above + res$n_below,
+        n_clusters = if (is.null(n_studies) || !is.finite(n_studies) || n_studies == 0L) {
+          NA_integer_
+        } else {
+          as.integer(n_studies)
+        },
+        note = note,
+        stringsAsFactors = FALSE
+      )
+    }))
+  }
+
+  elliott_rows <- function(elliott_results) {
+    if (!is.list(elliott_results) || length(elliott_results) == 0L) {
+      return(NULL)
+    }
+
+    do.call(rbind, lapply(elliott_results, function(test) {
+      data.frame(
+        method = "p_hacking_tests",
+        model = test$family %||% "elliott",
+        term = test$support %||% test$test,
+        p_value = as.numeric(test$p_value),
+        note = attr(test$p_value, "reason") %||% NA_character_,
+        stringsAsFactors = FALSE
+      )
+    }))
+  }
+
+  rows <- Filter(Negate(is.null), list(
+    caliper_rows(results$caliper_results),
+    elliott_rows(results$elliott_results)
+  ))
+
+  if (length(rows) == 0L) {
+    return(new_estimates())
+  }
+
+  new_estimates(do.call(rbind, lapply(rows, new_estimates)))
 }
 
 box::use(
@@ -205,4 +296,4 @@ run <- register_runtime_method(
   required_columns = c("effect", "se", "t_stat", "study_id")
 )
 
-box::export(p_hacking_tests, run)
+box::export(p_hacking_tests, p_hacking_tests_estimates, run)

--- a/inst/artma/methods/robma.R
+++ b/inst/artma/methods/robma.R
@@ -170,8 +170,51 @@ robma <- function(df) {
       components = components,
       models = model_table
     ),
+    estimates = robma_estimates(ensemble$estimates, nrow(fit_data)),
     meta = list(model = fit, n_obs = nrow(fit_data))
   )
+}
+
+#' @title Tidy estimates for RoBMA
+#' @description
+#' Map the model-averaged parameter table onto the shared `estimates` schema,
+#' one row per parameter (`mu`, `tau`, the selection weights). The posterior
+#' mean becomes `estimate` and the credible interval bounds become `conf_low`
+#' and `conf_high`; RoBMA reports no standard error or p-value, so those stay
+#' `NA`. Values are taken from the unrounded ensemble summary, not from the
+#' rounded display table.
+#' @param tbl *\[data.frame\]* The `estimates` element of `summary.RoBMA`.
+#' @param n_obs *\[integer, optional\]* Observations the ensemble was fitted on.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+robma_estimates <- function(tbl, n_obs = NA_integer_) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (is.null(tbl) || nrow(tbl) == 0L) {
+    return(new_estimates())
+  }
+
+  out <- as.data.frame(unclass(tbl), stringsAsFactors = FALSE)
+  column <- function(...) {
+    for (name in c(...)) {
+      if (name %in% names(out)) {
+        return(as.numeric(out[[name]]))
+      }
+    }
+    rep(NA_real_, nrow(out))
+  }
+
+  new_estimates(data.frame(
+    method = "robma",
+    term = rownames(tbl) %||% as.character(seq_len(nrow(out))),
+    estimate = column("Mean", "mean"),
+    conf_low = column("0.025", "X0.025", "lCI"),
+    conf_high = column("0.975", "X0.975", "uCI"),
+    n_obs = n_obs,
+    note = "conf_low/conf_high are posterior credible interval bounds",
+    stringsAsFactors = FALSE
+  ))
 }
 
 #' @title Resolve the RoBMA parallel sampling flag
@@ -260,4 +303,4 @@ run <- register_runtime_method(
   cached = TRUE
 )
 
-box::export(robma, run)
+box::export(robma, robma_estimates, run)

--- a/inst/artma/methods/variable_summary_stats.R
+++ b/inst/artma/methods/variable_summary_stats.R
@@ -51,6 +51,7 @@ variable_summary_stats <- function(df) {
 
   # Iterate over all desired variables and append summary statistics to the main DF
   missing_data_vars <- c()
+  raw_stats <- list()
   for (row_idx in seq_along(desired_vars)) {
     var_name <- desired_vars[[row_idx]]
     var_data <- as.vector(unlist(subset(df, select = var_name))) # Roundabout way, because types
@@ -64,13 +65,26 @@ variable_summary_stats <- function(df) {
       next
     }
 
-    var_mean <- round(base::mean(var_data, na.rm = TRUE), round_to)
-    var_median <- round(stats::median(var_data, na.rm = TRUE), round_to)
-    var_sd <- round(stats::sd(var_data, na.rm = TRUE), round_to)
-    var_min <- round(base::min(var_data, na.rm = TRUE), round_to)
-    var_max <- round(base::max(var_data, na.rm = TRUE), round_to)
-    var_obs <- sum(!is.na(var_data))
-    var_missing <- round((sum(is.na(var_data)) / length(var_data)) * 100, 1)
+    # The unrounded statistics feed the estimates slot; the display row below
+    # keeps the rounded, percent-formatted variants.
+    stats_raw <- list(
+      mean = base::mean(var_data, na.rm = TRUE),
+      median = stats::median(var_data, na.rm = TRUE),
+      min = base::min(var_data, na.rm = TRUE),
+      max = base::max(var_data, na.rm = TRUE),
+      sd = stats::sd(var_data, na.rm = TRUE),
+      missing_share = sum(is.na(var_data)) / length(var_data),
+      obs = sum(!is.na(var_data))
+    )
+    raw_stats[[length(raw_stats) + 1]] <- c(list(label = var_name_display), stats_raw)
+
+    var_mean <- round(stats_raw$mean, round_to)
+    var_median <- round(stats_raw$median, round_to)
+    var_sd <- round(stats_raw$sd, round_to)
+    var_min <- round(stats_raw$min, round_to)
+    var_max <- round(stats_raw$max, round_to)
+    var_obs <- stats_raw$obs
+    var_missing <- round(stats_raw$missing_share * 100, 1)
     var_missing_verbose <- paste0(as.character(var_missing), "%")
 
     # Aggregate and append to the main DF
@@ -97,7 +111,54 @@ variable_summary_stats <- function(df) {
     cli::cli_alert_warning("Missing data for {.val {length(missing_data_vars)}} variables: {.val {missing_data_vars}}")
   }
 
-  invisible(new_method_result(tables = list(summary = df_out)))
+  invisible(new_method_result(
+    tables = list(summary = df_out),
+    estimates = variable_summary_stats_estimates(raw_stats)
+  ))
+}
+
+#' @title Tidy estimates for the variable summary statistics
+#' @description
+#' Flatten the summary table into the shared `estimates` schema. The method is
+#' descriptive rather than inferential, so the mapping is a judgement call:
+#' each row of the display table is one variable and each of its columns one
+#' statistic, so in the long schema `model` is the variable and `term` names
+#' the statistic (`"mean"`, `"median"`, `"min"`, `"max"`, `"sd"`,
+#' `"missing_share"`). `estimate` holds the statistic itself; there is nothing
+#' inferential to fill.
+#'
+#' `missing_share` is a proportion in `[0, 1]`, not the `"12.5%"` string the
+#' display table prints: the estimates frame is machine-readable and must parse
+#' as a number.
+#'
+#' Variables whose data are entirely missing or non-numeric produce no rows,
+#' matching the all-`NA` row they get in the display table.
+#' @param raw_stats *\[list\]* Per-variable unrounded statistics, each a list
+#'   with `label` and the statistic elements.
+#' @return *\[data.frame\]* A frame in the shared estimates schema.
+variable_summary_stats_estimates <- function(raw_stats) {
+  box::use(
+    artma / modules / runtime_methods[new_estimates]
+  )
+
+  if (!is.list(raw_stats) || length(raw_stats) == 0L) {
+    return(new_estimates())
+  }
+
+  terms <- c("mean", "median", "min", "max", "sd", "missing_share")
+
+  rows <- lapply(raw_stats, function(entry) {
+    data.frame(
+      method = "variable_summary_stats",
+      model = entry$label,
+      term = terms,
+      estimate = as.numeric(unlist(entry[terms])),
+      n_obs = as.integer(entry$obs),
+      stringsAsFactors = FALSE
+    )
+  })
+
+  new_estimates(do.call(rbind, rows))
 }
 
 box::use(
@@ -106,4 +167,4 @@ box::use(
 
 run <- register_runtime_method(variable_summary_stats, stage = "variable_summary_stats")
 
-box::export(variable_summary_stats, run)
+box::export(variable_summary_stats, variable_summary_stats_estimates, run)

--- a/inst/artma/output/export.R
+++ b/inst/artma/output/export.R
@@ -233,11 +233,13 @@ resolve_table_basename <- function(method_name, key) {
 #'
 #' @description
 #' A generic walk over the standard return contract. When the result carries an
-#' `estimates` frame, that frame is the machine-readable artifact and takes the
-#' `<method_name>.csv` name: it is written unrounded, exactly as the method
-#' produced it, and the display table that would otherwise own that name moves
-#' to `<method_name>_display.csv`. LaTeX output is inherently presentational, so
-#' it stays driven by the display tables under their original names and the
+#' `estimates` frame with at least one row, that frame is the machine-readable
+#' artifact and takes the `<method_name>.csv` name: it is written unrounded,
+#' exactly as the method produced it, and the display table that would otherwise
+#' own that name moves to `<method_name>_display.csv`. An empty `estimates`
+#' frame (a plot-only method) is treated as no estimates at all, so no
+#' header-only CSV is written. LaTeX output is inherently presentational, so it
+#' stays driven by the display tables under their original names and the
 #' `estimates` frame is never written as `.tex`.
 #'
 #' Everything else (`plots`, `meta`) is ignored here. There are no per-method
@@ -258,7 +260,10 @@ export_method_result <- function(result, method_name, output_dir) {
   write_tex <- "tex" %in% formats
 
   estimates <- result$estimates
-  has_estimates <- is.data.frame(estimates)
+  # A plot-only method contributes an empty frame (or none at all). Writing it
+  # would leave a header-only CSV next to the graphics and push the display
+  # table to a `_display` name for no reason, so treat it as absent.
+  has_estimates <- is.data.frame(estimates) && nrow(estimates) > 0L
   if (has_estimates && write_csv) {
     save_table(estimates, method_name, output_dir, formats = "csv")
   }

--- a/inst/artma/output/ma_table.R
+++ b/inst/artma/output/ma_table.R
@@ -3,23 +3,30 @@
 #' Builds and displays a unified model averaging table combining BMA and FMA
 #' results. When both methods have run, the table shows BMA (P.Mean, SD, PIP)
 #' and FMA (Coef, SE, p-val) columns side by side. When only one method has
-#' run, only its columns are shown.
+#' run, only its columns are shown. Both are read from the methods' `estimates`
+#' frames, so the numbers are rounded here and nowhere upstream.
 NULL
 
 #' Build a unified model averaging table
 #'
-#' @param bma_coefficients *\[data.frame, optional\]* BMA coefficients with columns:
-#'   variable, pip, post_mean, post_sd.
-#' @param fma_coefficients *\[data.frame, optional\]* FMA coefficients with columns:
-#'   variable, coefficient, se, p_value.
+#' @description
+#' Both inputs are `estimates` frames in the shared schema (see
+#' `new_estimates()`), one row per moderator: `term` is the variable, and the
+#' displayed numbers come from `estimate`, `std_error`, and, per method,
+#' `statistic` (the BMA posterior inclusion probability) or `p_value` (the FMA
+#' Wald p-value). Reading the unrounded frames rather than the display tables
+#' keeps this table the only place the rounding happens.
+#'
+#' @param bma_estimates *\[data.frame, optional\]* The BMA estimates frame.
+#' @param fma_estimates *\[data.frame, optional\]* The FMA estimates frame.
 #' @param round_to *\[integer\]* Number of decimal places for rounding. Defaults to 3.
 #' @return *\[data.frame\]* Combined MA table, or NULL if no valid inputs.
 #' @export
-build_ma_table <- function(bma_coefficients = NULL, fma_coefficients = NULL, round_to = 3L) {
+build_ma_table <- function(bma_estimates = NULL, fma_estimates = NULL, round_to = 3L) {
   box::use(artma / libs / core / validation[validate])
 
-  has_bma <- !is.null(bma_coefficients) && is.data.frame(bma_coefficients) && nrow(bma_coefficients) > 0
-  has_fma <- !is.null(fma_coefficients) && is.data.frame(fma_coefficients) && nrow(fma_coefficients) > 0
+  has_bma <- !is.null(bma_estimates) && is.data.frame(bma_estimates) && nrow(bma_estimates) > 0
+  has_fma <- !is.null(fma_estimates) && is.data.frame(fma_estimates) && nrow(fma_estimates) > 0
 
   if (!has_bma && !has_fma) {
     return(NULL)
@@ -35,12 +42,12 @@ build_ma_table <- function(bma_coefficients = NULL, fma_coefficients = NULL, rou
   # Build the union of variable names, preserving order from whichever ran first
   all_vars <- character(0)
   if (has_bma) {
-    bma_coefficients$variable <- normalize_intercept(bma_coefficients$variable)
-    all_vars <- bma_coefficients$variable
+    bma_estimates$term <- normalize_intercept(bma_estimates$term)
+    all_vars <- bma_estimates$term
   }
   if (has_fma) {
-    fma_coefficients$variable <- normalize_intercept(fma_coefficients$variable)
-    new_vars <- setdiff(fma_coefficients$variable, all_vars)
+    fma_estimates$term <- normalize_intercept(fma_estimates$term)
+    new_vars <- setdiff(fma_estimates$term, all_vars)
     all_vars <- c(all_vars, new_vars)
   }
 
@@ -55,18 +62,18 @@ build_ma_table <- function(bma_coefficients = NULL, fma_coefficients = NULL, rou
 
   # Add BMA columns
   if (has_bma) {
-    bma_idx <- match(all_vars, bma_coefficients$variable)
-    result[["BMA P.Mean"]] <- round(bma_coefficients$post_mean[bma_idx], round_to)
-    result[["BMA SD"]] <- round(bma_coefficients$post_sd[bma_idx], round_to)
-    result[["BMA PIP"]] <- round(bma_coefficients$pip[bma_idx], round_to)
+    bma_idx <- match(all_vars, bma_estimates$term)
+    result[["BMA P.Mean"]] <- round(bma_estimates$estimate[bma_idx], round_to)
+    result[["BMA SD"]] <- round(bma_estimates$std_error[bma_idx], round_to)
+    result[["BMA PIP"]] <- round(bma_estimates$statistic[bma_idx], round_to)
   }
 
   # Add FMA columns
   if (has_fma) {
-    fma_idx <- match(all_vars, fma_coefficients$variable)
-    result[["FMA Coef"]] <- round(fma_coefficients$coefficient[fma_idx], round_to)
-    result[["FMA SE"]] <- round(fma_coefficients$se[fma_idx], round_to)
-    result[["FMA p-val"]] <- round(fma_coefficients$p_value[fma_idx], round_to)
+    fma_idx <- match(all_vars, fma_estimates$term)
+    result[["FMA Coef"]] <- round(fma_estimates$estimate[fma_idx], round_to)
+    result[["FMA SE"]] <- round(fma_estimates$std_error[fma_idx], round_to)
+    result[["FMA p-val"]] <- round(fma_estimates$p_value[fma_idx], round_to)
   }
 
   result

--- a/tests/testthat/test-econometric-p-hacking.R
+++ b/tests/testthat/test-econometric-p-hacking.R
@@ -223,7 +223,10 @@ test_that("run_caliper_tests only stars an excess above the threshold", {
   )
 
   expect_equal(results[[1]]$direction, "below")
-  expect_false(grepl("\\*", results[[1]]$p_value))
+  expect_false(grepl("\\*", results[[1]]$p_value_formatted))
+  # The raw p-value rides alongside the formatted one, unrounded.
+  expect_true(is.numeric(results[[1]]$p_value))
+  expect_true(is.numeric(results[[1]]$share_above))
 
   # Flip the imbalance and the same p-value does get starred.
   flipped <- run_caliper_tests(
@@ -233,7 +236,7 @@ test_that("run_caliper_tests only stars an excess above the threshold", {
     show_progress = FALSE
   )
   expect_equal(flipped[[1]]$direction, "above")
-  expect_match(flipped[[1]]$p_value, "\\*")
+  expect_match(flipped[[1]]$p_value_formatted, "\\*")
 })
 
 test_that("build_caliper_summary shows a direction row and study counts", {

--- a/tests/testthat/test-effect-summary-stats-integration.R
+++ b/tests/testthat/test-effect-summary-stats-integration.R
@@ -68,11 +68,19 @@ test_that("effect_summary_stats defaults to the All Data row in non-interactive 
   )
 
   # Should default the effect column in, producing the "All Data" row
-  result <- effect_summary_stats(df)$tables$summary
+  method_result <- effect_summary_stats(df)
+  result <- method_result$tables$summary
 
   expect_true(is.data.frame(result))
   expect_equal(nrow(result), 1)
   expect_equal(result$`Var Name`, "All Data")
+
+  # The same run fills the estimates slot, one row per statistic, unrounded.
+  estimates <- method_result$estimates
+  expect_equal(unique(estimates$model), "All Data")
+  expect_equal(estimates$estimate[estimates$term == "mean"], mean(df$effect))
+  expect_equal(estimates$estimate[estimates$term == "median"], stats::median(df$effect))
+  expect_equal(unique(estimates$n_obs), 3L)
 })
 
 test_that("effect_summary_stats processes configured variables correctly", {

--- a/tests/testthat/test-ma-table.R
+++ b/tests/testthat/test-ma-table.R
@@ -11,55 +11,50 @@ box::use(
 )
 
 box::use(
+  artma / methods / bma[bma_estimates],
+  artma / methods / fma[fma_estimates],
+  artma / modules / runtime_methods[new_estimates],
   artma / output / ma_table[build_ma_table, display_ma_table]
 )
 
-make_bma_coefficients <- function() {
-  data.frame(
+# The fixtures go through the methods' own estimates builders, so the table
+# stays pinned to the mapping the methods actually produce.
+make_bma_estimates <- function() {
+  bma_estimates(data.frame(
     variable = c("Intercept", "T stat", "Precision", "Pcc"),
     pip = c(0.55, 1.0, 1.0, 0.97),
     post_mean = c(0.01, 0.43, -0.20, 0.13),
     post_sd = c(0.05, 0.016, 0.023, 0.019),
     cond_pos_sign = c(0.60, 1.0, 0.0, 1.0),
     stringsAsFactors = FALSE
-  )
+  ))
 }
 
-make_fma_coefficients <- function() {
-  data.frame(
+make_fma_estimates <- function() {
+  fma_estimates(data.frame(
     variable = c("Intercept", "T stat", "Precision", "Pcc"),
     coefficient = c(-3.674, 0.288, -5.794, 1.604),
     se = c(0.888, 0.011, 0.539, 0.247),
     p_value = c(0.001, 0.000, 0.000, 0.000),
     stringsAsFactors = FALSE
-  )
+  ))
 }
 
 describe("build_ma_table", {
   it("returns NULL when both inputs are NULL", {
-    result <- build_ma_table(bma_coefficients = NULL, fma_coefficients = NULL)
+    result <- build_ma_table(bma_estimates = NULL, fma_estimates = NULL)
     expect_null(result)
   })
 
   it("returns NULL when both inputs are empty data frames", {
-    empty_bma <- data.frame(
-      variable = character(0), pip = numeric(0),
-      post_mean = numeric(0), post_sd = numeric(0),
-      stringsAsFactors = FALSE
-    )
-    empty_fma <- data.frame(
-      variable = character(0), coefficient = numeric(0),
-      se = numeric(0), p_value = numeric(0),
-      stringsAsFactors = FALSE
-    )
-    result <- build_ma_table(bma_coefficients = empty_bma, fma_coefficients = empty_fma)
+    result <- build_ma_table(bma_estimates = new_estimates(), fma_estimates = new_estimates())
     expect_null(result)
   })
 
   it("builds table with both BMA and FMA columns", {
-    bma <- make_bma_coefficients()
-    fma <- make_fma_coefficients()
-    result <- build_ma_table(bma_coefficients = bma, fma_coefficients = fma)
+    bma <- make_bma_estimates()
+    fma <- make_fma_estimates()
+    result <- build_ma_table(bma_estimates = bma, fma_estimates = fma)
 
     expect_true(is.data.frame(result))
     expect_equal(nrow(result), 4)
@@ -67,9 +62,16 @@ describe("build_ma_table", {
     expect_named(result, expected_cols)
   })
 
+  it("reads the BMA posterior inclusion probability from the statistic column", {
+    result <- build_ma_table(bma_estimates = make_bma_estimates())
+
+    expect_equal(result[["BMA PIP"]], c(0.55, 1.0, 1.0, 0.97))
+    expect_equal(result[["BMA P.Mean"]], c(0.01, 0.43, -0.20, 0.13))
+  })
+
   it("builds table with BMA columns only", {
-    bma <- make_bma_coefficients()
-    result <- build_ma_table(bma_coefficients = bma, fma_coefficients = NULL)
+    bma <- make_bma_estimates()
+    result <- build_ma_table(bma_estimates = bma, fma_estimates = NULL)
 
     expect_true(is.data.frame(result))
     expect_equal(nrow(result), 4)
@@ -78,8 +80,8 @@ describe("build_ma_table", {
   })
 
   it("builds table with FMA columns only", {
-    fma <- make_fma_coefficients()
-    result <- build_ma_table(bma_coefficients = NULL, fma_coefficients = fma)
+    fma <- make_fma_estimates()
+    result <- build_ma_table(bma_estimates = NULL, fma_estimates = fma)
 
     expect_true(is.data.frame(result))
     expect_equal(nrow(result), 4)
@@ -88,32 +90,32 @@ describe("build_ma_table", {
   })
 
   it("places Intercept as the first row", {
-    bma <- make_bma_coefficients()
+    bma <- make_bma_estimates()
     # Shuffle so Intercept is not first
     bma <- bma[c(2, 3, 1, 4), ]
-    result <- build_ma_table(bma_coefficients = bma)
+    result <- build_ma_table(bma_estimates = bma)
 
     expect_equal(result$Variable[1], "Intercept")
   })
 
   it("normalizes (Intercept) to Intercept", {
-    bma <- make_bma_coefficients()
-    bma$variable[1] <- "(Intercept)"
-    result <- build_ma_table(bma_coefficients = bma)
+    bma <- make_bma_estimates()
+    bma$term[1] <- "(Intercept)"
+    result <- build_ma_table(bma_estimates = bma)
 
     expect_true("Intercept" %in% result$Variable)
     expect_equal(result$Variable[1], "Intercept")
   })
 
   it("rounds values to the specified number of decimals", {
-    bma <- data.frame(
+    bma <- bma_estimates(data.frame(
       variable = c("Var1"),
       pip = c(0.123456),
       post_mean = c(0.654321),
       post_sd = c(0.111111),
       stringsAsFactors = FALSE
-    )
-    result <- build_ma_table(bma_coefficients = bma, round_to = 2)
+    ))
+    result <- build_ma_table(bma_estimates = bma, round_to = 2)
 
     expect_equal(result[["BMA PIP"]], 0.12)
     expect_equal(result[["BMA P.Mean"]], 0.65)
@@ -121,21 +123,21 @@ describe("build_ma_table", {
   })
 
   it("handles variable sets that differ between BMA and FMA", {
-    bma <- data.frame(
+    bma <- bma_estimates(data.frame(
       variable = c("Var A", "Var B"),
       pip = c(1.0, 0.8),
       post_mean = c(0.5, 0.3),
       post_sd = c(0.1, 0.2),
       stringsAsFactors = FALSE
-    )
-    fma <- data.frame(
+    ))
+    fma <- fma_estimates(data.frame(
       variable = c("Var B", "Var C"),
       coefficient = c(0.4, 0.6),
       se = c(0.05, 0.07),
       p_value = c(0.01, 0.03),
       stringsAsFactors = FALSE
-    )
-    result <- build_ma_table(bma_coefficients = bma, fma_coefficients = fma)
+    ))
+    result <- build_ma_table(bma_estimates = bma, fma_estimates = fma)
 
     expect_equal(nrow(result), 3)
     expect_equal(result$Variable, c("Var A", "Var B", "Var C"))
@@ -166,8 +168,8 @@ describe("display_ma_table", {
   })
 
   it("does not error for valid table at verbosity 1", {
-    bma <- make_bma_coefficients()
-    table <- build_ma_table(bma_coefficients = bma)
+    bma <- make_bma_estimates()
+    table <- build_ma_table(bma_estimates = bma)
     result <- display_ma_table(table, verbosity = 1L)
     expect_true(is.data.frame(result))
   })

--- a/tests/testthat/test-method-estimates-contract.R
+++ b/tests/testthat/test-method-estimates-contract.R
@@ -1,0 +1,510 @@
+box::use(
+  testthat[
+    expect_equal,
+    expect_length,
+    expect_named,
+    expect_setequal,
+    expect_true,
+    test_that
+  ]
+)
+
+box::use(
+  artma / modules / runtime_methods[ESTIMATES_COLUMNS],
+  artma / paths[PATHS]
+)
+
+# Methods that produce graphics only. They have no numbers to report, so they
+# leave `estimates` unset; everything else must fill it.
+PLOT_ONLY_METHODS <- c(
+  "box_plot",
+  "funnel_plot",
+  "prima_facie_graphs",
+  "t_stat_histogram"
+)
+
+discovered_method_names <- function() {
+  files <- list.files(PATHS$DIR_METHODS, pattern = "[.][Rr]$", full.names = FALSE)
+  sort(tools::file_path_sans_ext(files))
+}
+
+# TRUE when any `new_method_result()` call in the file passes an `estimates`
+# argument. Walking the parse tree, rather than grepping, keeps a method that
+# merely mentions the word from passing the check.
+wires_estimates <- function(path) {
+  found <- FALSE
+
+  # An empty argument (`df[i, ]`) is the empty symbol, which errors the moment
+  # it is evaluated, so every child is forced behind a guard.
+  is_empty_arg <- function(x) {
+    tryCatch(
+      {
+        force(x)
+        FALSE
+      },
+      error = function(e) TRUE
+    )
+  }
+
+  walk <- function(node) {
+    if (found) {
+      return(invisible(NULL))
+    }
+    if (is.call(node)) {
+      target <- node[[1L]]
+      if (is.name(target) && identical(as.character(target), "new_method_result") &&
+        "estimates" %in% names(node)) {
+        found <<- TRUE
+        return(invisible(NULL))
+      }
+    }
+    if (is.call(node) || is.pairlist(node) || is.expression(node)) {
+      for (child in as.list(node)) {
+        if (is_empty_arg(child)) next
+        walk(child)
+      }
+    }
+    invisible(NULL)
+  }
+
+  walk(parse(path, keep.source = FALSE))
+  found
+}
+
+test_that("the plot-only allowlist names methods that actually exist", {
+  expect_true(all(PLOT_ONLY_METHODS %in% discovered_method_names()))
+})
+
+test_that("every runtime method either reports estimates or is plot-only", {
+  method_names <- discovered_method_names()
+  expect_true(length(method_names) > 0L)
+
+  reporting <- setdiff(method_names, PLOT_ONLY_METHODS)
+  missing <- Filter(
+    function(name) !wires_estimates(file.path(PATHS$DIR_METHODS, paste0(name, ".R"))),
+    reporting
+  )
+
+  # A new method that only builds a display table trips this: either fill the
+  # `estimates` slot or declare the method plot-only above.
+  expect_equal(as.character(missing), character())
+})
+
+# Per-method estimates builders ---------------------------------------------
+
+expect_schema <- function(estimates, expected_method) {
+  expect_named(estimates, ESTIMATES_COLUMNS)
+  expect_true(is.numeric(estimates$estimate))
+  expect_true(is.integer(estimates$n_obs))
+  expect_true(is.character(estimates$note))
+  if (nrow(estimates) > 0L) {
+    expect_setequal(unique(estimates$method), expected_method)
+  }
+  invisible(estimates)
+}
+
+test_that("linear_tests_estimates conforms to the schema and stays unrounded", {
+  box::use(artma / methods / linear_tests[linear_tests_estimates])
+
+  estimates <- linear_tests_estimates(data.frame(
+    model = c("ols", "ols"),
+    term = c("effect", "publication_bias"),
+    estimate = c(0.0571234, -0.1289876),
+    std_error = c(0.0123456, 0.0234567),
+    statistic = c(4.63, -5.5),
+    p_value = c(0.0000123, 0.0000456),
+    bootstrap_lower = c(0.03, -0.2),
+    bootstrap_upper = c(0.08, -0.05),
+    n_obs = c(120L, 120L),
+    ci_conflict = c(FALSE, TRUE),
+    stringsAsFactors = FALSE
+  ))
+
+  expect_schema(estimates, "linear_tests")
+  expect_equal(estimates$estimate, c(0.0571234, -0.1289876))
+  expect_true(is.na(estimates$note[[1L]]))
+  expect_true(nzchar(estimates$note[[2L]]))
+})
+
+test_that("nonlinear_tests_estimates maps the per-model coefficient frame", {
+  box::use(artma / methods / nonlinear_tests[nonlinear_tests_estimates])
+
+  estimates <- nonlinear_tests_estimates(data.frame(
+    model = c("waap", "waap"),
+    term = c("publication_bias", "effect"),
+    estimate = c(0.2345678, 0.0456789),
+    std_error = c(0.01, 0.02),
+    p_value = c(0.01, 0.2),
+    n_obs_total = c(200L, 200L),
+    n_obs_model = c(84L, 84L),
+    stringsAsFactors = FALSE
+  ))
+
+  expect_schema(estimates, "nonlinear_tests")
+  expect_equal(estimates$n_obs, c(84L, 84L))
+  expect_equal(estimates$estimate, c(0.2345678, 0.0456789))
+
+  expect_equal(nrow(nonlinear_tests_estimates(data.frame())), 0L)
+})
+
+test_that("exogeneity_tests_estimates splits the two estimators into models", {
+  box::use(artma / methods / exogeneity_tests[exogeneity_tests_estimates])
+
+  coefficients <- function() {
+    data.frame(
+      term = c("effect", "publication_bias"),
+      estimate = c(0.11, 0.22),
+      std_error = c(0.01, 0.02),
+      statistic = c(11, 11),
+      p_value = c(0.001, 0.002),
+      n_obs = c(50L, 50L),
+      stringsAsFactors = FALSE
+    )
+  }
+
+  estimates <- exogeneity_tests_estimates(list(
+    iv = list(coefficients = coefficients(), weak_instrument = TRUE),
+    puniform = list(coefficients = coefficients(), note = "did not converge")
+  ))
+
+  expect_schema(estimates, "exogeneity_tests")
+  expect_equal(nrow(estimates), 4L)
+  expect_setequal(unique(estimates$model), c("iv", "puniform"))
+  expect_true(all(grepl("weak", estimates$note[estimates$model == "iv"])))
+  expect_true(all(estimates$note[estimates$model == "puniform"] == "did not converge"))
+
+  expect_equal(nrow(exogeneity_tests_estimates(list())), 0L)
+})
+
+test_that("p_hacking_tests_estimates maps thresholds to models and widths to terms", {
+  box::use(artma / methods / p_hacking_tests[p_hacking_tests_estimates])
+
+  estimates <- p_hacking_tests_estimates(list(
+    caliper_results = list(
+      list(
+        threshold = 1.96, width = 0.05, share_above = 0.6666667, p_value = 0.0412345,
+        n_above = 6, n_below = 3, n_studies = 4L, direction = "above",
+        tail = "positive", cluster_method = "study"
+      )
+    ),
+    elliott_results = list(
+      binomial_005 = list(
+        test = "Binomial [0, 0.05]", family = "binomial",
+        support = "[0, 0.05]", p_value = 0.0123456
+      ),
+      lcm_005 = list(
+        test = "LCM [0, 0.05]", family = "lcm", support = "[0, 0.05]",
+        p_value = structure(NA_real_, reason = "package 'fdrtool' is not installed")
+      )
+    )
+  ))
+
+  expect_schema(estimates, "p_hacking_tests")
+  expect_equal(nrow(estimates), 3L)
+
+  caliper <- estimates[estimates$model == "threshold_1.96", ]
+  expect_equal(caliper$term, "width_0.05")
+  expect_equal(caliper$estimate, 0.6666667)
+  expect_equal(caliper$p_value, 0.0412345)
+  expect_equal(caliper$n_obs, 9L)
+  expect_equal(caliper$n_clusters, 4L)
+
+  lcm <- estimates[estimates$model == "lcm", ]
+  expect_true(is.na(lcm$p_value))
+  expect_true(grepl("fdrtool", lcm$note))
+
+  expect_equal(nrow(p_hacking_tests_estimates(list())), 0L)
+})
+
+test_that("variable_summary_stats_estimates reports missingness as a proportion", {
+  box::use(artma / methods / variable_summary_stats[variable_summary_stats_estimates])
+
+  estimates <- variable_summary_stats_estimates(list(
+    list(
+      label = "Study year", mean = 2005.4567, median = 2006, min = 1998,
+      max = 2019, sd = 4.98765, missing_share = 0.125, obs = 56L
+    )
+  ))
+
+  expect_schema(estimates, "variable_summary_stats")
+  expect_equal(estimates$model, rep("Study year", 6L))
+  expect_setequal(
+    estimates$term,
+    c("mean", "median", "min", "max", "sd", "missing_share")
+  )
+  expect_equal(estimates$estimate[estimates$term == "missing_share"], 0.125)
+  expect_equal(estimates$estimate[estimates$term == "mean"], 2005.4567)
+
+  expect_equal(nrow(variable_summary_stats_estimates(list())), 0L)
+})
+
+test_that("effect_summary_stats_estimates keeps each mean with its own interval", {
+  box::use(artma / methods / effect_summary_stats[effect_summary_stats_estimates])
+
+  estimates <- effect_summary_stats_estimates(list(
+    `All Data` = list(
+      label = "All Data",
+      unweighted = list(
+        mean = 0.1234567, sd = 0.5, ci = c(0.05, 0.19),
+        median = 0.1, min = -1.2, max = 2.4, obs = 300L
+      ),
+      weighted = list(mean = 0.0987654, ci = c(0.02, 0.18))
+    )
+  ))
+
+  expect_schema(estimates, "effect_summary_stats")
+  expect_equal(nrow(estimates), 6L)
+  expect_equal(estimates$estimate[estimates$term == "mean"], 0.1234567)
+  expect_equal(estimates$conf_low[estimates$term == "weighted_mean"], 0.02)
+  expect_true(all(is.na(estimates$conf_low[estimates$term %in% c("median", "min", "max", "sd")])))
+  expect_equal(unique(estimates$n_obs), 300L)
+
+  expect_equal(nrow(effect_summary_stats_estimates(list())), 0L)
+})
+
+test_that("bma_estimates puts the posterior inclusion probability in statistic", {
+  box::use(artma / methods / bma[bma_estimates])
+
+  estimates <- bma_estimates(
+    data.frame(
+      variable = c("Intercept", "Precision"),
+      pip = c(0.5512345, 0.9987654),
+      post_mean = c(0.0123456, -0.2034567),
+      post_sd = c(0.05, 0.023),
+      cond_pos_sign = c(0.6, 0),
+      stringsAsFactors = FALSE
+    ),
+    n_obs = 412L
+  )
+
+  expect_schema(estimates, "bma")
+  expect_equal(estimates$statistic, c(0.5512345, 0.9987654))
+  expect_equal(estimates$estimate, c(0.0123456, -0.2034567))
+  expect_equal(unique(estimates$n_obs), 412L)
+  expect_true(all(grepl("PIP", estimates$note)))
+})
+
+test_that("fma_estimates fills n_clusters only when the SEs are clustered", {
+  box::use(artma / methods / fma[fma_estimates])
+
+  coefficients <- data.frame(
+    variable = c("Intercept", "Precision"),
+    coefficient = c(-3.6741234, 0.2881234),
+    se = c(0.888, 0.011),
+    p_value = c(0.0012345, 0.0000123),
+    stringsAsFactors = FALSE
+  )
+
+  clustered <- fma_estimates(coefficients, n_obs = 412L, n_clusters = 37L)
+  expect_schema(clustered, "fma")
+  expect_equal(unique(clustered$n_clusters), 37L)
+  expect_equal(clustered$estimate, c(-3.6741234, 0.2881234))
+
+  iid <- fma_estimates(coefficients, n_obs = 412L)
+  expect_true(all(is.na(iid$n_clusters)))
+})
+
+test_that("robma_estimates carries the credible interval bounds", {
+  box::use(artma / methods / robma[robma_estimates])
+
+  tbl <- data.frame(
+    Mean = c(0.1234567, 0.0456789),
+    Median = c(0.12, 0.04),
+    `0.025` = c(0.01, 0.001),
+    `0.975` = c(0.25, 0.09),
+    check.names = FALSE
+  )
+  rownames(tbl) <- c("mu", "tau")
+
+  estimates <- robma_estimates(tbl, n_obs = 88L)
+
+  expect_schema(estimates, "robma")
+  expect_equal(estimates$term, c("mu", "tau"))
+  expect_equal(estimates$estimate, c(0.1234567, 0.0456789))
+  expect_equal(estimates$conf_low, c(0.01, 0.001))
+  expect_equal(estimates$conf_high, c(0.25, 0.09))
+
+  expect_equal(nrow(robma_estimates(NULL)), 0L)
+})
+
+test_that("maive_estimates splits the corrected and unadjusted models", {
+  box::use(artma / methods / maive[maive_estimates])
+
+  estimates <- maive_estimates(
+    list(
+      beta = 0.1234567,
+      SE = 0.0456789,
+      egger_coef = 1.2345678,
+      egger_se = 0.3456789,
+      `pub bias p-value` = 0.0004321,
+      beta_standard = 0.2345678,
+      SE_standard = 0.0345678,
+      `F-test` = 24.6813579
+    ),
+    n_obs = 150L
+  )
+
+  expect_schema(estimates, "maive")
+  expect_setequal(unique(estimates$model), c("maive", "unadjusted"))
+
+  effect <- estimates[estimates$model == "maive" & estimates$term == "effect", ]
+  expect_equal(effect$estimate, 0.1234567)
+  expect_true(effect$conf_low < effect$estimate && effect$conf_high > effect$estimate)
+
+  f_row <- estimates[estimates$term == "first_stage_f", ]
+  expect_length(f_row$statistic, 1L)
+  expect_equal(f_row$statistic, 24.6813579)
+  expect_true(is.na(f_row$estimate))
+
+  expect_equal(nrow(maive_estimates(NULL)), 0L)
+})
+
+test_that("bpe_estimates maps each scope to a model", {
+  box::use(artma / methods / best_practice_estimate[bpe_estimates])
+
+  estimates <- bpe_estimates(
+    data.frame(
+      scope = c("author", "study"),
+      study_id = c(NA_character_, "s1"),
+      study_label = c("Author", "Smith (2019)"),
+      estimate = c(0.1234567, 0.2345678),
+      standard_error = c(0.0123456, 0.0234567),
+      ci_lower = c(0.09, 0.19),
+      ci_upper = c(0.16, 0.28),
+      stringsAsFactors = FALSE
+    ),
+    n_clusters = 42L
+  )
+
+  expect_schema(estimates, "best_practice_estimate")
+  expect_equal(estimates$model, c("author", "study"))
+  expect_equal(estimates$term, c("Author", "Smith (2019)"))
+  expect_equal(estimates$estimate, c(0.1234567, 0.2345678))
+  expect_equal(unique(estimates$n_clusters), 42L)
+
+  expect_equal(nrow(bpe_estimates(data.frame())), 0L)
+})
+
+# Export round trip ---------------------------------------------------------
+
+# One representative frame per reporting method, built by that method's own
+# estimates builder. Every fixture value carries seven decimals, so a rounded
+# export shows up as a changed number rather than a formatting nicety.
+sample_estimates <- function() {
+  box::use(
+    artma / methods / best_practice_estimate[bpe_estimates],
+    artma / methods / bma[bma_estimates],
+    artma / methods / effect_summary_stats[effect_summary_stats_estimates],
+    artma / methods / exogeneity_tests[exogeneity_tests_estimates],
+    artma / methods / fma[fma_estimates],
+    artma / methods / linear_tests[linear_tests_estimates],
+    artma / methods / maive[maive_estimates],
+    artma / methods / nonlinear_tests[nonlinear_tests_estimates],
+    artma / methods / p_hacking_tests[p_hacking_tests_estimates],
+    artma / methods / robma[robma_estimates],
+    artma / methods / variable_summary_stats[variable_summary_stats_estimates]
+  )
+
+  robma_table <- data.frame(
+    Mean = 0.1234567, Median = 0.12, `0.025` = 0.0123456, `0.975` = 0.2534567,
+    check.names = FALSE
+  )
+  rownames(robma_table) <- "mu"
+
+  list(
+    best_practice_estimate = bpe_estimates(data.frame(
+      scope = "author", study_id = NA_character_, study_label = "Author",
+      estimate = 0.1234567, standard_error = 0.0123456,
+      ci_lower = 0.0912345, ci_upper = 0.1612345, stringsAsFactors = FALSE
+    )),
+    bma = bma_estimates(data.frame(
+      variable = "Precision", pip = 0.9987654, post_mean = -0.2034567,
+      post_sd = 0.0234567, stringsAsFactors = FALSE
+    )),
+    effect_summary_stats = effect_summary_stats_estimates(list(list(
+      label = "All Data",
+      unweighted = list(
+        mean = 0.1234567, sd = 0.5123456, ci = c(0.0512345, 0.1912345),
+        median = 0.1023456, min = -1.2034567, max = 2.4056789, obs = 300L
+      ),
+      weighted = list(mean = 0.0987654, ci = c(0.0212345, 0.1812345))
+    ))),
+    exogeneity_tests = exogeneity_tests_estimates(list(
+      iv = list(
+        coefficients = data.frame(
+          term = "effect", estimate = 0.1123456, std_error = 0.0212345,
+          statistic = 5.2876543, p_value = 0.0012345, n_obs = 50L,
+          stringsAsFactors = FALSE
+        ),
+        weak_instrument = FALSE
+      )
+    )),
+    fma = fma_estimates(data.frame(
+      variable = "Precision", coefficient = 0.2881234, se = 0.0112345,
+      p_value = 0.0000123, stringsAsFactors = FALSE
+    )),
+    linear_tests = linear_tests_estimates(data.frame(
+      model = "ols", term = "effect", estimate = 0.0571234,
+      std_error = 0.0123456, statistic = 4.6271234, p_value = 0.0000123,
+      bootstrap_lower = 0.0312345, bootstrap_upper = 0.0812345,
+      n_obs = 120L, ci_conflict = FALSE, stringsAsFactors = FALSE
+    )),
+    maive = maive_estimates(list(
+      beta = 0.1234567, SE = 0.0456789, egger_coef = 1.2345678,
+      egger_se = 0.3456789, `pub bias p-value` = 0.0004321
+    )),
+    nonlinear_tests = nonlinear_tests_estimates(data.frame(
+      model = "waap", term = "effect", estimate = 0.0456789,
+      std_error = 0.0212345, p_value = 0.2012345, n_obs_model = 84L,
+      stringsAsFactors = FALSE
+    )),
+    p_hacking_tests = p_hacking_tests_estimates(list(caliper_results = list(list(
+      threshold = 1.96, width = 0.05, share_above = 0.6666667,
+      p_value = 0.0412345, n_above = 6, n_below = 3, n_studies = 4L,
+      direction = "above", tail = "positive", cluster_method = "study"
+    )))),
+    robma = robma_estimates(robma_table),
+    variable_summary_stats = variable_summary_stats_estimates(list(list(
+      label = "Study year", mean = 2005.4567891, median = 2006, min = 1998,
+      max = 2019, sd = 4.9876543, missing_share = 0.1256789, obs = 56L
+    )))
+  )
+}
+
+test_that("every method's exported estimates CSV parses as unrounded numerics", {
+  box::use(
+    artma / output / export[ensure_output_dirs, export_results],
+    withr[local_options, local_tempdir]
+  )
+
+  dir <- local_tempdir()
+  local_options(
+    artma.output.dir = dir,
+    artma.output.number_of_decimals = 3,
+    artma.output.table_formats = "csv",
+    artma.visualization.export_path = "graphics",
+    artma.verbose = 1
+  )
+  ensure_output_dirs(dir)
+
+  frames <- sample_estimates()
+  results <- lapply(frames, function(estimates) list(tables = list(), estimates = estimates))
+  export_results(results, dir)
+
+  for (method_name in names(frames)) {
+    path <- file.path(dir, "tables", paste0(method_name, ".csv"))
+    expect_true(file.exists(path))
+
+    written <- utils::read.csv(path, stringsAsFactors = FALSE)
+    for (column in c("estimate", "std_error", "statistic", "p_value", "conf_low", "conf_high")) {
+      values <- written[[column]]
+      expect_true(is.numeric(values) || all(is.na(values)))
+    }
+
+    # Every fixture carries more precision than the display rounding, so a
+    # value that survives rounding unchanged means the method pre-rounded it.
+    numbers <- unlist(written[c("estimate", "std_error", "p_value")])
+    numbers <- numbers[is.finite(numbers) & numbers != 0]
+    expect_true(any(numbers != round(numbers, 3)))
+  }
+})

--- a/tests/testthat/test-methods-p-hacking-exogeneity.R
+++ b/tests/testthat/test-methods-p-hacking-exogeneity.R
@@ -47,6 +47,14 @@ test_that("p_hacking_tests returns the standard contract with a caliper table", 
   expect_true(is.list(result))
   expect_true(is.data.frame(result$tables$caliper))
   expect_true(nrow(result$tables$caliper) > 0)
+
+  # The caliper grid also arrives as long-format estimates: one row per
+  # threshold-width pair, with the share above the threshold as the estimate.
+  estimates <- result$estimates
+  expect_true(nrow(estimates) > 0)
+  expect_true(all(grepl("^threshold_", estimates$model)))
+  expect_true(all(grepl("^width_", estimates$term)))
+  expect_true(is.numeric(estimates$estimate))
 })
 
 test_that("p_hacking_tests aborts when a required column is missing", {

--- a/tests/testthat/test-output-export.R
+++ b/tests/testthat/test-output-export.R
@@ -387,6 +387,26 @@ test_that("export_results leaves display names alone without an estimates slot",
   expect_equal(list.files(file.path(dir, "tables")), "bma.csv")
 })
 
+test_that("an empty estimates frame writes no header-only CSV", {
+  box::use(artma / modules / runtime_methods[new_estimates])
+  dir <- setup_output_dir()
+
+  export_results(
+    list(funnel_plot = list(tables = list(), estimates = new_estimates())),
+    dir
+  )
+
+  expect_equal(list.files(file.path(dir, "tables")), character())
+
+  # An empty frame also leaves the display table under its own name.
+  export_results(
+    list(bma = list(tables = list(summary = data.frame(a = 1)), estimates = new_estimates())),
+    dir
+  )
+
+  expect_equal(list.files(file.path(dir, "tables")), "bma.csv")
+})
+
 test_that("estimates are never written as LaTeX and the display table keeps <method>.tex", {
   dir <- setup_output_dir()
   local_options(artma.output.table_formats = c("csv", "tex"))

--- a/tests/testthat/test-variable-summary-stats.R
+++ b/tests/testthat/test-variable-summary-stats.R
@@ -37,7 +37,8 @@ test_that("Obs counts non-missing observations, not the count of ones for dummy 
     is_rct = c(1, 0, 0, NA)
   )
 
-  result <- variable_summary_stats(df)$tables$summary
+  method_result <- variable_summary_stats(df)
+  result <- method_result$tables$summary
 
   expect_named(result, c(
     "Var Name", "Var Class", "Mean", "Median",
@@ -46,4 +47,13 @@ test_that("Obs counts non-missing observations, not the count of ones for dummy 
   expect_identical(result$`Var Name`, c("Effect", "Is RCT"))
   # 3 non-missing rows for each variable, even though `is_rct` has only one 1.
   expect_equal(result$Obs, c("3", "3"))
+  expect_equal(result$`Missing obs`, c("25%", "25%"))
+
+  # The estimates slot reports the same run as numbers, with missingness as a
+  # proportion rather than the display table's percentage string.
+  estimates <- method_result$estimates
+  expect_identical(unique(estimates$model), c("Effect", "Is RCT"))
+  expect_equal(estimates$estimate[estimates$term == "missing_share"], c(0.25, 0.25))
+  expect_equal(estimates$estimate[estimates$term == "mean"], c(0.2, 1 / 3))
+  expect_equal(unique(estimates$n_obs), 3L)
 })


### PR DESCRIPTION
Every runtime method that reports numbers now fills the `estimates` slot introduced in #416, so the exported `<method>.csv` is unrounded and long-format. Plumbing for the methods that already built tidy coefficient frames (exogeneity, non-linear, BMA, FMA, RoBMA, MAIVE, best-practice estimate), and a documented dimension mapping for the ones where it was a judgement call: the caliper grid becomes one row per threshold-width pair, the Elliott battery one row per test family and support, and the summary-stats methods put the statistic in `estimate` with `term` naming it (`missing_share` is a proportion, not the display table's `"25%"` string). The MA table aggregate now reads BMA and FMA from their estimates frames rather than the display tables, the exporter treats an empty frame as no estimates so plot-only methods write no header-only CSV, and a new suite-wide test walks each discovered method's parse tree to fail a method that silently regresses to display-only output.

Closes #417