### PR TITLE
fix(data): use legible study names for study_label when study keys are numeric

### DIFF
--- a/inst/artma/data/compute.R
+++ b/inst/artma/data/compute.R
@@ -32,14 +32,123 @@ add_obs_id_column <- function(df) {
   df
 }
 
+#' @title Check whether label values are human-legible
+#' @description Study labels count as legible when they are mostly non-numeric
+#'   text ("Smith (2009)"), mirroring the value heuristics of
+#'   \code{is_likely_study_key}.
+#' @param labels *\[character\]* Candidate label values.
+#' @return *\[logical\]* TRUE if the values read as human-legible labels.
+#' @keywords internal
+is_legible_label_vector <- function(labels) {
+  labels <- trimws(as.character(labels))
+  labels <- labels[!is.na(labels) & nzchar(labels)]
+
+  if (length(labels) == 0) {
+    return(FALSE)
+  }
+
+  numeric_like_ratio <- mean(grepl("^[-+]?[0-9]+(\\.[0-9]+)?$", labels))
+  if (numeric_like_ratio > 0.8) {
+    return(FALSE)
+  }
+
+  mean(grepl("[A-Za-z]", labels)) >= 0.6
+}
+
+
+#' @title Check that labels group rows exactly like study IDs
+#' @description A label column can stand in for the study key only when the
+#'   mapping is one-to-one: every study ID carries a single label and no two
+#'   studies share one.
+#' @param labels *\[character\]* Candidate label values, one per row.
+#' @param study_ids *\[integer\]* Normalized study IDs, one per row.
+#' @return *\[logical\]* TRUE if labels and IDs induce the same grouping.
+#' @keywords internal
+labels_align_with_study_ids <- function(labels, study_ids) {
+  if (any(is.na(labels) | !nzchar(labels)) || any(is.na(study_ids))) {
+    return(FALSE)
+  }
+
+  n_ids <- length(unique(study_ids))
+  n_labels <- length(unique(labels))
+  n_pairs <- length(unique(paste(study_ids, labels, sep = "\r")))
+
+  n_pairs == n_ids && n_labels == n_ids
+}
+
+
+#' @title Find a human-legible source column for study labels
+#' @description When the study key column holds numeric IDs, the frame often
+#'   still carries the citation-style study names under another column
+#'   ("study", "author", ...). Returns the best such column: it must look like
+#'   study labels, group rows exactly like the study IDs, and carry a
+#'   study-name-like column name (an existing \code{study_label} column always
+#'   qualifies). NULL when the current labels are already legible or no
+#'   suitable column exists.
+#' @param df *\[data.frame\]* The data frame.
+#' @param study_ids *\[integer\]* Normalized study IDs, one per row.
+#' @param current_labels *\[character\]* Labels derived from the study key.
+#' @return *\[character\]* Column name, or NULL.
+#' @keywords internal
+find_study_label_source <- function(df, study_ids, current_labels) {
+  box::use(
+    artma / data / column_recognition[MATCH_THRESHOLDS, get_column_patterns, match_column_name],
+    artma / data / utils[get_reserved_colnames]
+  )
+
+  if (is_legible_label_vector(current_labels)) {
+    return(NULL)
+  }
+
+  candidates <- setdiff(names(df), setdiff(get_reserved_colnames(), "study_label"))
+  if (length(candidates) == 0) {
+    return(NULL)
+  }
+
+  study_patterns <- get_column_patterns()["study_id"]
+
+  scores <- vapply(candidates, function(col) {
+    values <- df[[col]]
+    if (!(is.character(values) || is.factor(values))) {
+      return(NA_real_)
+    }
+    labels <- trimws(as.character(values))
+    if (!is_legible_label_vector(labels)) {
+      return(NA_real_)
+    }
+    if (!labels_align_with_study_ids(labels, study_ids)) {
+      return(NA_real_)
+    }
+    if (identical(col, "study_label")) {
+      # A user-provided study_label column beats any name-matched candidate
+      return(2)
+    }
+    match <- match_column_name(col, study_patterns)
+    if (identical(match$match, "study_id") && match$score >= MATCH_THRESHOLDS$optional_confidence) {
+      match$score
+    } else {
+      NA_real_
+    }
+  }, numeric(1))
+
+  if (all(is.na(scores))) {
+    return(NULL)
+  }
+
+  candidates[which.max(scores)]
+}
+
+
 #' @title Add study ID column
 #' @description Add or normalize the study ID column. Uses the existing
 #'   \code{study_id} column (character or integer), preserves its original
 #'   labels in \code{study_label}, and overwrites \code{study_id} with
-#'   integer IDs derived from factorizing its values.
+#'   integer IDs derived from factorizing its values. When the study key is
+#'   numeric and another column carries human-legible study names that group
+#'   rows the same way, \code{study_label} is taken from that column instead.
 #' @param df *\[data.frame\]* The data frame with a \code{study_id} column.
 #' @return *\[data.frame\]* The data frame with \code{study_id} as integer IDs
