### PR TITLE
fix: unhang a standalone best_practice_estimate run

### DIFF
--- a/inst/artma/methods/best_practice_estimate.R
+++ b/inst/artma/methods/best_practice_estimate.R
@@ -416,8 +416,21 @@ bpe_estimates <- function(rows, n_clusters = NA_integer_) {
   ))
 }
 
-resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
+#' @title Resolve the BMA bundle the best-practice estimate needs
+#' @param df *\[data.frame\]* The prepared data frame.
+#' @param bma_result *\[list, optional\]* An upstream `bma()` result, or `NULL`
+#'   when the method was run without one.
+#' @param run_bma_if_missing *\[logical\]* Whether BMA may be computed on demand.
+#' @param is_interactive *\[logical, optional\]* Whether the session is
+#'   interactive. Injectable for testing; defaults to `interactive()`.
+#' @param prompt_fn *\[function, optional\]* The confirmation prompt. Injectable
+#'   for testing; defaults to `prompt_run_bma_for_bpe()`.
+#' @return *\[list\]* `list(model=, data=, var_list=, params=, formula=, source=)`.
+resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing,
+                                      is_interactive = interactive(),
+                                      prompt_fn = prompt_run_bma_for_bpe) {
   box::use(
+    artma / libs / core / autonomy[should_prompt_user],
     artma / libs / core / utils[get_verbosity],
     artma / libs / core / validation[assert, validate],
     artma / methods / bma[bma, unwrap_bma_result]
@@ -426,7 +439,10 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
   validate(
     is.data.frame(df),
     is.logical(run_bma_if_missing),
-    length(run_bma_if_missing) == 1
+    length(run_bma_if_missing) == 1,
+    is.logical(is_interactive),
+    length(is_interactive) == 1,
+    is.function(prompt_fn)
   )
 
   normalized <- unwrap_bma_result(bma_result)
@@ -440,9 +456,15 @@ resolve_bma_input_for_bpe <- function(df, bma_result, run_bma_if_missing) {
     cli::cli_abort("Best-practice estimate requires a BMA result and run_bma_if_missing is FALSE.")
   }
 
+  # `run_bma_if_missing` already records that BMA may run on demand, so this is
+  # a confirmation rather than a genuine choice: only the most talkative
+  # autonomy level is asked. Gating on `interactive()` alone left every
+  # autonomy level facing a prompt, and a method's output is captured while it
+  # runs, so the menu rendered into the capture buffer and the run hung on a
+  # keypress the user could not see.
   should_run_bma <- TRUE
-  if (interactive()) {
-    should_run_bma <- prompt_run_bma_for_bpe()
+  if (should_prompt_user(required_level = "balanced", is_interactive = is_interactive)) {
+    should_run_bma <- prompt_fn()
   }
 
   if (!isTRUE(should_run_bma)) {

--- a/inst/artma/methods/bma.R
+++ b/inst/artma/methods/bma.R
@@ -301,6 +301,26 @@ prepare_bma_inputs <- function(df, config, use_vif_optimization, max_groups_to_r
     bma_vars <- bma_vars[bma_vars %in% names(df)]
   }
 
+  # BMA regresses on a numeric design matrix throughout: `get_bma_data()`
+  # z-scores each non-binary column and `run_bma()` asserts every column is
+  # numeric. A character or factor moderator therefore aborts the run, and it
+  # does so from inside `scale()` with a bare "'x' must be numeric" that names
+  # no column. Drop them here instead, where the offender can be named.
+  non_numeric_vars <- bma_vars[vapply(bma_vars, function(v) {
+    !is.numeric(df[[v]]) && !is.logical(df[[v]])
+  }, logical(1))]
+  if (length(non_numeric_vars)) {
+    if (verbosity >= 2) {
+      cli::cli_alert_warning(
+        "Excluding {length(non_numeric_vars)} non-numeric variable{?s} from the BMA moderator set: {.val {non_numeric_vars}}"
+      )
+      cli::cli_inform(
+        "BMA needs numeric moderators. Encode {cli::qty(length(non_numeric_vars))}{?this/these} column{?s} as dummies, or set {.code bma: false} on {?it/them} in the data config."
+      )
+    }
+    bma_vars <- setdiff(bma_vars, non_numeric_vars)
+  }
+
   # Constant columns carry no moderator information, and scaling one yields an
   # all-NaN column that na.omit would then use to drop every observation.
   constant_vars <- bma_vars[vapply(bma_vars, function(v) {

--- a/inst/artma/modules/method_execution.R
+++ b/inst/artma/modules/method_execution.R
@@ -8,8 +8,12 @@
 #
 # Two properties are preserved regardless of how many workers are used:
 #
-#   * CLI output is captured per method and replayed in discovery order after
-#     the layer joins, so forked output never interleaves.
+#   * Output reaches the console in discovery order. Forked methods have their
+#     CLI output captured and replayed after the layer joins, so concurrent
+#     output never interleaves; a sequential layer is already in order and
+#     writes straight to the console. That distinction matters: a sunk method
+#     cannot prompt, because the menu renders into the capture buffer while the
+#     method blocks on a keypress nobody can see.
 #   * Each method runs on a pre-assigned L'Ecuyer-CMRG stream, so a run is
 #     reproducible given the seed whether it executed in parallel or not.
 
@@ -304,6 +308,30 @@ with_captured_output <- function(expr) {
   list(value = result$value, error = result$error, output = captured %||% character())
 }
 
+#' @title Evaluate an expression, trapping errors but leaving output alone
+#' @description
+#' The sequential counterpart of `with_captured_output()`: the same
+#' `list(value, error, output)` shape, but nothing is sunk, so whatever `expr`
+#' prints goes straight to the console and a method that prompts stays visible
+#' and answerable. `output` is always empty, since the console has already seen
+#' it; the caller's replay step is then a no-op.
+#'
+#' Warnings are left to signal normally rather than being folded into the
+#' output text. In the parent process they surface where R would put them
+#' anyway, which is not true of a forked worker.
+#' @param expr *\[any\]* The expression to evaluate. Errors are caught, not
+#'   propagated.
+#' @return *\[list\]* A list with `value`, `error` (a message or `NULL`), and an
+#'   empty `output`.
+without_captured_output <- function(expr) {
+  result <- tryCatch(
+    list(value = expr, error = NULL),
+    error = function(err) list(value = NULL, error = conditionMessage(err))
+  )
+
+  list(value = result$value, error = result$error, output = character())
+}
+
 #' @title Replay captured CLI output
 #' @description Write previously captured lines to the console verbatim,
 #'   preserving any ANSI formatting they carry.
@@ -365,13 +393,22 @@ describe_dead_worker <- function(outcome, method_name) {
 #'   sequentially in the current process.
 #' @return *\[list\]* One `list(value, error, output, files)` per method, in
 #'   input order. `files` holds the paths the method wrote, which is the only
-#'   way the parent learns about them when the method ran in a fork.
+#'   way the parent learns about them when the method ran in a fork. `output`
+#'   is empty for a sequential layer, whose output has already reached the
+#'   console.
 execute_method_layer <- function(method_names, run_one, streams = list(), workers = 1L) {
   assert(is.function(run_one), "`run_one` must be a function.")
   method_names <- as.character(method_names)
   if (length(method_names) == 0L) {
     return(list())
   }
+
+  # Capturing exists to keep concurrent output from interleaving, so a
+  # sequential layer skips it: it is already in order, and sinking it would
+  # make any prompt the method raises invisible and unanswerable.
+  # `resolve_worker_count()` never returns more than one worker for a session
+  # whose autonomy level still lets methods prompt, so the two line up.
+  run_captured <- workers > 1L
 
   run_task <- function(method_name) {
     stream <- streams[[method_name]]
@@ -383,7 +420,11 @@ execute_method_layer <- function(method_names, run_one, streams = list(), worker
     # with the child, so the paths have to travel back in the return value.
     capture_id <- begin_output_file_capture()
     on.exit(end_output_file_capture(capture_id), add = TRUE)
-    outcome <- with_captured_output(run_one(method_name))
+    outcome <- if (run_captured) {
+      with_captured_output(run_one(method_name))
+    } else {
+      without_captured_output(run_one(method_name))
+    }
     outcome$files <- end_output_file_capture(capture_id)
     outcome
   }
@@ -436,5 +477,6 @@ box::export(
   method_stream_seed,
   replay_captured_output,
   resolve_worker_count,
-  with_captured_output
+  with_captured_output,
+  without_captured_output
 )

--- a/tests/testthat/test-bma-result-unwrap.R
+++ b/tests/testthat/test-bma-result-unwrap.R
@@ -226,6 +226,48 @@ test_that("fma skips gracefully instead of crashing when only one moderator is a
   expect_match(result$meta$skip_reason, "at least 2 candidate moderator variables")
 })
 
+test_that("the 'run BMA first?' confirmation respects the autonomy level", {
+  # Gating this prompt on interactive() alone asked every autonomy level, and
+  # a method's output is captured while it runs, so the menu was invisible and
+  # the run hung on a keypress the user could not see.
+  asked <- character()
+  # Declining keeps the test off the BMS code path once the prompt has fired.
+  spy <- function() {
+    asked <<- c(asked, "asked")
+    FALSE
+  }
+
+  config <- list(
+    effect = list(var_name = "effect", var_name_verbose = "Effect", bma = FALSE),
+    se = list(var_name = "se", var_name_verbose = "SE", bma = TRUE)
+  )
+
+  ask_count <- function(level) {
+    local_options(list(
+      artma.verbose = 0,
+      artma.autonomy.level = level,
+      artma.data.columns = config
+    ))
+    asked <<- character()
+    # Errors either way: declined at `ask_more`, and at the quieter levels the
+    # single-moderator frame makes BMA itself skip. Only the prompt is under test.
+    expect_error(resolve_bma_input_for_bpe(
+      df = make_single_moderator_df(),
+      bma_result = NULL,
+      run_bma_if_missing = TRUE,
+      is_interactive = TRUE,
+      prompt_fn = spy
+    ))
+    length(asked)
+  }
+
+  # `run_bma_if_missing = TRUE` already authorises the run, so only the most
+  # talkative level is asked to confirm it.
+  expect_equal(ask_count("ask_more"), 1L)
+  expect_equal(ask_count("balanced"), 0L)
+  expect_equal(ask_count("autonomous"), 0L)
+})
+
 test_that("resolve_bma_input_for_bpe surfaces the BMA skip reason when BMA cannot run", {
   df <- make_single_moderator_df()
   config <- list(

--- a/tests/testthat/test-bma.R
+++ b/tests/testthat/test-bma.R
@@ -567,6 +567,54 @@ test_that("rename_bma_model leaves unmatched regressor names untouched", {
   expect_equal(renamed$reg.names, c("Moderator 1", "not_in_list"))
 })
 
+test_that("prepare_bma_inputs drops non-numeric moderators instead of dying inside scale()", {
+  local_options(list("artma.verbose" = 1))
+
+  # A character moderator used to reach `scale()`, which aborts with a bare
+  # "'x' must be numeric" naming no column.
+  df <- make_demo_bma_data()
+  df$reg_num <- sample(c("a", "b", "c"), nrow(df), replace = TRUE)
+  config <- list(
+    moderator1 = list(var_name = "moderator1", bma = TRUE),
+    moderator2 = list(var_name = "moderator2", bma = TRUE),
+    reg_num = list(var_name = "reg_num", bma = TRUE)
+  )
+
+  expect_message(
+    prepared <- prepare_bma_inputs(
+      df, config,
+      use_vif_optimization = FALSE,
+      max_groups_to_remove = 3,
+      verbosity = 2
+    ),
+    "reg_num"
+  )
+
+  expect_null(prepared$skipped)
+  expect_false("reg_num" %in% colnames(prepared$bma_data))
+  expect_true(all(vapply(prepared$bma_data, is.numeric, logical(1))))
+})
+
+test_that("prepare_bma_inputs keeps logical moderators, which scale() handles", {
+  local_options(list("artma.verbose" = 1))
+
+  df <- make_demo_bma_data()
+  df$flag_mod <- rep(c(TRUE, FALSE), length.out = nrow(df))
+  config <- list(
+    moderator1 = list(var_name = "moderator1", bma = TRUE),
+    flag_mod = list(var_name = "flag_mod", bma = TRUE)
+  )
+
+  prepared <- prepare_bma_inputs(
+    df, config,
+    use_vif_optimization = FALSE,
+    max_groups_to_remove = 3,
+    verbosity = 0
+  )
+
+  expect_true("flag_mod" %in% colnames(prepared$bma_data))
+})
+
 test_that("prepare_bma_inputs warns about the excluded constant moderator", {
   local_options(list("artma.verbose" = 1))
 

--- a/tests/testthat/test-method-execution.R
+++ b/tests/testthat/test-method-execution.R
@@ -6,6 +6,7 @@ box::use(
     expect_length,
     expect_match,
     expect_null,
+    expect_output,
     expect_true,
     skip_if,
     skip_if_not_installed,
@@ -157,6 +158,47 @@ test_that("resolve_worker_count respects the environment's process ceiling", {
     ),
     3L
   )
+})
+
+test_that("without_captured_output lets output through and still traps errors", {
+  box::use(artma / modules / method_execution[without_captured_output])
+
+  expect_output(
+    outcome <- without_captured_output({
+      cat("to stdout\n")
+      "value"
+    }),
+    "to stdout"
+  )
+  expect_equal(outcome$value, "value")
+  expect_null(outcome$error)
+  expect_equal(outcome$output, character())
+
+  failed <- without_captured_output(stop("boom"))
+  expect_null(failed$value)
+  expect_match(failed$error, "boom")
+})
+
+test_that("a sequential layer leaves output on the console so prompts stay visible", {
+  box::use(artma / modules / method_execution[execute_method_layer])
+
+  # A method that prompts renders its menu with cat()/cli. Sinking that output
+  # hid the menu while the method blocked on a keypress, hanging the run.
+  expect_output(
+    outcomes <- execute_method_layer(
+      "asks",
+      run_one = function(name) {
+        cat("Do you want to run BMA first?\n")
+        name
+      },
+      workers = 1L
+    ),
+    "Do you want to run BMA first?",
+    fixed = TRUE
+  )
+
+  expect_equal(outcomes[[1L]]$value, "asks")
+  expect_equal(outcomes[[1L]]$output, character())
 })
 
 test_that("with_captured_output captures output instead of printing it", {


### PR DESCRIPTION
Running `best_practice_estimate` on its own hung indefinitely at `• Running the best_practice_estimate method...`, with no further output.

## Cause

Three things stacked up.

**1. The BMA confirmation prompt ignored the autonomy level.** `resolve_bma_input_for_bpe()` gated its "Do you want to run BMA first?" menu on `interactive()` alone, so it fired at every autonomy level, including `autonomous`. Every other prompt in the package routes through `should_prompt_user()`.

**2. A prompting method cannot be seen.** `execute_method_layer()` ran every method inside `with_captured_output()`, which sinks stdout and traps messages so concurrent output does not interleave. `climenu::select()` draws with `cat()` and `cli::cli_text()`, so the menu rendered into the capture buffer while the method blocked on a keypress nobody could see. Capture only exists for forked workers, and `resolve_worker_count()` already returns a single worker for any session whose autonomy level still lets methods prompt, so the two never needed to overlap.

**3. Answering the prompt just moved the failure.** With the hang out of the way, `bachelor.yaml` then aborted with a bare `'x' must be numeric` from inside `scale()`: the config marks the character column `reg_num` as a BMA moderator, and nothing named the offending column.

## Changes

- `prompt_run_bma_for_bpe()` is now gated on `should_prompt_user(required_level = "balanced")`. `run_bma_if_missing = TRUE` already authorises the run, so this is a confirmation rather than a choice and only `ask_more` is asked. `resolve_bma_input_for_bpe()` gains injectable `is_interactive` and `prompt_fn` arguments so the gate is testable.
- `execute_method_layer()` captures output only when `workers > 1`. A sequential layer writes straight to the console, in order, and stays answerable. New `without_captured_output()` keeps the error trapping and file recording that the capture path provides.
- `prepare_bma_inputs()` drops non-numeric moderators alongside the existing constant-variable exclusion, naming them and pointing at `bma: false` or dummy encoding. Logical columns are kept, since `scale()` handles them.

## Verification

`best_practice_estimate` alone on `bachelor.yaml` now completes in 8.3s and writes all three tables, where it previously hung. Full suite: 3515 passing, 0 failures, 1 pre-existing OpenMP skip. `make lint` clean.