### PR TITLE
fix(output): drop zero counts from the run summary and winsorization notes

### DIFF
--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -46,8 +46,9 @@ remove_empty_rows <- function(df) {
   empty_rows <- all_required_na | all_critical_na
 
   if (any(empty_rows)) {
+    n_empty <- sum(empty_rows)
     df <- df[!empty_rows, , drop = FALSE]
-    cli::cli_alert_success("Removed {.val {sum(empty_rows)}} empty rows.")
+    cli::cli_alert_success("Removed {.val {n_empty}} empty row{?s}.")
   }
   df
 }
@@ -219,6 +220,20 @@ apply_subset_conditions <- function(df) {
   df
 }
 
+#' @title Describe which tail winsorization touched
+#' @description Name only the tails that had values pulled in, so a one-sided
+#'   winsorization does not report "0 lower".
+#' @param n_lower *\[integer\]* Values pulled up to the lower quantile.
+#' @param n_upper *\[integer\]* Values pulled down to the upper quantile.
+#' @return *\[character\]* One phrase per affected tail.
+#' @keywords internal
+winsorization_tails <- function(n_lower, n_upper) {
+  c(
+    if (n_lower > 0) cli::format_inline("{n_lower} lower"),
+    if (n_upper > 0) cli::format_inline("{n_upper} upper")
+  )
+}
+
 #' @title Winsorize data
 #' @description Winsorize effect and standard error columns at specified quantiles.
 #' @param df *\[data.frame\]* The data frame to winsorize
@@ -255,7 +270,8 @@ winsorize_data <- function(df) {
     df$effect <- pmax(pmin(df$effect, upper_q), lower_q)
 
     if (get_verbosity() >= 3 && (n_lower + n_upper) > 0) {
-      cli::cli_alert_info("Winsorized {.val {n_lower + n_upper}} effect values ({n_lower} lower, {n_upper} upper)")
+      tails <- winsorization_tails(n_lower, n_upper)
+      cli::cli_alert_info("Winsorized {.val {n_lower + n_upper}} effect value{?s} ({tails})")
     }
   }
 
@@ -270,7 +286,8 @@ winsorize_data <- function(df) {
     df$se <- pmax(pmin(df$se, upper_q), lower_q)
 
     if (get_verbosity() >= 3 && (n_lower + n_upper) > 0) {
-      cli::cli_alert_info("Winsorized {.val {n_lower + n_upper}} SE values ({n_lower} lower, {n_upper} upper)")
+      tails <- winsorization_tails(n_lower, n_upper)
+      cli::cli_alert_info("Winsorized {.val {n_lower + n_upper}} SE value{?s} ({tails})")
     }
   }
 

--- a/inst/artma/libs/core/string.R
+++ b/inst/artma/libs/core/string.R
@@ -30,6 +30,32 @@ pluralize <- function(word, count = NULL) {
 
   apply_plural(word)
 }
+#' @title Describe counts, leaving the zeros out
+#' @description Turn named counts into readable phrases: `c(table = 2, plot = 0)`
+#'   becomes `"2 tables"`. A count of zero is dropped rather than reported, so a
+#'   message never tells the reader about something that did not happen. The
+#'   result is a character vector, which `cli` collapses into "a, b and c" when
+#'   interpolated; an all-zero input yields an empty vector, which the caller
+#'   uses to pick a "nothing happened" wording instead.
+#' @param counts *\[numeric\]* Counts, named by the singular noun each belongs to.
+#' @return *\[character\]* One phrase per non-zero count, in the given order.
+count_phrases <- function(counts) {
+  counts <- unlist(counts)
+  if (length(counts) == 0) {
+    return(character())
+  }
+
+  validate(is.numeric(counts))
+  assert(!is.null(names(counts)), "`counts` must be named by the noun each count describes.")
+
+  counts <- counts[!is.na(counts) & counts > 0]
+  vapply(
+    seq_along(counts),
+    function(i) paste(counts[[i]], pluralize(names(counts)[[i]], counts[[i]])),
+    character(1)
+  )
+}
+
 #' @title Trim quotes
 #' @description Removes single or double quotes from the beggining and end of a string. Preserves these quotes elsewhere in the string.
 #' @param s *\[character\]* The string to trim quotes for.
