### PR TITLE
docs: fix unexported prepare_data() call in getting-started vignette

### DIFF
--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -429,8 +429,7 @@ artma::options.validate("my_analysis.yaml")
 artma::methods.list()
 
 # Check data structure (after loading)
-df <- artma::prepare_data()
-str(df)
+artma::data.preview(options = "my_analysis.yaml")
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- `vignettes/getting-started.Rmd` showed `df <- artma::prepare_data()` as an example, but `prepare_data` is an internal `box` module function (`inst/artma/data/index.R`), not exported in `NAMESPACE`. The snippet would error if run.
- Replaced it with `artma::data.preview(options = "my_analysis.yaml")`, the actual exported, supported way to inspect prepared data.

## Test plan
- Read-only doc change inside a plain ` ```r ` fence (not evaluated by R CMD check).