### PR TITLE
fix(exogeneity): default the IV instrument to 1/sqrt(n_obs)

### DIFF
--- a/inst/artma/econometric/exogeneity.R
+++ b/inst/artma/econometric/exogeneity.R
@@ -101,7 +101,17 @@ WEAK_INSTRUMENT_TIEBREAK <- "1/sqrt(n_obs)"
 #' Ranks candidate instruments by first-stage strength: the "Weak
 #' instruments" F-statistic reported by `AER::ivreg`'s diagnostics, which is
 #' the standard weak-instruments diagnostic for a single endogenous
-#' regressor. R-squared, Wu-Hausman, and Sargan are deliberately not used
+#' regressor.
+#'
+#' This is reachable only via `iv_instrument = "automatic"` and is not the
+#' default, because ranking instruments on the same data used for inference is
+#' a specification search: it favors whichever instrument happens to look
+#' strongest in sample and leaves the reported standard errors ignorant of the
+#' selection step. The default, `1/sqrt(n_obs)`, is fixed a priori on the
+#' grounds that an estimator's standard error scales with `1/sqrt(N)`, and is
+#' what the applied literature uses.
+#'
+#' R-squared, Wu-Hausman, and Sargan are deliberately not used
 #' for selection: IV R-squared is unbounded below and has no
 #' instrument-quality interpretation; Wu-Hausman measures how strongly the
 #' data reject exogeneity, a property of the data rather than the
