### PR TITLE
feat(core): add leveled verbosity log wrappers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Controls how much user interaction happens during analysis. `interactive()` is t
 
 - Validation: use `validate()` and `assert()` from `artma / libs / core / validation`, not `stopifnot()`. `assert(cond, "message")` takes an explicit error message.
 - Interactive menus: use the `climenu` package (a sub-package of this repository). Never `utils::menu()` or other menu packages.
-- Verbosity: `options(artma.verbose = <1..4>)` scales from errors-only (1) to debug (4); default 3. Gate output with `get_verbosity() >= 3` from `artma / libs / core / utils`.
+- Verbosity: `options(artma.verbose = <1..4>)` scales from errors-only (1) to debug (4); default 3. Call the leveled wrapper (`log_error`/`log_warn`/`log_info`/`log_debug`, or `is_*_enabled()` to gate non-message output) from `artma / libs / core / log`; never compare verbosity numbers outside `libs/core`.
 - Constants: `CONST` (`inst/artma/const.R`) and `PATHS` (`inst/artma/paths.R`), both globally declared; import with `box::use(artma / const[CONST])`.
 - Style: 2-space indentation; `snake_case` or `dotted.case` names (max 40 chars); prefer `cli::cli_*` over base messaging; custom linters live in `.lintr.R`.
 - Documentation: roxygen2 with type annotations: `@param x *\[character, optional\]* Description`.

--- a/inst/artma/calc/methods/elliott.R
+++ b/inst/artma/calc/methods/elliott.R
@@ -1,5 +1,6 @@
 box::use(
-  artma / visualization / fork_safety[in_forked_worker]
+  artma / visualization / fork_safety[in_forked_worker],
+  artma / libs / core / log[is_info_enabled]
 )
 
 #' Format a numeric value with a fixed number of decimals
