### PR TITLE
docs(api): move README, vignettes, and pkgdown reference to snake_case names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ The entry point is `prepare_data()` from `artma/data/index.R`.
 
 ### Autonomy System
 
-Controls how much user interaction happens during analysis. `interactive()` is the hard gate: non-interactive sessions never prompt. Within interactive sessions the level (stored in the options file under `autonomy.level`) is one of `ask_more`, `balanced`, or `autonomous` (the default), ordered from most to least talkative. Gate prompts with `should_prompt_user(required_level)` from `artma / libs / core / autonomy`: use `required_level = "balanced"` for non-critical options, preferences, and save/overwrite confirmations; `required_level = "autonomous"` (the default) for variable selection, method selection, and column mapping. Public API: `artma::autonomy.get()`, `artma::autonomy.set()`, `artma::autonomy.is_full()` (also TRUE in non-interactive sessions).
+Controls how much user interaction happens during analysis. `interactive()` is the hard gate: non-interactive sessions never prompt. Within interactive sessions the level (stored in the options file under `autonomy.level`) is one of `ask_more`, `balanced`, or `autonomous` (the default), ordered from most to least talkative. Gate prompts with `should_prompt_user(required_level)` from `artma / libs / core / autonomy`: use `required_level = "balanced"` for non-critical options, preferences, and save/overwrite confirmations; `required_level = "autonomous"` (the default) for variable selection, method selection, and column mapping. Public API: `artma::autonomy_get()`, `artma::autonomy_set()`, `artma::autonomy_is_full()` (also TRUE in non-interactive sessions).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Expensive computations are cached on disk between runs, so rerunning an analysis
 
 # Available methods
 
-List them at any time with `artma::methods.list()`. The current set:
+List them at any time with `artma::methods_list()`. The current set:
 
 | Method | What it does |
 | --- | --- |
@@ -134,7 +134,7 @@ getOption("artma.verbose") # e.g. 3
 If you call a runtime method without an options file, artma prompts you to create one. You can also do it explicitly:
 
 ```r
-artma::options.create()
+artma::options_create()
 ```
 
 Pass the file name to `artma()` to use it for a run:
@@ -151,20 +151,20 @@ Options are loaded only for the duration of the call, so different configuration
 Useful helpers:
 
 ```r
-artma::options.list()              # names of your existing options files
-artma::options.open()              # open a file for editing
-artma::options.help()              # documentation for every available option
-artma::options.validate()          # check a file against the template
-artma::options.fix()               # fill in missing options with defaults
-artma::options.copy()              # duplicate a configuration
-artma::options.delete()            # remove one
-artma::options.print_default_dir() # where the files live
+artma::options_list()              # names of your existing options files
+artma::options_open()              # open a file for editing
+artma::options_help()              # documentation for every available option
+artma::options_validate()          # check a file against the template
+artma::options_fix()               # fill in missing options with defaults
+artma::options_copy()              # duplicate a configuration
+artma::options_delete()            # remove one
+artma::options_print_default_dir() # where the files live
 ```
 
 ## Modifying options
 
 ```r
-artma::options.modify(
+artma::options_modify(
   options_file_name = "my_analysis.yaml",
   user_input = list("verbose" = 4)
 )
@@ -190,7 +190,7 @@ artma reads CSV, TSV, Excel (`.xlsx`/`.xls`), JSON, Stata (`.dta`), and RDS file
 Preview any dataset (from a path, a data frame, or your options file) with:
 
 ```r
-artma::data.preview()
+artma::data_preview()
 ```
 
 ## Per-variable configuration
@@ -198,12 +198,12 @@ artma::data.preview()
 Each column in your dataset has a configuration entry that controls how it participates in the analyses: its type, which methods use it, grouping flags, and so on. Sensible defaults are auto-detected from the data; only your deviations from the defaults are persisted in the options file.
 
 ```r
