### PR TITLE
fix(linear): make between-effects standard errors robust and label every model's vcov

### DIFF
--- a/inst/artma/econometric/linear.R
+++ b/inst/artma/econometric/linear.R
@@ -18,7 +18,7 @@ box::use(
   artma / libs / formatting / summary_table[
     shared_build_summary_table = build_summary_table
   ],
-  artma / econometric / vcov[robust_vcov]
+  artma / econometric / vcov[robust_vcov, vcov_type]
 )
 
 # nocov start: glue/cli heavy formatting helpers ---------------------------
@@ -338,14 +338,15 @@ tidy_from_coeftest <- function(coef_matrix) {
   )
 }
 
-tidy_lm_model <- function(model, data, cluster_column) {
+tidy_lm_model <- function(model, data, cluster_column, label = NULL) {
   vcov <- robust_vcov(
     model = model,
     cluster = data[[cluster_column]],
     engine = "sandwich",
     clustered_type = "HC1",
     fallback_types = "HC1",
-    final_vcov_fallback = FALSE
+    final_vcov_fallback = FALSE,
+    label = label
   )
 
   coef_matrix <- lmtest::coeftest(model, vcov. = vcov)
@@ -357,16 +358,18 @@ tidy_lm_model <- function(model, data, cluster_column) {
   )[tidy$term_raw]
   tidy <- tidy[!is.na(tidy$term), , drop = FALSE]
   tidy$term_raw <- NULL
+  tidy$vcov_type <- vcov_type(vcov)
   tidy
 }
 
-tidy_plm_generic <- function(model, data) {
+tidy_plm_generic <- function(model, data, label = NULL) {
   vcov <- robust_vcov(
     model = model,
     cluster = "group",
     engine = "plm",
     clustered_type = "HC1",
-    fallback_types = "HC0"
+    fallback_types = "HC0",
+    label = label
   )
   coef_matrix <- lmtest::coeftest(model, vcov = vcov)
 
@@ -378,17 +381,92 @@ tidy_plm_generic <- function(model, data) {
   )[tidy$term_raw]
   tidy <- tidy[!is.na(tidy$term), , drop = FALSE]
   tidy$term_raw <- NULL
+  tidy$vcov_type <- vcov_type(vcov)
   tidy
 }
 
-tidy_plm_within <- function(model, data) {
+#' @title Collapse a prepared frame to one row per cluster
+#' @description The between estimator is unweighted OLS on cluster means, so
+#'   this is the frame it is actually fitted on.
+#' @param data *[data.frame]* Prepared data with `effect`, `se`, and the
+#'   cluster column.
+#' @param cluster_column *[character]* Name of the cluster column.
+#' @return *[data.frame]* One row per cluster, with `effect` and `se` means.
+group_mean_frame <- function(data, cluster_column) {
+  group <- droplevels(factor(data[[cluster_column]]))
+  first_in_group <- !duplicated(as.integer(group))
+  data.frame(
+    effect = stats::ave(data$effect, group)[first_in_group],
+    se = stats::ave(data$se, group)[first_in_group]
+  )
+}
+
+#' @title Tidy a between (group means) panel model
+#' @description
+#' `plm::vcovHC()` supports only `random`, `within`, `pooling` and `fd` models,
+#' so the shared ladder exhausts every robust step on a `between` fit and lands
+#' on classical standard errors. The between estimator is unweighted OLS on
+#' cluster means, so the same coefficients (and residual degrees of freedom)
+#' come out of an `lm` on that collapsed frame, where `sandwich` does work.
+#'
+#' Heteroskedasticity-robust HC1 is the right target rather than a clustered
+#' vcov: after collapsing there is exactly one observation per cluster, so
+#' `sandwich::vcovCL()` clustered on the study id returns the HC1 matrix
+#' element for element. Clustering buys nothing here, and pretending otherwise
+#' would suggest the between column corrects for within-study dependence when
+#' averaging has already removed it.
+#' @param model *[plm]* The fitted `between` model, used only to check that the
+#'   collapsed `lm` reproduces it.
+#' @param data *[data.frame]* The prepared data the model was fitted on.
+#' @param cluster_column *[character, optional]* Name of the cluster column.
+#' @param label *[character, optional]* Model display name, for warnings.
+#' @return *[data.frame]* A tidy coefficient frame with a `vcov_type` column.
+tidy_plm_between <- function(model, data, cluster_column = "study_id", label = NULL) {
+  box::use(artma / libs / core / validation[assert])
+
+  means <- group_mean_frame(data, cluster_column)
+  means_model <- stats::lm(effect ~ se, data = means)
+
+  assert(
+    isTRUE(all.equal(
+      unname(stats::coef(means_model)),
+      unname(stats::coef(model)),
+      tolerance = 1e-8
+    )),
+    "The group-means regression does not reproduce the between estimator."
+  )
+
+  vcov <- robust_vcov(
+    model = means_model,
+    cluster = NULL,
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = "HC0",
+    label = label
+  )
+
+  coef_matrix <- lmtest::coeftest(means_model, vcov. = vcov)
+  tidy <- tidy_from_coeftest(coef_matrix)
+
+  tidy$term <- c(
+    `se` = "publication_bias",
+    `(Intercept)` = "effect"
+  )[tidy$term_raw]
+  tidy <- tidy[!is.na(tidy$term), , drop = FALSE]
+  tidy$term_raw <- NULL
+  tidy$vcov_type <- vcov_type(vcov)
+  tidy
+}
+
+tidy_plm_within <- function(model, data, label = NULL) {
   vcov <- robust_vcov(
     model = model,
     cluster = "group",
     engine = "plm",
     clustered_type = "HC1",
     fallback_types = "HC0",
-    final_vcov_fallback = FALSE
+    final_vcov_fallback = FALSE,
+    label = label
   )
 
   coef_matrix <- lmtest::coeftest(model, vcov = vcov)
@@ -423,7 +501,9 @@ tidy_plm_within <- function(model, data) {
     check.names = FALSE
   )
 
-  rbind(intercept_row, slope[c("term", "estimate", "std_error", "statistic", "p_value")])
+  tidy <- rbind(intercept_row, slope[c("term", "estimate", "std_error", "statistic", "p_value")])
+  tidy$vcov_type <- vcov_type(vcov)
+  tidy
 }
 
 #' Extract bootstrap point estimates from an intercept + `se` slope model.
@@ -519,7 +599,7 @@ linear_model_specs <- function() {
       cluster_column = "study_id",
       terms = c("effect", "publication_bias"),
       fit = function(df) stats::lm(effect ~ se, data = df),
-      tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
+      tidy = function(model, data) tidy_lm_model(model, data, "study_id", "OLS"),
       boot_coefs = boot_coefs_intercept_slope,
       boot_estimate = boot_estimate_ols,
       supports_bootstrap = TRUE
@@ -534,7 +614,7 @@ linear_model_specs <- function() {
       required_packages = "plm",
       precheck = precheck_fe,
       fit = function(df) plm::plm(effect ~ se, data = df, model = "within", index = "study_id"),
-      tidy = tidy_plm_within,
+      tidy = function(model, data) tidy_plm_within(model, data, "Fixed Effects"),
       boot_coefs = boot_coefs_within,
       boot_estimate = boot_estimate_within,
       supports_bootstrap = TRUE
@@ -549,7 +629,7 @@ linear_model_specs <- function() {
       required_packages = "plm",
       precheck = precheck_be,
       fit = function(df) plm::plm(effect ~ se, data = df, model = "between", index = "study_id"),
-      tidy = tidy_plm_generic,
+      tidy = function(model, data) tidy_plm_between(model, data, "study_id", "Between Effects"),
       boot_coefs = boot_coefs_intercept_slope,
       boot_estimate = boot_estimate_be,
       supports_bootstrap = TRUE
@@ -564,7 +644,7 @@ linear_model_specs <- function() {
       required_packages = "plm",
       precheck = precheck_re,
       fit = function(df) plm::plm(effect ~ se, data = df, model = "random", index = "study_id"),
-      tidy = tidy_plm_generic,
+      tidy = function(model, data) tidy_plm_generic(model, data, "Random Effects"),
       boot_coefs = boot_coefs_intercept_slope,
       boot_estimate = boot_estimate_re,
       supports_bootstrap = TRUE
@@ -578,7 +658,7 @@ linear_model_specs <- function() {
       weight_column = "study_size",
       terms = c("effect", "publication_bias"),
       fit = function(df) stats::lm(effect ~ se, data = df, weights = (1 / df$study_size)),
-      tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
+      tidy = function(model, data) tidy_lm_model(model, data, "study_id", "Study Weighted OLS"),
       boot_coefs = boot_coefs_intercept_slope,
       boot_estimate = boot_estimate_study_weighted_ols,
       supports_bootstrap = TRUE
@@ -592,7 +672,7 @@ linear_model_specs <- function() {
       weight_column = "precision",
       terms = c("effect", "publication_bias"),
       fit = function(df) stats::lm(effect ~ se, data = df, weights = (df$precision^2)),
-      tidy = function(model, data) tidy_lm_model(model, data, "study_id"),
+      tidy = function(model, data) tidy_lm_model(model, data, "study_id", "Precision Weighted OLS"),
       boot_coefs = boot_coefs_intercept_slope,
       boot_estimate = make_boot_estimate_weighted_ols("precision"),
       supports_bootstrap = TRUE
@@ -717,6 +797,7 @@ run_linear_models <- function(df, options, is_pkg_available = NULL) {
       n_obs = integer(),
       bootstrap_lower = numeric(),
       bootstrap_upper = numeric(),
+      vcov_type = character(),
       stringsAsFactors = FALSE
     )
     return(list(coefficients = empty, summary = empty, skipped = skipped, options = options))
@@ -763,6 +844,10 @@ build_summary_table <- function(coefficients, digits) {
     return(data.frame())
   }
 
+  # The models do not all get the same kind of standard error (the between
+  # estimator cannot be clustered, and any model can be downgraded by a failing
+  # robust estimator), so the table says which is which. Without it the columns
+  # read as directly comparable when they are not.
   row_labels <- c(
     "Publication Bias",
     "(Std. Error)",
@@ -770,7 +855,8 @@ build_summary_table <- function(coefficients, digits) {
     "Effect Beyond Bias",
     "(Std. Error)",
     "Bootstrap CI (Effect)",
-    "Total Observations"
+    "Total Observations",
+    "Standard Errors"
   )
 
   columns <- list()
@@ -787,6 +873,10 @@ build_summary_table <- function(coefficients, digits) {
       n_obs_value <- n_obs_value[1]
     }
 
+    vcov_values <- unique(model_rows$vcov_type %||% NA_character_)
+    vcov_values <- vcov_values[!is.na(vcov_values)]
+    vcov_label <- if (length(vcov_values)) paste(vcov_values, collapse = "; ") else NA_character_
+
     column_name <- model_rows$model_label[1]
     columns[[column_name]] <- c(
       if (nrow(pb)) pb$estimate_formatted else NA_character_,
@@ -795,7 +885,8 @@ build_summary_table <- function(coefficients, digits) {
       if (nrow(eff)) eff$estimate_formatted else NA_character_,
       if (nrow(eff)) eff$std_error_formatted else NA_character_,
       if (nrow(eff)) eff$bootstrap_formatted else NA_character_,
-      if (nrow(model_rows)) format_number(n_obs_value, 0) else NA_character_
+      if (nrow(model_rows)) format_number(n_obs_value, 0) else NA_character_,
+      vcov_label
     )
   }
 

--- a/inst/artma/econometric/vcov.R
+++ b/inst/artma/econometric/vcov.R
@@ -11,6 +11,43 @@ box::use(
   artma / libs / core / validation[validate]
 )
 
+#' Display name of the classical (non-robust, non-clustered) estimator.
+VCOV_CLASSICAL <- "Classical (non-robust)"
+
+#' @title Name a vcov estimator
+#' @description Display name for the estimator a ladder step used. The strings
+#'   are user-facing: they reach the summary table, the LaTeX output, and the
+#'   `note` column of the estimates frame.
+#' @param type *[character]* The HC type, e.g. `"HC1"`.
+#' @param clustered *[logical]* Whether the step clustered.
+#' @return *[character]* A single display name.
+describe_vcov <- function(type, clustered) {
+  if (clustered) {
+    paste0("Cluster-robust (", type, ")")
+  } else {
+    paste0("Heteroskedasticity-robust (", type, ")")
+  }
+}
+
+#' @title Tag a variance-covariance matrix with its estimator name
+#' @param value *[matrix]* The variance-covariance matrix.
+#' @param type *[character]* The estimator display name.
+#' @return *[matrix]* `value` carrying a `vcov_type` attribute.
+tag_vcov <- function(value, type) {
+  attr(value, "vcov_type") <- type
+  value
+}
+
+#' @title Read the estimator behind a variance-covariance matrix
+#' @param value *[matrix]* A matrix returned by `robust_vcov()`.
+#' @param default *[character, optional]* Value returned when the matrix carries
+#'   no tag. Defaults to `NA_character_`.
+#' @return *[character]* The estimator display name.
+vcov_type <- function(value, default = NA_character_) {
+  type <- attr(value, "vcov_type")
+  if (is.null(type)) default else type
+}
+
 #' @title Compute a robust variance-covariance matrix with fallbacks
 #' @description
 #' Runs an ordered ladder of vcov estimators and returns the first that
@@ -65,7 +102,12 @@ box::use(
 #' @param suppress_warnings *[logical]* When `TRUE`, wrap the robust
 #'   (`sandwich`/`plm`) steps in `suppressWarnings()`. The `stats::vcov()` last
 #'   resort is never suppressed. Defaults to `FALSE`.
-#' @return *[matrix]* A variance-covariance matrix.
+#' @param label *[character, optional]* Display name of the model the vcov
+#'   belongs to. When supplied, downgrade warnings name it, so a table of
+#'   several models makes clear which column was affected.
+#' @return *[matrix]* A variance-covariance matrix, carrying a `vcov_type`
+#'   attribute naming the estimator that produced it (read it with
+#'   `vcov_type()`).
 robust_vcov <- function(model,
                         cluster = NULL,
                         engine = c("sandwich", "plm"),
@@ -74,7 +116,8 @@ robust_vcov <- function(model,
                         require_cluster = FALSE,
                         match_cluster_length = FALSE,
                         final_vcov_fallback = TRUE,
-                        suppress_warnings = FALSE) {
+                        suppress_warnings = FALSE,
+                        label = NULL) {
   engine <- match.arg(engine)
 
   if (require_cluster) {
@@ -90,12 +133,21 @@ robust_vcov <- function(model,
   }
 
   # Downgrading from clustered to non-clustered inference changes reported
-  # SEs materially (usually shrinking them); never do it silently.
+  # SEs materially (usually shrinking them); never do it silently. A run
+  # estimates several models side by side, so name the affected one when the
+  # caller knows it: an unattributed warning reads as if the whole table were
+  # downgraded.
   warn_downgrade <- function(reason) {
     if (get_verbosity() >= 2) {
-      cli::cli_alert_warning(
-        "Clustered vcov unavailable ({reason}); standard errors are NOT clustered."
-      )
+      if (is.null(label)) {
+        cli::cli_alert_warning(
+          "Clustered vcov unavailable ({reason}); standard errors are NOT clustered."
+        )
+      } else {
+        cli::cli_alert_warning(
+          "{label}: standard errors are NOT clustered ({reason})."
+        )
+      }
     }
   }
 
@@ -104,7 +156,8 @@ robust_vcov <- function(model,
   }
 
   # A robust (sandwich/plm) vcov step, optionally clustered, wrapped in
-  # suppressWarnings() when requested.
+  # suppressWarnings() when requested. Each step tags its result with the
+  # estimator that produced it so callers can report it downstream.
   robust_step <- function(type, clustered) {
     force(type)
     force(clustered)
@@ -122,7 +175,7 @@ robust_vcov <- function(model,
           plm::vcovHC(model, type = type)
         }
       }
-      value
+      tag_vcov(value, describe_vcov(type, clustered))
     }
   }
 
@@ -136,7 +189,9 @@ robust_vcov <- function(model,
   }
 
   # The final stats::vcov() step is never suppressed and runs uncaught.
-  final_step <- if (final_vcov_fallback) function() stats::vcov(model) else NULL
+  final_step <- if (final_vcov_fallback) {
+    function() tag_vcov(stats::vcov(model), VCOV_CLASSICAL)
+  }
 
   for (i in seq_along(steps)) {
     is_last <- is.null(final_step) && i == length(steps)
@@ -159,4 +214,4 @@ robust_vcov <- function(model,
   final_step()
 }
 
-box::export(robust_vcov)
+box::export(robust_vcov, vcov_type)

--- a/inst/artma/methods/linear_tests.R
+++ b/inst/artma/methods/linear_tests.R
@@ -82,6 +82,11 @@ linear_tests <- function(df) {
 #' Map the per-model coefficient frame onto the shared `estimates` schema. The
 #' numbers are carried over verbatim: the rounded and formatted columns that sit
 #' alongside them in `coefficients` belong to the display table only.
+#'
+#' The `note` column carries the variance estimator behind each row's standard
+#' error, so the distinction between a cluster-robust and a merely
+#' heteroskedasticity-robust column survives export instead of living only in a
+#' console warning.
 #' @param coefficients *\[data.frame\]* The coefficient frame from
 #'   `run_linear_models()`.
 #' @return *\[data.frame\]* A frame in the shared estimates schema.
@@ -94,11 +99,28 @@ linear_tests_estimates <- function(coefficients) {
     return(new_estimates())
   }
 
+  n_rows <- nrow(coefficients)
+
+  # Which variance estimator produced the standard error. The models in a run
+  # do not all get the same one, and the display table is the only other place
+  # that says so.
+  vcov_type <- coefficients$vcov_type %||% rep(NA_character_, n_rows)
+  vcov_note <- rep(NA_character_, n_rows)
+  known_vcov <- !is.na(vcov_type)
+  vcov_note[known_vcov] <- paste0("Standard errors: ", vcov_type[known_vcov])
+
   # The display table marks these rows with a dagger; the note carries the same
   # warning for a consumer that never sees the formatted table.
-  conflict <- coefficients$ci_conflict %||% rep(NA, nrow(coefficients))
-  note <- rep(NA_character_, nrow(coefficients))
-  note[!is.na(conflict) & conflict] <- "Bootstrap confidence interval and analytic significance disagree"
+  conflict <- coefficients$ci_conflict %||% rep(NA, n_rows)
+  conflict_note <- rep(NA_character_, n_rows)
+  conflict_note[!is.na(conflict) & conflict] <-
+    "Bootstrap confidence interval and analytic significance disagree"
+
+  note <- vapply(seq_len(n_rows), function(i) {
+    parts <- c(vcov_note[[i]], conflict_note[[i]])
+    parts <- parts[!is.na(parts)]
+    if (length(parts) == 0L) NA_character_ else paste(parts, collapse = "; ")
+  }, character(1))
 
   new_estimates(data.frame(
     method = "linear_tests",

--- a/tests/testthat/test-econometric-vcov.R
+++ b/tests/testthat/test-econometric-vcov.R
@@ -9,7 +9,7 @@ box::use(
     test_that
   ],
   withr[local_options],
-  artma / econometric / vcov[robust_vcov]
+  artma / econometric / vcov[robust_vcov, vcov_type]
 )
 
 # Deterministic fixture matching the shape used across the linear tests: an
@@ -49,7 +49,7 @@ test_that("robust_vcov reproduces the get_robust_vcov clustered HC1 ladder", {
   oracle <- suppressWarnings(
     sandwich::vcovCL(model, cluster = df$study_id, type = "HC1")
   )
-  expect_equal(result, oracle)
+  expect_equal(result, oracle, ignore_attr = "vcov_type")
 
   # Pinned golden values captured from the original ladder.
   expect_equal(unname(result["se", "se"]), 0.092270063, tolerance = 1e-7)
@@ -76,7 +76,7 @@ test_that("get_robust_vcov ladder falls back to non-clustered HC1 on cluster err
   )
 
   oracle <- suppressWarnings(sandwich::vcovHC(model, type = "HC1"))
-  expect_equal(result, oracle)
+  expect_equal(result, oracle, ignore_attr = "vcov_type")
 })
 
 test_that("robust_vcov warns when clustering is silently lost", {
@@ -157,6 +157,60 @@ test_that("robust_vcov warns on the no-cluster single-step downgrade to stats::v
   )
 })
 
+test_that("robust_vcov attributes the downgrade warning to the named model", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  # A run estimates several models at once, so the warning has to name the one
+  # it applies to; an unattributed line reads as if every column were affected.
+  expect_message(
+    robust_vcov(
+      model = model,
+      cluster = c(1, 2, 3),
+      engine = "sandwich",
+      clustered_type = "HC1",
+      fallback_types = "HC1",
+      label = "Between Effects"
+    ),
+    regexp = "Between Effects: standard errors are NOT clustered"
+  )
+})
+
+test_that("robust_vcov tags the result with the estimator that produced it", {
+  skip_if_not_installed("sandwich")
+  df <- make_vcov_fixture()
+  model <- stats::lm(effect ~ se, data = df)
+
+  clustered <- robust_vcov(
+    model = model,
+    cluster = df$study_id,
+    engine = "sandwich",
+    clustered_type = "HC1"
+  )
+  expect_equal(vcov_type(clustered), "Cluster-robust (HC1)")
+
+  downgraded <- robust_vcov(
+    model = model,
+    cluster = c(1, 2, 3),
+    engine = "sandwich",
+    clustered_type = "HC1",
+    fallback_types = "HC0"
+  )
+  expect_equal(vcov_type(downgraded), "Heteroskedasticity-robust (HC0)")
+
+  classical <- robust_vcov(
+    model = model,
+    cluster = NULL,
+    engine = "sandwich",
+    clustered_type = "BOGUS"
+  )
+  expect_equal(vcov_type(classical), "Classical (non-robust)")
+
+  # An untagged matrix (e.g. one built outside the ladder) reports NA.
+  expect_true(is.na(vcov_type(stats::vcov(model))))
+})
+
 test_that("robust_vcov errors when a required cluster is NULL", {
   df <- make_vcov_fixture()
   model <- stats::lm(effect ~ se, data = df)
@@ -181,7 +235,7 @@ test_that("robust_vcov reproduces resolve_bpe_vcov clustered HC0 (matching lengt
   )
 
   oracle <- sandwich::vcovCL(model, cluster = df$study_id, type = "HC0")
-  expect_equal(result, oracle)
+  expect_equal(result, oracle, ignore_attr = "vcov_type")
   expect_equal(unname(result["se", "se"]), 0.089088337, tolerance = 1e-7)
 })
 
@@ -203,7 +257,7 @@ test_that("resolve_bpe_vcov ladder uses non-clustered HC0 when cluster length mi
   )
 
   oracle <- sandwich::vcovHC(model, type = "HC0")
-  expect_equal(result, oracle)
+  expect_equal(result, oracle, ignore_attr = "vcov_type")
   expect_equal(unname(result["se", "se"]), 0.1105633, tolerance = 1e-6)
 
   # NULL cluster follows the same non-clustered branch.
@@ -214,7 +268,7 @@ test_that("resolve_bpe_vcov ladder uses non-clustered HC0 when cluster length mi
     clustered_type = "HC0",
     match_cluster_length = TRUE
   )
-  expect_equal(result_null, oracle)
+  expect_equal(result_null, oracle, ignore_attr = "vcov_type")
 })
 
 # --- sandwich engine: tidy_lm_model ladder ---------------------------------
@@ -237,7 +291,7 @@ test_that("robust_vcov reproduces tidy_lm_model HC1 ladder without a vcov last r
     sandwich::vcovCL(model, cluster = df$study_id, type = "HC1"),
     error = function(e) sandwich::vcovHC(model, type = "HC1")
   )
-  expect_equal(result, oracle)
+  expect_equal(result, oracle, ignore_attr = "vcov_type")
 })
 
 # --- plm engine: tidy_plm_generic / tidy_plm_within ladders ----------------
@@ -264,7 +318,7 @@ test_that("robust_vcov reproduces the tidy_plm_generic HC1/HC0 ladder", {
       )
     }
   )
-  expect_equal(result, oracle)
+  expect_equal(result, oracle, ignore_attr = "vcov_type")
   expect_equal(unname(result["se", "se"]), 0.086204523, tolerance = 1e-7)
 })
 
@@ -286,6 +340,6 @@ test_that("robust_vcov reproduces the tidy_plm_within HC1/HC0 ladder", {
     plm::vcovHC(model, type = "HC1", cluster = "group"),
     error = function(e) plm::vcovHC(model, type = "HC0")
   )
-  expect_equal(result, oracle)
+  expect_equal(result, oracle, ignore_attr = "vcov_type")
   expect_equal(unname(result["se", "se"]), 0.1058499, tolerance = 1e-6)
 })

--- a/tests/testthat/test-linear-tests.R
+++ b/tests/testthat/test-linear-tests.R
@@ -1,6 +1,7 @@
 box::use(
   testthat[
     expect_equal,
+    expect_error,
     expect_false,
     expect_gt,
     expect_match,
@@ -210,8 +211,8 @@ test_that("linear tests return tidy coefficients and summary", {
   expect_named(
     res$meta$coefficients,
     c(
-      "estimate", "std_error", "statistic", "p_value", "term", "model",
-      "model_label", "n_obs", "term_label", "bootstrap_lower",
+      "estimate", "std_error", "statistic", "p_value", "term", "vcov_type",
+      "model", "model_label", "n_obs", "term_label", "bootstrap_lower",
       "bootstrap_upper", "significance", "estimate_rounded",
       "std_error_rounded", "estimate_formatted", "std_error_formatted",
       "bootstrap_formatted", "ci_conflict"
@@ -224,9 +225,17 @@ test_that("linear tests return tidy coefficients and summary", {
     c(
       "Publication Bias", "(Std. Error)", "Bootstrap CI (PB)",
       "Effect Beyond Bias", "(Std. Error)", "Bootstrap CI (Effect)",
-      "Total Observations"
+      "Total Observations", "Standard Errors"
     )
   )
+
+  # The between column cannot be clustered, so the table has to say so.
+  expect_equal(
+    res$tables$summary[["Between Effects"]][[8L]],
+    "Heteroskedasticity-robust (HC1)"
+  )
+  expect_equal(res$tables$summary[["OLS"]][[8L]], "Cluster-robust (HC1)")
+
   expect_true(all(res$meta$coefficients$significance %in% c("", "*", "**", "***")))
   expect_equal(res$meta$options$bootstrap_replications, 10L)
 })
@@ -475,6 +484,68 @@ test_that("within fast path merges duplicated resampled clusters like plm", {
     unname(plm::within_intercept(model)[[1L]]),
     tolerance = 1e-12
   )
+})
+
+test_that("between effects standard errors are heteroskedasticity-robust on group means", {
+  skip_if_not_installed("plm")
+  skip_if_not_installed("sandwich")
+
+  df <- make_demo_data()
+  df$study_id <- droplevels(factor(df$study_id))
+
+  specs <- linear_model_specs()
+  names(specs) <- vapply(specs, function(spec) spec$name, character(1))
+  be_spec <- specs[["be"]]
+
+  model <- be_spec$fit(df)
+
+  # The reason the between column needs its own tidy path: plm::vcovHC accepts
+  # only random/within/pooling/fd models. Should a future plm gain `between`
+  # support, this expectation fails rather than the numbers changing quietly.
+  expect_error(
+    plm::vcovHC(model, type = "HC1", cluster = "group"),
+    regexp = "random"
+  )
+
+  tidy <- be_spec$tidy(model, df)
+
+  group <- droplevels(factor(df$study_id))
+  first_in_group <- !duplicated(as.integer(group))
+  means <- data.frame(
+    effect = stats::ave(df$effect, group)[first_in_group],
+    se = stats::ave(df$se, group)[first_in_group]
+  )
+  means_model <- stats::lm(effect ~ se, data = means)
+  oracle <- lmtest::coeftest(
+    means_model,
+    vcov. = sandwich::vcovHC(means_model, type = "HC1")
+  )
+
+  expect_equal(tidy$estimate[tidy$term == "effect"], oracle["(Intercept)", "Estimate"])
+  expect_equal(tidy$std_error[tidy$term == "effect"], oracle["(Intercept)", "Std. Error"])
+  expect_equal(tidy$std_error[tidy$term == "publication_bias"], oracle["se", "Std. Error"])
+  expect_equal(unique(tidy$vcov_type), "Heteroskedasticity-robust (HC1)")
+
+  # Point estimates still come from the between estimator itself.
+  expect_equal(
+    tidy$estimate[tidy$term == "publication_bias"],
+    unname(stats::coef(model)[["se"]])
+  )
+
+  # Clustering by study after collapsing to one row per study is degenerate:
+  # vcovCL returns the HC1 matrix element for element, which is why
+  # heteroskedasticity-robust is the ceiling rather than a shortcut.
+  expect_equal(
+    sandwich::vcovCL(means_model, cluster = seq_len(nrow(means)), type = "HC1"),
+    sandwich::vcovHC(means_model, type = "HC1")
+  )
+
+  # The classical standard errors the old path fell through to are different
+  # numbers, not a rounding difference.
+  expect_false(isTRUE(all.equal(
+    unname(tidy$std_error[tidy$term == "publication_bias"]),
+    unname(sqrt(diag(stats::vcov(model)))[["se"]])
+  )))
 })
 
 test_that("between effects fast path matches plm on duplicated resampled clusters", {
@@ -899,6 +970,14 @@ test_that("linear_tests_estimates flags CI conflicts and handles an empty frame"
   expect_true(is.na(estimates$note[1]))
   expect_match(estimates$note[2], "disagree")
   expect_equal(estimates$conf_low, coefficients$bootstrap_lower)
+
+  # The variance estimator travels with the numbers, so an exported CSV keeps
+  # the distinction that would otherwise live only in a console warning.
+  coefficients$vcov_type <- c("Cluster-robust (HC1)", "Heteroskedasticity-robust (HC1)")
+  annotated <- linear_tests_estimates(coefficients)
+  expect_equal(annotated$note[1], "Standard errors: Cluster-robust (HC1)")
+  expect_match(annotated$note[2], "^Standard errors: Heteroskedasticity-robust \\(HC1\\); ")
+  expect_match(annotated$note[2], "disagree$")
 
   empty <- linear_tests_estimates(data.frame())
   expect_equal(nrow(empty), 0L)

--- a/tests/testthat/test-summary-table-characterization.R
+++ b/tests/testthat/test-summary-table-characterization.R
@@ -79,37 +79,40 @@ test_that("linear_tests summary table is pinned on fixture data", {
       Metric = c(
         "Publication Bias", "(Std. Error)", "Bootstrap CI (PB)",
         "Effect Beyond Bias", "(Std. Error)", "Bootstrap CI (Effect)",
-        "Total Observations"
+        "Total Observations", "Standard Errors"
       ),
       OLS = c(
         "-0.25", "(0.30)", "[-0.61, 0.38]", "0.21***", "(0.03)",
-        "[0.13, 0.25]", "30"
+        "[0.13, 0.25]", "30", "Cluster-robust (HC1)"
       ),
       `Fixed Effects` = c(
         "-0.19", "(0.33)", "[-0.54, 0.02]", "0.20***", "(0.04)",
-        "[0.18, 0.25]", "30"
+        "[0.18, 0.25]", "30", "Cluster-robust (HC1)"
       ),
+      # The between estimator is OLS on group means, where plm::vcovHC does not
+      # apply and clustering is degenerate; its column is the only one on
+      # heteroskedasticity-robust rather than cluster-robust errors.
       `Between Effects` = c(
-        "-1.63", "(2.24)", "[-3.95, 0.21]", "0.36", "(0.25)",
-        "[0.17, 0.62] †", "30"
+        "-1.63", "(0.86)", "[-3.95, 0.21]", "0.36**", "(0.10)",
+        "[0.17, 0.62]", "30", "Heteroskedasticity-robust (HC1)"
       ),
       `Random Effects` = c(
         "-0.23", "(0.29)", "[-0.59, 0.16]", "0.21***", "(0.03)",
-        "[0.18, 0.24]", "30"
+        "[0.18, 0.24]", "30", "Cluster-robust (HC1)"
       ),
       `Study Weighted OLS` = c(
         "-0.17", "(0.30)", "[-0.60, 0.08]", "0.21***", "(0.03)",
-        "[0.18, 0.24]", "30"
+        "[0.18, 0.24]", "30", "Cluster-robust (HC1)"
       ),
       `Precision Weighted OLS` = c(
         "-0.24", "(0.24)", "[-0.53, 0.03]", "0.21***", "(0.03)",
-        "[0.18, 0.23]", "30"
+        "[0.18, 0.23]", "30", "Cluster-robust (HC1)"
       )
     ),
     row.names = c(
       "Publication Bias", "(Std. Error)", "Bootstrap CI (PB)",
       "Effect Beyond Bias", "(Std. Error)", "Bootstrap CI (Effect)",
-      "Total Observations"
+      "Total Observations", "Standard Errors"
     ),
     class = "data.frame"
   )


### PR DESCRIPTION
The Between Effects column of `linear_tests` always reported classical standard errors: `plm::vcovHC` rejects `between` models outright, so the fallback ladder in `inst/artma/econometric/vcov.R` exhausted every robust step and landed on `stats::vcov()`, with nothing in the exported table saying so. The between estimator is unweighted OLS on group means, so it is now tidied through an `lm` on the collapsed frame (identical coefficients and residual degrees of freedom, verified by an assertion) where `sandwich::vcovHC` applies. Heteroskedasticity-robust HC1 is the ceiling rather than a clustered vcov: after collapsing there is one observation per study, so `sandwich::vcovCL` returns the HC1 matrix element for element. `robust_vcov()` now takes the model's display name and puts it in any downgrade warning, and tags its result with the estimator that produced it; that tag reaches a "Standard Errors" row in the summary table (so it appears in the display CSV and the LaTeX output) and the `note` column of the estimates frame, so the distinction survives export. A new test pins the between path and fails loudly if a future `plm` release starts accepting `between` in `vcovHC`.

Closes #419