@@ -61,8 +62,7 @@ simulate_cdfs_parallel <- function(
 
   bb_sup <- numeric(it)
 
-  verbosity <- getOption("artma.verbose", 3L)
-  show_pb <- isTRUE(show_progress) && verbosity >= 3L && it >= 1000L
+  show_pb <- isTRUE(show_progress) && is_info_enabled() && it >= 1000L
 
   if (show_pb) {
     cli::cli_inform("Pre-computing critical values for LCM test via Brownian bridge simulations")

--- a/inst/artma/econometric/p_hacking.R
+++ b/inst/artma/econometric/p_hacking.R
@@ -8,6 +8,7 @@ NULL
 box::use(
   stats[pchisq, ecdf, coef],
   artma / libs / core / validation[validate, assert],
+  artma / libs / core / log[is_info_enabled],
   artma / libs / formatting / results[
     format_number,
     format_se,
@@ -279,8 +280,7 @@ run_caliper_tests <- function(t_stats, thresholds = c(1.645, 1.96, 2.58),
   total_tests <- length(thresholds) * length(widths)
 
   # Show progress bar if requested and verbosity allows
-  verbosity <- getOption("artma.verbose", 3)
-  show_pb <- show_progress && verbosity >= 3 && total_tests >= 3
+  show_pb <- show_progress && is_info_enabled() && total_tests >= 3
 
   if (show_pb) {
     cli::cli_progress_bar(

--- a/inst/artma/libs/core/log.R
+++ b/inst/artma/libs/core/log.R
@@ -1,0 +1,120 @@
+#' @title Leveled CLI logging
+#' @description Wrappers around `cli::cli_alert_*()`/`cli::cli_inform()` that
+#'   check `get_verbosity()` internally, so call sites stop repeating
+#'   `if (get_verbosity() >= n) cli::cli_...(...)` (and, worse, re-deriving `n`
+#'   via a hardcoded `getOption("artma.verbose", <default>)` that drifts from
+#'   `CONST$DEFAULT_VERBOSITY`). One wrapper per documented verbosity level:
+#'   1 errors, 2 warnings, 3 info (the default), 4 debug. Each forwards `...`
+#'   and evaluates glue interpolation in the caller's environment, so a call
+#'   such as `log_info("Read {.val {n}} rows")` behaves exactly like the
+#'   `cli::cli_alert_*()` call it replaces.
+#'
+#'   The `is_*_enabled()` predicates expose the same thresholds for call
+#'   sites that gate something other than a single message (e.g. whether to
+#'   render a progress bar) on a verbosity level, without comparing verbosity
+#'   numbers themselves outside this module.
+box::use(artma / libs / core / utils[get_verbosity])
+
+#' @title Check whether error-level logging is enabled
+#' @description `TRUE` when `get_verbosity() >= 1`.
+#' @return *\[logical\]*
+#' @export
+is_error_enabled <- function() get_verbosity() >= 1
+
+#' @title Check whether warn-level logging is enabled
+#' @description `TRUE` when `get_verbosity() >= 2`.
+#' @return *\[logical\]*
+#' @export
+is_warn_enabled <- function() get_verbosity() >= 2
+
+#' @title Check whether info-level logging is enabled
+#' @description `TRUE` when `get_verbosity() >= 3` (the default verbosity).
+#' @return *\[logical\]*
+#' @export
+is_info_enabled <- function() get_verbosity() >= 3
+
+#' @title Check whether debug-level logging is enabled
+#' @description `TRUE` when `get_verbosity() >= 4`.
+#' @return *\[logical\]*
+#' @export
+is_debug_enabled <- function() get_verbosity() >= 4
+
+#' @title Log an error-level message
+#' @description Emits via `cli::cli_alert_danger()` when
+#'   `get_verbosity() >= 1`. This is for non-fatal error reporting (the
+#'   analysis continues); use `cli::cli_abort()` directly to actually stop
+#'   execution, since aborting is never gated on verbosity.
+#' @param text *\[character\]* Message, following the same glue/cli syntax as
+#'   `cli::cli_alert_danger()`.
+#' @param ... Forwarded to `cli::cli_alert_danger()`.
+#' @param .envir *\[environment\]* Environment glue interpolation resolves
+#'   `{}` expressions in. Defaults to the caller's environment.
+#' @return `NULL` (invisible).
+#' @export
+log_error <- function(text, ..., .envir = parent.frame()) {
+  if (is_error_enabled()) {
+    cli::cli_alert_danger(text, ..., .envir = .envir)
+  }
+  invisible(NULL)
+}
+
+#' @title Log a warning-level message
+#' @description Emits via `cli::cli_alert_warning()` when
+#'   `get_verbosity() >= 2`.
+#' @param text *\[character\]* Message, following the same glue/cli syntax as
+#'   `cli::cli_alert_warning()`.
+#' @param ... Forwarded to `cli::cli_alert_warning()`.
+#' @param .envir *\[environment\]* Environment glue interpolation resolves
+#'   `{}` expressions in. Defaults to the caller's environment.
+#' @return `NULL` (invisible).
+#' @export
+log_warn <- function(text, ..., .envir = parent.frame()) {
+  if (is_warn_enabled()) {
+    cli::cli_alert_warning(text, ..., .envir = .envir)
+  }
+  invisible(NULL)
+}
+
+#' @title Log an info-level message
+#' @description Emits via `cli::cli_alert_info()` when `get_verbosity() >= 3`
+#'   (the default verbosity).
+#' @param text *\[character\]* Message, following the same glue/cli syntax as
+#'   `cli::cli_alert_info()`.
+#' @param ... Forwarded to `cli::cli_alert_info()`.
+#' @param .envir *\[environment\]* Environment glue interpolation resolves
+#'   `{}` expressions in. Defaults to the caller's environment.
+#' @return `NULL` (invisible).
+#' @export
+log_info <- function(text, ..., .envir = parent.frame()) {
+  if (is_info_enabled()) {
+    cli::cli_alert_info(text, ..., .envir = .envir)
+  }
+  invisible(NULL)
+}
+
+#' @title Log a debug-level message
+#' @description Emits via `cli::cli_inform()` when `get_verbosity() >= 4`.
+#' @param text *\[character\]* Message, following the same glue/cli syntax as
+#'   `cli::cli_inform()`.
+#' @param ... Forwarded to `cli::cli_inform()`.
+#' @param .envir *\[environment\]* Environment glue interpolation resolves
+#'   `{}` expressions in. Defaults to the caller's environment.
+#' @return `NULL` (invisible).
+#' @export
+log_debug <- function(text, ..., .envir = parent.frame()) {
+  if (is_debug_enabled()) {
+    cli::cli_inform(text, ..., .envir = .envir)
+  }
+  invisible(NULL)
+}
+
+box::export(
+  log_error,
+  log_warn,
+  log_info,
+  log_debug,
+  is_error_enabled,
+  is_warn_enabled,
+  is_info_enabled,
+  is_debug_enabled
+)

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -1,0 +1,118 @@
+box::use(
+  testthat[
+    expect_equal, expect_false, expect_message, expect_no_message, expect_true, test_that
+  ]
+)
+
+test_that("log_error emits only at verbosity >= 1", {
+  box::use(artma / libs / core / log[log_error])
+
+  withr::local_options(list(artma.verbose = 0))
+  expect_no_message(log_error("boom"))
+
+  for (level in 1:4) {
+    withr::local_options(list(artma.verbose = level))
+    expect_message(log_error("boom"), "boom")
+  }
+})
+
+test_that("log_warn emits only at verbosity >= 2", {
+  box::use(artma / libs / core / log[log_warn])
+
+  for (level in c(0, 1)) {
+    withr::local_options(list(artma.verbose = level))
+    expect_no_message(log_warn("careful"))
+  }
+
+  for (level in 2:4) {
+    withr::local_options(list(artma.verbose = level))
+    expect_message(log_warn("careful"), "careful")
+  }
+})
+
+test_that("log_info emits only at verbosity >= 3", {
+  box::use(artma / libs / core / log[log_info])
+
+  for (level in c(0, 1, 2)) {
+    withr::local_options(list(artma.verbose = level))
+    expect_no_message(log_info("fyi"))
+  }
+
+  for (level in 3:4) {
+    withr::local_options(list(artma.verbose = level))
+    expect_message(log_info("fyi"), "fyi")
+  }
+})
+
+test_that("log_debug emits only at verbosity >= 4", {
+  box::use(artma / libs / core / log[log_debug])
+
+  for (level in c(0, 1, 2, 3)) {
+    withr::local_options(list(artma.verbose = level))
+    expect_no_message(log_debug("trace"))
+  }
+
+  withr::local_options(list(artma.verbose = 4))
+  expect_message(log_debug("trace"), "trace")
+})
+
+test_that("all wrappers default to CONST$DEFAULT_VERBOSITY when the option is unset", {
+  box::use(
+    artma / const[CONST],
+    artma / libs / core / log[log_error, log_warn, log_info, log_debug]
+  )
+
+  withr::local_options(list(artma.verbose = NULL))
+  expect_equal(CONST$DEFAULT_VERBOSITY, 3)
+
+  # Default verbosity (3) is info: error/warn/info emit, debug stays silent.
+  expect_message(log_error("boom"), "boom")
+  expect_message(log_warn("careful"), "careful")
+  expect_message(log_info("fyi"), "fyi")
+  expect_no_message(log_debug("trace"))
+})
+
+test_that("is_*_enabled predicates match the documented thresholds", {
+  box::use(
+    artma / libs / core / log[
+      is_error_enabled, is_warn_enabled, is_info_enabled, is_debug_enabled
+    ]
+  )
+
+  expectations <- list(
+    "0" = c(FALSE, FALSE, FALSE, FALSE),
+    "1" = c(TRUE, FALSE, FALSE, FALSE),
+    "2" = c(TRUE, TRUE, FALSE, FALSE),
+    "3" = c(TRUE, TRUE, TRUE, FALSE),
+    "4" = c(TRUE, TRUE, TRUE, TRUE)
+  )
+
+  for (level_str in names(expectations)) {
+    withr::local_options(list(artma.verbose = as.integer(level_str)))
+    expected <- expectations[[level_str]]
+
+    expect_equal(is_error_enabled(), expected[1], info = paste("level", level_str))
+    expect_equal(is_warn_enabled(), expected[2], info = paste("level", level_str))
+    expect_equal(is_info_enabled(), expected[3], info = paste("level", level_str))
+    expect_equal(is_debug_enabled(), expected[4], info = paste("level", level_str))
+  }
+})
+
+test_that("wrappers interpolate cli glue expressions from the caller's environment", {
+  box::use(artma / libs / core / log[log_info])
+
+  withr::local_options(list(artma.verbose = 3))
+
+  n_rows <- 42
+  label <- "widgets"
+  expect_message(log_info("Read {n_rows} {label}"), "Read 42 widgets")
+})
+
+test_that("wrappers forward extra cli arguments (pluralization, inline classes)", {
+  box::use(artma / libs / core / log[log_warn])
+
+  withr::local_options(list(artma.verbose = 2))
+
+  n <- 3
+  expect_message(log_warn("Found {n} issue{?s}"), "Found 3 issues")
+})


### PR DESCRIPTION
## Summary

Adds a small set of leveled logging wrappers in `inst/artma/libs/core/log.R` and fixes the two call sites that had drifted from `CONST$DEFAULT_VERBOSITY`.

- `log_error`/`log_warn`/`log_info`/`log_debug`: check `get_verbosity()` internally and emit via `cli::cli_alert_danger`/`cli_alert_warning`/`cli_alert_info`/`cli_inform` respectively, mapped to the documented semantics (1 errors, 2 warnings, 3 info/default, 4 debug). They forward `...` and evaluate glue interpolation in the caller's frame (`.envir = parent.frame()`), so migrating an existing `cli::cli_inform()`/`cli_alert_*()` call is mechanical.
- `is_error_enabled`/`is_warn_enabled`/`is_info_enabled`/`is_debug_enabled`: boolean predicates for call sites that gate something other than a message (e.g. a progress bar) on a verbosity level, so verbosity numbers stay compared only inside `libs/core`.
- Migrated the two call sites that had hardcoded `getOption("artma.verbose", 3)`/`3L` instead of going through `get_verbosity()` (`inst/artma/calc/methods/elliott.R`, `inst/artma/econometric/p_hacking.R`), both of which gate a progress bar rather than emit a single message, so they now use `is_info_enabled()`.
- Updated the Verbosity convention line in `CLAUDE.md`.
- Added `tests/testthat/test-log.R` covering each wrapper's threshold across verbosity levels 0-4, the unset-option default, the `is_*_enabled()` predicates, and cli glue interpolation/pluralization from the caller's frame.

Does not mass-migrate the ~212 existing `get_verbosity() >= n` call sites; that stays an explicit follow-up.

## Testing

- `make lint`
- `make test`