-artma::config.get()                          # the fully resolved config
-artma::config.get(var_name = "study_size")   # one variable's entry
-artma::config.set("study_size", bma = TRUE)  # override specific fields
-artma::config.overrides()                    # see only what you've overridden
-artma::config.reset("study_size")            # back to auto-detected defaults
-artma::config.fix()                          # regenerate the config from the data
+artma::config_get()                          # the fully resolved config
+artma::config_get(var_name = "study_size")   # one variable's entry
+artma::config_set("study_size", bma = TRUE)  # override specific fields
+artma::config_overrides()                    # see only what you've overridden
+artma::config_reset("study_size")            # back to auto-detected defaults
+artma::config_fix()                          # regenerate the config from the data
 ```
 
 # Autonomy: how much artma asks
@@ -217,8 +217,8 @@ The autonomy level controls how many interactive prompts you get during a run:
 | `autonomous` (default) | Minimal prompts; rely on defaults and auto-detection |
 
 ```r
-artma::autonomy.get()
-artma::autonomy.set("balanced")
+artma::autonomy_get()
+artma::autonomy_set("balanced")
 ```
 
 Non-interactive sessions (scripts, CI) never prompt, regardless of the level.
@@ -228,16 +228,16 @@ Non-interactive sessions (scripts, CI) never prompt, regardless of the level.
 Tables are exported as CSV and plots as graphics files into the results directory:
 
 ```r
-artma::results.dir()  # print and return the path
-artma::results.open() # open it in your file browser
+artma::results_dir()  # print and return the path
+artma::results_open() # open it in your file browser
 ```
 
 Plot appearance is configurable per session:
 
 ```r
-artma::viz.themes()             # available themes
-artma::viz.get()                # current settings
-artma::viz.set(theme = "purple")
+artma::viz_themes()             # available themes
+artma::viz_get()                # current settings
+artma::viz_set(theme = "purple")
 ```
 
 # Custom methods

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,3 +17,35 @@ articles:
       - methods-overview
       - options-files
       - release-cycle
+
+reference:
+  - title: Run an analysis
+    contents:
+      - artma
+      - methods_list
+  - title: Options files
+    contents:
+      - starts_with("options_")
+  - title: Data configuration
+    contents:
+      - starts_with("config_")
+      - data_preview
+  - title: Autonomy
+    contents:
+      - starts_with("autonomy_")
+  - title: Results and reports
+    contents:
+      - results_dir
+      - results_open
+      - report_render
+  - title: Visualization
+    contents:
+      - starts_with("viz_")
+      - starts_with("print.artma_")
+  - title: Command-line interface
+    contents:
+      - cli_run
+      - cli_install
+  - title: Deprecated
+    contents:
+      - artma-deprecated

--- a/contributingGuides/METHODS.md
+++ b/contributingGuides/METHODS.md
@@ -30,11 +30,11 @@ run <- register_runtime_method(
 box::export(my_method, run)
 ```
 
-Export `run` plus the implementation (tests import it); do not export other internals unless another module genuinely reuses them. Methods are auto-discovered by scanning `inst/artma/methods/`; `artma::methods.list()` renders the registered metadata of every discovered method as a console table and returns it as a data frame (`inst/artma/modules/methods_table.R`), and the methods-overview vignette repeats the same facts under a parity test. `df` is the preprocessed data frame; other arguments come from the options system.
+Export `run` plus the implementation (tests import it); do not export other internals unless another module genuinely reuses them. Methods are auto-discovered by scanning `inst/artma/methods/`; `artma::methods_list()` renders the registered metadata of every discovered method as a console table and returns it as a data frame (`inst/artma/modules/methods_table.R`), and the methods-overview vignette repeats the same facts under a parity test. `df` is the preprocessed data frame; other arguments come from the options system.
 
 ## Metadata
 
-`description` is required in practice: `tests/testthat/test-methods-table.R` fails when a discovered method registers none. It is the one-line summary `artma::methods.list()` prints, so keep it to a single line and lead with what the method produces; the printed table truncates it to the console width.
+`description` is required in practice: `tests/testthat/test-methods-table.R` fails when a discovered method registers none. It is the one-line summary `artma::methods_list()` prints, so keep it to a single line and lead with what the method produces; the printed table truncates it to the console width.
 
 The remaining metadata arguments are optional:
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -28,7 +28,7 @@ When you run this in an interactive R session, artma will:
 4. **Let you choose methods** - Select which analyses you want to run
 5. **Run your analysis** - Execute everything and return results
 