@@ -51,6 +77,7 @@ make_verbose_name <- function(input_str) {
 }
 
 box::export(
+  count_phrases,
   make_verbose_name,
   pluralize,
   trim_quotes

--- a/inst/artma/output/run_summary.R
+++ b/inst/artma/output/run_summary.R
@@ -12,7 +12,8 @@
 #' `render_run_summary()`.
 
 box::use(
-  artma / libs / core / log[is_info_enabled]
+  artma / libs / core / log[is_info_enabled],
+  artma / libs / core / string[count_phrases]
 )
 
 #' @title Summarise a finished run
@@ -102,9 +103,21 @@ render_run_summary <- function(results, output_dir = NULL, run_files = character
   if (is.null(run$output_dir)) {
     cli::cli_alert_info("Results were not saved to disk.")
   } else {
-    cli::cli_alert_info(
-      "Wrote {run$tables} table{?s} and {run$graphics} plot{?s} to {.path {run$output_dir}}"
-    )
+    # Only the categories the run actually wrote are named; a run that wrote no
+    # plots says nothing about plots. `other` is counted too (the HTML report,
+    # widgets written outside the graphics directory), so "nothing was written"
+    # is only ever said when the run really wrote nothing.
+    written <- count_phrases(c(
+      table = run$tables,
+      plot = run$graphics,
+      "other file" = run$other
+    ))
+
+    if (length(written) == 0L) {
+      cli::cli_alert_info("Nothing was written to {.path {run$output_dir}}")
+    } else {
+      cli::cli_alert_info("Wrote {written} to {.path {run$output_dir}}")
+    }
   }
 
   invisible(run)

--- a/tests/testthat/test-libs-string.R
+++ b/tests/testthat/test-libs-string.R
@@ -1,0 +1,30 @@
+box::use(
+  testthat[expect_equal, expect_error, test_that],
+  artma / libs / core / string[count_phrases]
+)
+
+test_that("count_phrases pluralizes each count and keeps the given order", {
+  expect_equal(
+    count_phrases(c(table = 2, plot = 1)),
+    c("2 tables", "1 plot")
+  )
+})
+
+test_that("count_phrases drops the zeros", {
+  expect_equal(count_phrases(c(table = 2, plot = 0)), "2 tables")
+  expect_equal(count_phrases(c(table = 0, plot = 0)), character())
+})
+
+test_that("count_phrases handles multi-word nouns and missing counts", {
+  expect_equal(count_phrases(c("other file" = 3)), "3 other files")
+  expect_equal(count_phrases(c(table = NA_integer_, plot = 1)), "1 plot")
+})
+
+test_that("count_phrases returns nothing for an empty input", {
+  expect_equal(count_phrases(integer()), character())
+  expect_equal(count_phrases(list()), character())
+})
+
+test_that("count_phrases rejects unnamed counts", {
+  expect_error(count_phrases(c(1, 2)), "named")
+})

--- a/tests/testthat/test-run-summary.R
+++ b/tests/testthat/test-run-summary.R
@@ -111,6 +111,28 @@ test_that("render_run_summary names the skipped and failed methods with their re
 test_that("render_run_summary reports the file counts and the output directory", {
   out <- local_tempdir()
   dir.create(file.path(out, "tables"))
+  dir.create(file.path(out, "graphics"))
+  local_options(artma.verbose = 3, cli.width = 400, artma.visualization.export_path = "graphics")
+
+  msgs <- paste(
+    testthat::capture_messages(render_run_summary(
+      make_results(output_files = list(funnel_plot = file.path(out, "graphics", "funnel_plot.png"))),
+      output_dir = out,
+      run_files = c(
+        file.path(out, "tables", "funnel_plot.csv"),
+        file.path(out, "tables", "linear_tests.csv")
+      )
+    )),
+    collapse = ""
+  )
+
+  expect_true(grepl("Wrote 2 tables and 1 plot to", msgs, fixed = TRUE))
+  expect_true(grepl(basename(out), msgs, fixed = TRUE))
+})
+
+test_that("render_run_summary leaves out the categories the run did not write", {
+  out <- local_tempdir()
+  dir.create(file.path(out, "tables"))
   local_options(artma.verbose = 3, cli.width = 400)
 
   msgs <- paste(
@@ -122,8 +144,39 @@ test_that("render_run_summary reports the file counts and the output directory",
     collapse = ""
   )
 
-  expect_true(grepl("Wrote 1 table and 0 plots", msgs, fixed = TRUE))
-  expect_true(grepl(basename(out), msgs, fixed = TRUE))
+  written_line <- grep("Wrote", strsplit(msgs, "\n", fixed = TRUE)[[1]], value = TRUE)
+
+  expect_true(grepl("Wrote 1 table to", written_line, fixed = TRUE))
+  expect_false(grepl("plot", written_line, fixed = TRUE))
+})
+
+test_that("render_run_summary counts files outside the tables and graphics directories", {
+  out <- local_tempdir()
+  local_options(artma.verbose = 3, cli.width = 400)
+
+  msgs <- paste(
+    testthat::capture_messages(render_run_summary(
+      make_results(),
+      output_dir = out,
+      run_files = file.path(out, "report.html")
+    )),
+    collapse = ""
+  )
+
+  expect_true(grepl("Wrote 1 other file to", msgs, fixed = TRUE))
+})
+
+test_that("render_run_summary says nothing was written when the run wrote no files", {
+  out <- local_tempdir()
+  local_options(artma.verbose = 3, cli.width = 400)
+
+  msgs <- paste(
+    testthat::capture_messages(render_run_summary(make_results(), output_dir = out)),
+    collapse = ""
+  )
+
+  expect_true(grepl("Nothing was written to", msgs, fixed = TRUE))
+  expect_false(grepl("Wrote", msgs, fixed = TRUE))
 })
 
 test_that("render_run_summary stays silent below info verbosity", {


### PR DESCRIPTION
## What

The closing run summary reported categories the run never wrote:

```
i Wrote 2 tables and 0 plots to /tmp/.../artma-results
```

Now only the non-empty categories are named, and a run that wrote nothing says so:

```
i Wrote 2 tables to '/tmp/.../artma-results'
i Wrote 2 tables and 1 plot to '/tmp/.../artma-results'
i Nothing was written to '/tmp/.../artma-results'
```

Files that land outside `tables/` and the graphics directory (the HTML report, standalone widgets) are counted as `other file{s}` rather than ignored, so "Nothing was written" is only ever printed when the run really wrote nothing.

## How

- New `count_phrases()` in `artma/libs/core/string`: takes counts named by their singular noun, drops the zeros, pluralizes the rest. `cli` collapses the returned vector into "a, b and c" on interpolation, and an empty result is the caller's signal to pick the "nothing happened" wording.
- `render_run_summary()` builds its file line from it.

## Other places with the same problem

- Winsorization printed `Winsorized 3 effect values (0 lower, 3 upper)`; it now names only the tail it touched: `Winsorized 3 effect values (3 upper)`. Both value counts also pluralize properly now.
- `Removed 1 empty rows.` -> `Removed 1 empty row.`

Everything else that prints a count in the package is already guarded by a `> 0` check, so nothing else changed.

## Testing

- `make lint`, `make test` (3508 passing, 1 pre-existing OpenMP skip)
- New `tests/testthat/test-libs-string.R` for `count_phrases()`, plus run-summary cases for the tables-only, other-files-only, and nothing-written wordings.