-#'   and \code{study_label} as the original study key values.
+#'   and \code{study_label} as the study label values.
 #' @keywords internal
 add_study_id_column <- function(df) {
   box::use(artma / libs / core / utils[get_verbosity])
@@ -53,16 +162,29 @@ add_study_id_column <- function(df) {
   valid_ids <- as.integer(factor(study_src, levels = unique(study_src)))
 
   study_labels <- as.character(study_src)
+  label_source <- "the original study keys"
+
+  label_col <- find_study_label_source(df, valid_ids, study_labels)
+  if (!is.null(label_col)) {
+    study_labels <- as.character(df[[label_col]])
+    label_source <- sprintf("the column '%s'", label_col)
+    if (get_verbosity() >= 3 && !identical(label_col, "study_label")) {
+      cli::cli_alert_info(
+        "The study keys are numeric; using {.field {label_col}} for {.field study_label} instead."
+      )
+    }
+  }
+
   if (!"study_label" %in% colnames(df)) {
     df$study_label <- study_labels
     if (get_verbosity() >= 4) {
-      cli::cli_inform("Created {.field study_label} column from original study keys")
+      cli::cli_inform("Created {.field study_label} column from {label_source}")
     }
   } else if (!identical(as.character(df$study_label), study_labels)) {
     if (get_verbosity() >= 2) {
       cli::cli_alert_warning(c(
-        "!" = "Existing {.val study_label} values differ from the source {.val study_id} column.",
-        "i" = "Overwriting {.val study_label} with the original study keys."
+        "!" = "Existing {.val study_label} values differ from {label_source}.",
+        "i" = "Overwriting {.val study_label}."
       ))
     }
     df$study_label <- study_labels

--- a/tests/testthat/test-data-compute.R
+++ b/tests/testthat/test-data-compute.R
@@ -75,6 +75,84 @@ test_that("compute_optional_columns overwrites conflicting existing study_label"
 })
 
 
+test_that("compute_optional_columns takes study_label from a legible study name column when study keys are numeric", {
+  df <- data.frame(
+    study_id = c(1L, 2L, 1L, 3L),
+    study = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)", "Clark (2010)"),
+    effect = c(0.2, 0.5, 0.1, 0.3),
+    se = c(0.1, 0.2, 0.1, 0.2),
+    n_obs = c(120, 150, 120, 130),
+    stringsAsFactors = FALSE
+  )
+  local_compute_options()
+
+  result <- compute_optional_columns(df)
+
+  expect_equal(
+    result$study_label,
+    c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)", "Clark (2010)")
+  )
+  expect_equal(result$study_id, c(1L, 2L, 1L, 3L))
+})
+
+
+test_that("compute_optional_columns keeps numeric study labels when the name column does not align with study ids", {
+  df <- data.frame(
+    study_id = c(1L, 1L, 2L),
+    # Two different names within study 1: not a usable study label source
+    study = c("Albeigh (2008)", "Albeigh (2009)", "Baker (2009)"),
+    effect = c(0.2, 0.5, 0.1),
+    se = c(0.1, 0.2, 0.1),
+    n_obs = c(120, 150, 120),
+    stringsAsFactors = FALSE
+  )
+  local_compute_options()
+
+  result <- compute_optional_columns(df)
+
+  expect_equal(result$study_label, c("1", "1", "2"))
+})
+
+
+test_that("compute_optional_columns ignores legible columns whose names do not look like study names", {
+  df <- data.frame(
+    study_id = c(1L, 2L, 3L),
+    grp_reward = c("cash (low)", "voucher (mid)", "praise (high)"),
+    effect = c(0.2, 0.5, 0.1),
+    se = c(0.1, 0.2, 0.1),
+    n_obs = c(120, 150, 120),
+    stringsAsFactors = FALSE
+  )
+  local_compute_options()
+
+  result <- compute_optional_columns(df)
+
+  expect_equal(result$study_label, c("1", "2", "3"))
+})
+
+
+test_that("compute_optional_columns preserves a user-supplied legible study_label over numeric keys", {
+  df <- data.frame(
+    study_id = c(1L, 2L, 1L),
+    study_label = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)"),
+    effect = c(0.2, 0.5, 0.1),
+    se = c(0.1, 0.2, 0.1),
+    n_obs = c(120, 150, 120),
+    stringsAsFactors = FALSE
+  )
+  local_compute_options()
+  withr::local_options(list("artma.verbose" = 2))
+
+  result <- NULL
+  expect_no_message(result <- compute_optional_columns(df))
+
+  expect_equal(
+    result$study_label,
+    c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)")
+  )
+})
+
+
 test_that("compute_optional_columns recomputes a user-supplied precision column when winsorization is active", {
   df <- data.frame(
     study_id = c("Albeigh (2008)", "Baker (2009)", "Albeigh (2008)"),


### PR DESCRIPTION
## Summary

For the bachelor-thesis dataset the box plot showed integer y-axis labels even though the data file carries citation-style study names. The raw file maps an integer column to `study_id`, and `study_label` was always derived from those keys, so the labels came out as "1", "2", ... while the legible `study` column sat unused in the frame.

`add_study_id_column()` now checks whether the study keys are human-legible. When they are numeric, it searches the frame for a column that:

- holds legible, citation-like text (letters, not numeric strings),
- groups rows exactly one-to-one with the normalized study IDs,
- carries a study-name-like column name (`study`, `study_name`, `author`, ...; matched through the existing column-recognition patterns with the strict optional-column threshold), or is a user-supplied `study_label` column, which always wins.

If such a column exists, `study_label` is taken from it and an info message says so. Otherwise behavior is unchanged. A side effect worth noting: a user-supplied legible `study_label` that groups consistently with numeric keys is now preserved instead of being overwritten with the numeric keys.

Verified on `data_set_bachelor_thesis_cala_corrected.xlsx`: the pipeline now picks `study` ("Charness and Gneezy (2009)", ...) for `study_label`, which the box plot already prefers for its axis.

## Tests

- new unit tests: legible name column adopted; misaligned name column rejected; non-study-named legible column rejected; user-supplied `study_label` preserved without warnings
- `make lint` and `make test` pass (3501 tests, 0 failures)