-If you want artma to open the results folder for you at the end of a run, set `open_results = TRUE`. You can always access your results later manually using `artma::results.open()`.
+If you want artma to open the results folder for you at the end of a run, set `open_results = TRUE`. You can always access your results later manually using `artma::results_open()`.
 
 That's it! The function handles all the complexity behind the scenes.
 
@@ -140,7 +140,7 @@ For scripts and automation:
 
 ```r
 # Create options file programmatically
-artma::options.create(
+artma::options_create(
   options_file_name = "analysis_2025",
   user_input = list(
     "data.source_path" = "/path/to/data.csv",
@@ -239,7 +239,7 @@ copy its directory, or point `output.dir` at a per-run location.
 To see what methods are available:
 
 ```r
-artma::methods.list()
+artma::methods_list()
 ```
 
 This prints all available methods to the console.
@@ -271,10 +271,10 @@ Options files are created automatically when needed, but you can also create the
 
 ```r
 # Interactive creation
-artma::options.create()
+artma::options_create()
 
 # Programmatic creation
-artma::options.create(
+artma::options_create(
   options_file_name = "my_analysis",
   user_input = list(
     "data.source_path" = "/path/to/data.csv",
@@ -290,16 +290,16 @@ artma::options.create(
 
 ```r
 # List all options files
-artma::options.list()
+artma::options_list()
 
 # Copy an options file
-artma::options.copy(
+artma::options_copy(
   options_file_name_from = "baseline.yaml",
   options_file_name_to = "sensitivity.yaml"
 )
 
 # Modify an options file
-artma::options.modify(
+artma::options_modify(
   options_file_name = "my_analysis.yaml",
   options_to_modify = list(
     "methods.effect_summary_stats.conf_level" = 0.99
@@ -307,7 +307,7 @@ artma::options.modify(
 )
 
 # Validate an options file
-artma::options.validate("my_analysis.yaml")
+artma::options_validate("my_analysis.yaml")
 ```
 
 For detailed information about options files, see the [Understanding Options Files](options-files.html) vignette.
@@ -392,7 +392,7 @@ options(artma.verbose = 4)  # Verbose: everything
 If you're modifying options files manually, validate them:
 
 ```r
-artma::options.validate("my_analysis.yaml")
+artma::options_validate("my_analysis.yaml")
 ```
 
 This catches errors before you run the analysis.
@@ -402,8 +402,8 @@ This catches errors before you run the analysis.
 ### Documentation
 
 - `?artma` - Main function help
-- `?artma::methods.list` - List available methods
-- `?artma::options.create` - Create options files
+- `?artma::methods_list` - List available methods
+- `?artma::options_create` - Create options files
 - Vignettes - Detailed guides (like this one!)
 
 ### Verbosity Levels
@@ -423,14 +423,13 @@ When in doubt, validate:
 
 ```r
 # Validate options file
-artma::options.validate("my_analysis.yaml")
+artma::options_validate("my_analysis.yaml")
 
 # Check available methods
-artma::methods.list()
+artma::methods_list()
 
-# Check data structure (after loading)
-df <- artma::prepare_data()
-str(df)
+# Check how artma reads and preprocesses your data
+artma::data_preview(options = "my_analysis.yaml")
 ```
 
 ## Next Steps

--- a/vignettes/methods-overview.Rmd
+++ b/vignettes/methods-overview.Rmd
@@ -14,13 +14,13 @@ vignette: >
 List the methods available in your installed version at any time with:
 
 ```r
-artma::methods.list()
+artma::methods_list()
 ```
 
 That prints one row per method: what it does, the data columns it needs, the methods that run before it, the optional packages it uses (with an `install <pkg>` status when one is missing), and whether it is opt-in. It also returns the same information as a data frame, invisibly. Pass your data to check the required columns before a run, so you see which methods would be skipped rather than finding out afterwards:
 
 ```r
-methods <- artma::methods.list(available_for = my_data)
+methods <- artma::methods_list(available_for = my_data)
 methods[!methods$available, c("method", "missing_columns", "missing_packages")]
 ```
 
@@ -28,7 +28,7 @@ The tables below carry the same metadata; a test keeps them in step with what th
 
 ## How methods execute
 
-Each method is a plain function registered with `register_runtime_method()`, which attaches declarative metadata: a one-line `description`, a `depends_on` list of upstream methods, a `required_columns` list of data columns it needs, and a `suggests` list of optional packages it needs. `methods.list()` reads that metadata back, so the printed overview cannot fall out of step with what the methods declare.
+Each method is a plain function registered with `register_runtime_method()`, which attaches declarative metadata: a one-line `description`, a `depends_on` list of upstream methods, a `required_columns` list of data columns it needs, and a `suggests` list of optional packages it needs. `methods_list()` reads that metadata back, so the printed overview cannot fall out of step with what the methods declare.
 
 When you call `artma(methods = ...)`, the requested methods are topologically sorted by their `depends_on` edges, so a method that builds on another method's output (for example, `best_practice_estimate` builds on `bma`) always runs after it and receives its result as a `<dependency>_result` argument. Ties preserve discovery order; dependency cycles abort the run.
 
@@ -110,10 +110,10 @@ results <- artma(methods = "all", options = "my_analysis.yaml")
 results <- artma(methods = c("funnel_plot", "bma", "fma"), options = "my_analysis.yaml")
 ```
 
-To see the skips in advance, hand your prepared data to `methods.list()`:
+To see the skips in advance, hand your prepared data to `methods_list()`:
 
 ```r
-methods <- artma::methods.list(available_for = my_data)
+methods <- artma::methods_list(available_for = my_data)
 subset(methods, !available)[, c("method", "missing_columns", "missing_packages")]
 ```
 

--- a/vignettes/options-files.Rmd
+++ b/vignettes/options-files.Rmd
@@ -190,7 +190,7 @@ artma::artma()
 You can also create one explicitly:
 
 ```r
-artma::options.create()
+artma::options_create()
 ```
 
 During creation, you'll be guided through:
@@ -218,7 +218,7 @@ Choose descriptive names that help you identify the analysis:
 You can also create options files programmatically by providing values:
 
 ```r
-artma::options.create(
+artma::options_create(
   options_file_name = "my_analysis",
   user_input = list(
     "data.source_path" = "/path/to/data.csv",
@@ -302,7 +302,7 @@ Options files are text files (YAML), making them perfect for version control. Co
 Always validate your options files before using them:
 
 ```r
-artma::options.validate("my_analysis.yaml")
+artma::options_validate("my_analysis.yaml")
 ```
 
 This checks that:
@@ -407,15 +407,15 @@ cache:
 
 ### Browsing the Option Tree
 
-Called without arguments, `artma::options.help()` prints every option the template defines, grouped by top-level section, one line per option with its type and default:
+Called without arguments, `artma::options_help()` prints every option the template defines, grouped by top-level section, one line per option with its type and default:
 
 ```r
-artma::options.help()
+artma::options_help()
 ```
 
 ```
 ── artma options ───────────────────────────────────────────────────────
-127 options in 10 sections. Call `artma::options.help('<name>')` with an
+127 options in 10 sections. Call `artma::options_help('<name>')` with an
 option or a group name for details.
 
 ── calc ──
@@ -427,24 +427,24 @@ option or a group name for details.
 Pass a name to read the full help text of an option:
 
 ```r
-artma::options.help("methods.bma.iter")
+artma::options_help("methods.bma.iter")
 ```
 
 A name that points at a group rather than a single option expands to everything underneath it, so you do not have to know the full path in advance:
 
 ```r
-artma::options.help("methods.bma")     # every option of the BMA method
-artma::options.help("methods")         # every method option
+artma::options_help("methods.bma")     # every option of the BMA method
+artma::options_help("methods")         # every method option
 ```
 
 Names that match nothing are reported, and the recognized ones are still printed.
 
 ### Comparing Options Files
 
-`artma::options.diff()` answers "what is actually different about this configuration": it lists the options whose values differ between two files, then each file's deviations from the template defaults.
+`artma::options_diff()` answers "what is actually different about this configuration": it lists the options whose values differ between two files, then each file's deviations from the template defaults.
 
 ```r
-artma::options.diff("baseline.yaml", "sensitivity.yaml")
+artma::options_diff("baseline.yaml", "sensitivity.yaml")
 ```
 
 ```
@@ -467,13 +467,13 @@ List-typed options such as `data.columns` are compared entry by entry, so the di
 See all available options files:
 
 ```r
-artma::options.list()
+artma::options_list()
 ```
 
 Pass `details = TRUE` for a data frame describing each file: the dataset it points at, when it was last modified, when it last produced results, and how many of its options deviate from the template defaults.
 
 ```r
-artma::options.list(details = TRUE)
+artma::options_list(details = TRUE)
 ```
 
 ```
@@ -489,7 +489,7 @@ The last run time is read from the file's output directory, and is `NA` for a fi
 Create a new options file based on an existing one:
 
 ```r
-artma::options.copy(
+artma::options_copy(
   options_file_name_from = "baseline.yaml",
   options_file_name_to = "sensitivity.yaml"
 )
@@ -500,7 +500,7 @@ artma::options.copy(
 Update an existing options file:
 
 ```r
-artma::options.modify(
+artma::options_modify(
   options_file_name = "my_analysis.yaml",
   options_to_modify = list(
     "methods.effect_summary_stats.conf_level" = 0.99,
@@ -514,7 +514,7 @@ artma::options.modify(
 Open an options file in your preferred editor:
 
 ```r
-artma::options.open("my_analysis.yaml")
+artma::options_open("my_analysis.yaml")
 ```
 
 ### Fixing Options Files
@@ -522,7 +522,7 @@ artma::options.open("my_analysis.yaml")
 If an options file has errors, fix it automatically:
 
 ```r
-artma::options.fix("my_analysis.yaml")
+artma::options_fix("my_analysis.yaml")
 ```
 
 This will:
@@ -543,10 +543,10 @@ This will:
 2. **"Invalid option value"**
    - Check that option values match expected types (character, numeric, logical)
    - For enum options, ensure the value is one of the allowed choices
-   - Validate the file: `artma::options.validate("file.yaml")`
+   - Validate the file: `artma::options_validate("file.yaml")`
 
 3. **"Missing required option"**
-   - Use `artma::options.fix()` to add missing options with defaults
+   - Use `artma::options_fix()` to add missing options with defaults
    - Or manually add the missing option to the YAML file
 
 4. **"Column not found in data"**
@@ -571,4 +571,4 @@ Remember:
 - Validate files before use
 - Keep options files in version control for reproducibility
 
-For more information on specific options, see the help documentation for individual functions or explore the options template using `artma::options.help()`, which prints the whole option tree when called without arguments.
+For more information on specific options, see the help documentation for individual functions or explore the options template using `artma::options_help()`, which prints the whole option tree when called without arguments.


### PR DESCRIPTION
Final API-rename PR (follows #437, #438, #440, #441, #442). Documentation sweep to the snake_case names:

- README and all four vignettes now show only snake_case calls (62 references).
- _pkgdown.yml gains a grouped reference index (Run an analysis, Options files, Data configuration, Autonomy, Results and reports, Visualization, CLI) with a Deprecated section for the alias topic; verified complete via pkgdown's reference index builder.
- CLAUDE.md autonomy section and contributingGuides/METHODS.md updated.
- Drive-by: the getting-started vignette showed artma::prepare_data(), which is not exported; the snippet now uses artma::data_preview(). (A separately spawned session may be fixing the same line; whichever lands second is a trivial rebase.)