### PR TITLE
docs: advertise the pkgdown site URL in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Description: Provides a unified and straightforward interface for
     Ideal for researchers aiming for efficiency and reproducibility, it
     streamlines workflows from data preparation to results interpretation.
 License: GPL-3
-URL: https://github.com/PetrCala/artma
+URL: https://github.com/PetrCala/artma,
+    https://petrcala.github.io/artma/
 BugReports: https://github.com/PetrCala/artma/issues
 Depends:
     R (>= 4.4.0)

--- a/man/artma-package.Rd
+++ b/man/artma-package.Rd
@@ -11,6 +11,7 @@ Provides a unified and straightforward interface for performing a variety of met
 Useful links:
 \itemize{
   \item \url{https://github.com/PetrCala/artma}
+  \item \url{https://petrcala.github.io/artma/}
   \item Report bugs at \url{https://github.com/PetrCala/artma/issues}
 }
 


### PR DESCRIPTION
pkgdown::check_pkgdown() failed because the site URL declared in _pkgdown.yml (https://petrcala.github.io/artma/) did not appear in DESCRIPTION's URL field, so downlit cross-linking and the CRAN landing page could not discover the docs site. Adds it alongside the GitHub URL; check_pkgdown() now reports no problems.