@@ -177,13 +187,17 @@ find_best_instrument <- function(df, instruments, instruments_verbose) {
 #' @title Run IV regression with specified or automatic instrument
 #' @description
 #' Performs IV regression of effect on se using an instrumental variable.
-#' Can automatically select the best instrument from a predefined set.
+#' Defaults to `1/sqrt(n_obs)`, the instrument the applied literature uses and
+#' the one motivated by the estimator's standard error scaling with `1/sqrt(N)`.
+#' Can instead select from a predefined set by first-stage strength, which is an
+#' exploratory option rather than a sound default (see `find_best_instrument()`).
 #' @param df *[data.frame]* Data frame with columns: effect, se, study_id, n_obs.
-#' @param iv_instrument *[character]* Instrument specification or "automatic" for auto-selection.
+#' @param iv_instrument *[character]* Instrument specification, or "automatic" to
+#'   select by first-stage strength.
 #' @param add_significance_marks *[logical]* Whether to add significance asterisks.
 #' @param round_to *[integer]* Number of decimal places for rounding.
 #' @return *[list]* Contains coefficients, instrument name, and Anderson-Rubin F-statistic.
-run_iv_regression <- function(df, iv_instrument = "automatic", add_significance_marks = TRUE, round_to = 3L) {
+run_iv_regression <- function(df, iv_instrument = "1/sqrt(n_obs)", add_significance_marks = TRUE, round_to = 3L) {
   validate(
     is.data.frame(df),
     is.character(iv_instrument),

--- a/inst/artma/methods/exogeneity_tests.R
+++ b/inst/artma/methods/exogeneity_tests.R
@@ -23,7 +23,7 @@ exogeneity_tests <- function(df) {
   resolved_options <- c(
     list(add_significance_marks = resolve_add_significance_marks()),
     resolve_options(opt, list(
-      iv_instrument = opt_spec(default = "automatic", type = "character"),
+      iv_instrument = opt_spec(default = "1/sqrt(n_obs)", type = "character"),
       puniform_alpha = opt_spec(
         default = 0.05, type = "numeric",
         constraint = function(x) x > 0 && x < 1,

--- a/inst/artma/options/templates/options_template.yaml
+++ b/inst/artma/options/templates/options_template.yaml
@@ -210,16 +210,27 @@ methods:
   exogeneity_tests:
     iv_instrument:
       type: "enum: automatic|1/sqrt(n_obs)|1/n_obs|1/n_obs^2|log(n_obs)"
-      default: "automatic"
+      default: "1/sqrt(n_obs)"
       help: |
         Instrument to use for the instrumental variable (IV) regression.
-        Use {.strong automatic} to rank candidates by first-stage F-statistic
-        (the weak-instruments diagnostic) and pick the strongest, breaking
-        ties in favor of {.strong 1/sqrt(n_obs)}, the theoretically motivated
-        instrument. A warning is printed if the selected instrument's
-        first-stage F falls below the conventional weak-instrument threshold
-        of 10. Alternatively, specify a specific instrument formula involving
-        n_obs.
+        Defaults to {.strong 1/sqrt(n_obs)}, the theoretically motivated
+        instrument: the standard error of an estimator scales with 1/sqrt(N),
+        so sample size predicts reported precision without being a channel for
+        selective reporting. It is also the instrument used throughout the
+        applied literature, which keeps results comparable with published
+        meta-analyses.
+
+        {.strong automatic} instead ranks the candidates by first-stage
+        F-statistic and picks the strongest, breaking ties in favor of
+        {.strong 1/sqrt(n_obs)}. Treat it as an exploratory option rather than
+        a default: choosing an instrument by its first-stage strength on the
+        same data used for inference is a specification search, which biases
+        selection toward instruments that look strong in sample and understates
+        the uncertainty of the resulting estimates.
+
+        A warning is printed if the selected instrument's first-stage F falls
+        below the conventional weak-instrument threshold of 10. Alternatively,
+        specify a specific instrument formula involving n_obs.
 
     puniform_alpha:
       type: "numeric"

--- a/tests/testthat/test-econometric-exogeneity.R
+++ b/tests/testthat/test-econometric-exogeneity.R
@@ -62,7 +62,7 @@ make_weak_instrument_df <- function(seed = 99, n = 120, mu = 0.5, bias = 1.0) {
 
 default_exogeneity_options <- function(...) {
   defaults <- list(
-    iv_instrument = "automatic",
+    iv_instrument = "1/sqrt(n_obs)",
     add_significance_marks = TRUE,
     round_to = 3L,
     puniform_alpha = 0.05,
@@ -93,7 +93,33 @@ test_that("run_iv_regression recovers the effect and bias from a known DGP", {
   expect_false(res$weak_instrument)
 })
 
-test_that("run_iv_regression auto-selects the sample-size instrument", {
+test_that("run_iv_regression defaults to the a-priori sample-size instrument", {
+  skip_if_not_installed("AER")
+  local_options(artma.verbose = 1)
+
+  # The default is fixed rather than selected: ranking candidates by their
+  # first-stage F on the same data used for inference is a specification
+  # search, so "automatic" is opt-in only.
+  df <- make_exogeneity_df()
+  res <- run_iv_regression(df)
+
+  expect_equal(res$instrument_name, "1/sqrt(n_obs)")
+  expect_equal(
+    res$coefficients$estimate,
+    run_iv_regression(df, iv_instrument = "1/sqrt(n_obs)")$coefficients$estimate
+  )
+})
+
+test_that("the iv_instrument template default matches the method's opt_spec", {
+  # CLAUDE.md: an opt_spec default that drifts from the template default makes
+  # getOption() and the options file disagree about what a fresh run does.
+  tpl <- yaml::read_yaml(
+    system.file("artma/options/templates/options_template.yaml", package = "artma")
+  )
+  expect_equal(tpl$methods$exogeneity_tests$iv_instrument$default, "1/sqrt(n_obs)")
+})
+
+test_that("run_iv_regression still auto-selects when explicitly asked", {
   skip_if_not_installed("AER")
   local_options(artma.verbose = 1)
 


### PR DESCRIPTION
`exogeneity_tests` defaulted `iv_instrument` to `"automatic"`, which builds four candidates — `1/sqrt(n_obs)`, `1/n_obs`, `1/n_obs^2`, `log(n_obs)` — ranks them by first-stage F-statistic and keeps the strongest, using `1/sqrt(n_obs)` only to break ties.

This changes the default to `1/sqrt(n_obs)`. `"automatic"` still works, as an explicit opt-in.

## Why

**It's a specification search.** Ranking instruments by their first-stage F on the same data used for inference favors whichever one happens to look strongest in sample, and the reported standard errors know nothing about the selection step. `find_best_instrument()`'s own documentation already makes this argument against selecting on R², Wu-Hausman and Sargan — first-stage F is open to the same objection.

**It puts artma out of step with the field.** The instrument is motivated a priori: an estimator's standard error scales with 1/√N, so sample size predicts reported precision without itself being a channel for selective reporting. The applied literature hard-codes it rather than searching — across the published replication packages on meta-analysis.cz: `ivreg pcc (sepcc = root)`, `ivreg pcc (sepcc = lnobs)`, `gen inv_sqrt_nobs = sqrt(inv_nobs)`. An artma IV column produced under `"automatic"` isn't comparable with a published one.

## Evidence

Found while replicating Simpartl (2023), *Military expenditure and economic growth*, one of the few IES theses reporting an IV column. Its dataset is public, so the specification can be checked directly:

| Instrument | FAT | PET |
|---|---:|---:|
| thesis, Table 1 p. 35 | 0.376 | −0.088 |
| `1/sqrt(n_obs)` — new default | 0.347 | **−0.08806** |
| `1/n_obs` — what `"automatic"` picked | 0.109 | −0.066 |
| `log(n_obs)` | 0.574 | −0.109 |

The a-priori instrument reproduces the reported PET to four decimals; the searched-for one is off by a quarter of its value and understates the bias-corrected effect by ~25%.

Verified end-to-end after the change:

```
ℹ Instrument used in IV regression: 1/sqrt(n_obs)
              term    estimate
1           effect -0.08805975
2 publication_bias  0.34740334
```

## Changes

Three places encoded the default; all now agree, per the CLAUDE.md rule that an `opt_spec` default must match the template default:

- `inst/artma/options/templates/options_template.yaml` — default, plus help text explaining why `"automatic"` is exploratory.
- `inst/artma/methods/exogeneity_tests.R` — `opt_spec(default = ...)`.
- `inst/artma/econometric/exogeneity.R` — function default and roxygen; `find_best_instrument()` now documents why it isn't the default.

Tests: the existing `"automatic"` behaviour test is kept (renamed to say it's opt-in), plus two new ones — that a bare `run_iv_regression(df)` uses `1/sqrt(n_obs)` and agrees with passing it explicitly, and that the template default matches the `opt_spec` default so the two can't drift.

## Test status

`testthat::test_local(filter = "econometric-exogeneity")` passes.

A first full local run showed 4 failures in `test-nonlinear-tests.R` and `test-summary-table-characterization.R`, all of the form "Hierarch row/column absent". Those are the `bayesm`-gated hierarchical sub-model, and `bayesm` is an optional `Suggests` that was missing from my container — `run_hierarchical()` aborts without it. Installing `bayesm` and re-running both files gives 0 failures, so they are unrelated to this change. (`test-nonlinear-tests.R` contains no reference to IV or exogeneity, and this diff touches no file on that path.)

## Scope

Behaviour change for anyone relying on the previous default: IV results will differ, and should be regarded as more comparable with the literature rather than less. Users who want the old behaviour set `iv_instrument: "automatic"` explicitly.

Context: found during the replication work in #449, which separately verifies that artma's six linear estimators reproduce reference implementations exactly. This is the one estimator-level defect that audit turned up.